### PR TITLE
feat: Updated Darknet-53 pretrained URL

### DIFF
--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -26,7 +26,7 @@ default_cfgs = {
                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet19_224-44aaede3.pth'},
     'darknet53': {'arch': 'DarknetV3',
                   'layout': [(1, 64, 128), (2, 128, 256), (8, 256, 512), (8, 512, 1024), (4, 1024)],
-                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet53_224-f4c640a8.pth'},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet53_224-42576ca0.pth'},
 }
 
 

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -35,6 +35,7 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 | 224       | 5      | imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epochs 5 --opt radam --sched onecycle --loss label_smoothing | 66.88%         | 1      |
 | 224       | 10     | imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epochs 10 --opt radam --sched onecycle --loss label_smoothing | 76.18%         | 1      |
 | 224       | 20     | imagenette2-320/ --model darknet19 --lr 5e-4 -b 32 -j 16 --epochs 20 --opt radam --sched onecycle --loss label_smoothing | 84.43%         | 1      |
+| 224       | 40     | imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epochs 40 --opt radam --sched onecycle --loss label_smoothing | 87.62%         | 1      |
 
 
 
@@ -42,7 +43,7 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 
 | Model     | Accuracy@1 (Err) | Param # | MACs  | Interpolation | Image size |
 | --------- | ---------------- | ------- | ----- | ------------- | ---------- |
-| darknet53 | 82.57 (17.43)    | 40.60M  | 7.13G | bilinear      | 224        |
+| darknet53 | 87.62 (12.38)    | 40.60M  | 7.13G | bilinear      | 224        |
 | darknet19 | 84.43 (15.57)    | 19.83M  | 2.71G | bilinear      | 224        |
 | darnet24  | 78.75 (21.25)    | 22.40M  | 4.21G | bilinear      | 224        |
 


### PR DESCRIPTION
This PR updated Darknet-53 by:
- updating its pretrained URL with an improved version
- updating classification reference README with new results