### PR TITLE
feat: Updated Darknet-24 and Darknet-19 pretrained URLs

### DIFF
--- a/.github/workflows/pkg-upload.yaml
+++ b/.github/workflows/pkg-upload.yaml
@@ -2,7 +2,7 @@ name: pypi-publish
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
 
 jobs:
 
@@ -63,9 +63,6 @@ jobs:
         id: release_tag
         run: |
           echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - name: Anaconda login
-        run: |
-          conda install -y conda-build conda-verify anaconda-client
       - name: Build and publish
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -20,10 +20,10 @@ __all__ = ['DarknetV1', 'DarknetV2', 'DarknetV3', 'darknet24', 'darknet19', 'dar
 default_cfgs = {
     'darknet24': {'arch': 'DarknetV1',
                   'layout': [[128, 256, 256, 512], [*([256, 512] * 4), 512, 1024], [512, 1024, 512, 1024]],
-                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet24_224-c88d3570.pth'},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet24_224-054704e0.pth'},
     'darknet19': {'arch': 'DarknetV2',
                   'layout': [(128, 1), (256, 1), (512, 2), (1024, 2)],
-                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet19_224-44aaede3.pth'},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet19_224-5aad1493.pth'},
     'darknet53': {'arch': 'DarknetV3',
                   'layout': [(1, 64, 128), (2, 128, 256), (8, 256, 512), (8, 512, 1024), (4, 1024)],
                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.0/darknet53_224-42576ca0.pth'},

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -35,7 +35,7 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 | 224       | 5      | imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epochs 5 --opt radam --sched onecycle --loss label_smoothing | 66.88%         | 1      |
 | 224       | 10     | imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epochs 10 --opt radam --sched onecycle --loss label_smoothing | 76.18%         | 1      |
 | 224       | 20     | imagenette2-320/ --model darknet19 --lr 5e-4 -b 32 -j 16 --epochs 20 --opt radam --sched onecycle --loss label_smoothing | 84.43%         | 1      |
-| 224       | 40     | imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epochs 40 --opt radam --sched onecycle --loss label_smoothing | 87.62%         | 1      |
+| 224       | 40     | imagenette2-320/ --model darknet19 --lr 5e-4 -b 32 -j 16 --epochs 40 --opt radam --sched onecycle --loss label_smoothing | 90.47%         | 1      |
 
 
 
@@ -44,6 +44,6 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 | Model     | Accuracy@1 (Err) | Param # | MACs  | Interpolation | Image size |
 | --------- | ---------------- | ------- | ----- | ------------- | ---------- |
 | darknet53 | 87.62 (12.38)    | 40.60M  | 7.13G | bilinear      | 224        |
-| darknet19 | 84.43 (15.57)    | 19.83M  | 2.71G | bilinear      | 224        |
-| darnet24  | 78.75 (21.25)    | 22.40M  | 4.21G | bilinear      | 224        |
+| darknet19 | 90.47 (9.53)     | 19.83M  | 2.71G | bilinear      | 224        |
+| darnet24  | 85.48 (14.52)    | 22.40M  | 4.21G | bilinear      | 224        |
 


### PR DESCRIPTION
This Pr aims at:
- updating pretrained URLs for darknet24 and darknet19
- preventing package upload upon release edits