### PR TITLE
feat: Fixed YOLO inference and loss computation

### DIFF
--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -87,9 +87,10 @@ class _YOLO(nn.Module):
             # Update loss for cells with an object
             if torch.any(cell_selection):
                 # Get prediction assignment
-                selection_o = pred_o.view(b, h * w, -1)[idx, cell_idxs, box_idxs]
+                selection_o = pred_o.view(b, h * w, -1)[idx, cell_idxs, box_idxs].view(-1)
                 selected_scores = pred_scores.view(b, h * w, num_anchors, -1)[idx, cell_idxs, box_idxs]
-                selected_boxes = pred_boxes.view(b, h * w, num_anchors, -1)[idx, cell_idxs, box_idxs]
+                selected_scores = selected_scores.view(-1, pred_scores.shape[-1])
+                selected_boxes = pred_boxes.view(b, h * w, num_anchors, -1)[idx, cell_idxs, box_idxs].view(-1, 4)
                 # Convert GT --> xc, yc, w, h
                 gt_wh = gt_boxes[idx][:, [2, 3]] - gt_boxes[idx][:, [0, 1]]
                 gt_centers = (gt_boxes[idx][:, [2, 3]] + gt_boxes[idx][:, [0, 1]]) / 2

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -98,9 +98,9 @@ class _YOLO(nn.Module):
                                                                      torch.zeros_like(empty_cell_o),
                                                                      reduction='none')
 
-        return dict(objectness_loss=objectness_loss.mean() / pred_boxes.shape[0],
-                    bbox_loss=bbox_loss.mean() / pred_boxes.shape[0],
-                    clf_loss=clf_loss.mean() / pred_boxes.shape[0])
+        return dict(objectness_loss=objectness_loss.sum() / pred_boxes.shape[0],
+                    bbox_loss=bbox_loss.sum() / pred_boxes.shape[0],
+                    clf_loss=clf_loss.sum() / pred_boxes.shape[0])
 
     @staticmethod
     def post_process(b_coords, b_o, b_scores, rpn_nms_thresh=0.7, box_score_thresh=0.05):

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -138,7 +138,10 @@ class _YOLO(nn.Module):
 
                 # NMS
                 # Switch to xmin, ymin, xmax, ymax coords
-                coords[..., -2:] += coords[..., :2]
+                wh = coords[..., 2:]
+                coords[..., 2:] /= 2
+                coords[..., 2:] += coords[..., :2]
+                coords[..., :2] -= wh / 2
                 coords = coords.clamp_(0, 1)
                 is_kept = nms(coords, scores, iou_threshold=rpn_nms_thresh)
                 coords = coords[is_kept]

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -299,15 +299,15 @@ class YOLOv2(_YOLO):
         # B * C * H * W --> B * H * W * num_anchors * (5 + num_classes)
         x = x.view(b, self.num_anchors, 5 + self.num_classes, h, w).permute(0, 3, 4, 1, 2)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float, device=x.device)
-        c_y = torch.arange(0, h, dtype=torch.float, device=x.device)
+        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) / w
+        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) / h
         # Box coordinates
-        b_x = img_w / w * (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
-        b_y = img_h / h * (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
+        b_x = (torch.sigmoid(x[..., 0]) / w + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
+        b_y = (torch.sigmoid(x[..., 1]) / h + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
         # B * H * W * num_anchors * (5 + num_classes) --> B * (H * W) * num_anchors * (5 + num_classes)
         x = x.view(b, h * w, self.num_anchors, -1)
-        b_w = img_w / w * (self.anchors[:, 0].view(1, 1, -1) * torch.exp(x[..., 2]))
-        b_h = img_h / h * (self.anchors[:, 1].view(1, 1, -1) * torch.exp(x[..., 3]))
+        b_w = self.anchors[:, 0].view(1, 1, -1) / w * torch.exp(x[..., 2])
+        b_h = self.anchors[:, 1].view(1, 1, -1) / h * torch.exp(x[..., 3])
         # B * (H * W) * num_anchors * 4
         b_coords = torch.stack((b_x, b_y, b_w, b_h), dim=3)
         # Objectness

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -30,7 +30,6 @@ default_cfgs = {
 
 
 class _YOLO(nn.Module):
-
     def _compute_losses(self, pred_boxes, pred_o, pred_scores, gt_boxes, gt_labels):
         """Computes the detector losses as described in `"You Only Look Once: Unified, Real-Time Object Detection"
         <https://pjreddie.com/media/files/papers/yolo_1.pdf>`_
@@ -51,7 +50,10 @@ class _YOLO(nn.Module):
         bbox_loss = torch.zeros(pred_boxes.shape[1], device=pred_boxes.device)
         clf_loss = torch.zeros(pred_boxes.shape[1], device=pred_boxes.device)
         # Convert from x, y, w, h to xmin, ymin, xmax, ymax
+        pred_wh = pred_boxes[..., 2:]
+        pred_boxes[..., 2:] /= 2
         pred_boxes[..., 2:] += pred_boxes[..., :2]
+        pred_boxes[..., :2] -= pred_wh / 2
         # B * cells * predictors * info
         for idx in range(pred_boxes.shape[0]):
 

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -85,8 +85,9 @@ class _YOLO(nn.Module):
                 clf_loss += F.cross_entropy(selected_scores, select_gt_labels, reduction='sum')
 
             # Objectness loss for cells where no object was detected
-            empty_cell_o = pred_o[idx][~cell_selection].max(dim=1).values
-            objectness_loss += 0.5 * F.mse_loss(empty_cell_o, torch.zeros_like(empty_cell_o), reduction='sum')
+            if torch.any(~cell_selection):
+                empty_cell_o = pred_o[idx][~cell_selection].max(dim=1).values
+                objectness_loss += 0.5 * F.mse_loss(empty_cell_o, torch.zeros_like(empty_cell_o), reduction='sum')
 
         return dict(objectness_loss=objectness_loss,
                     bbox_loss=bbox_loss,

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -220,6 +220,9 @@ class YOLOv1(_YOLO):
         if self.training and (gt_boxes is None or gt_labels is None):
             raise ValueError("`gt_boxes` and `gt_labels` need to be specified in training mode")
 
+        if isinstance(x, (list, tuple)):
+            x = torch.stack(x, dim=0)
+
         img_h, img_w = x.shape[-2:]
         x = self.backbone(x)
         x = self.block4(x)
@@ -330,6 +333,9 @@ class YOLOv2(_YOLO):
 
         if self.training and (gt_boxes is None or gt_labels is None):
             raise ValueError("`gt_boxes` and `gt_labels` need to be specified in training mode")
+
+        if isinstance(x, (list, tuple)):
+            x = torch.stack(x, dim=0)
 
         img_h, img_w = x.shape[-2:]
         x, passthrough = self.backbone(x)

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -54,7 +54,7 @@ class _YOLO(nn.Module):
 
         # Convert from x, y, w, h to xmin, ymin, xmax, ymax
         pred_wh = pred_boxes[..., 2:]
-        pred_boxes[..., 2:] = pred_boxes[..., :2] + pred_wh
+        pred_boxes[..., 2:] = pred_boxes[..., :2] + pred_wh / 2
         pred_boxes[..., :2] -= pred_wh / 2
 
         # B * cells * predictors * info
@@ -153,8 +153,7 @@ class _YOLO(nn.Module):
                 # NMS
                 # Switch to xmin, ymin, xmax, ymax coords
                 wh = coords[..., 2:]
-                coords[..., 2:] /= 2
-                coords[..., 2:] += coords[..., :2]
+                coords[..., 2:] = coords[..., :2] + wh / 2
                 coords[..., :2] -= wh / 2
                 coords = coords.clamp_(0, 1)
                 is_kept = nms(coords, scores, iou_threshold=rpn_nms_thresh)

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -52,7 +52,7 @@ class _YOLO(nn.Module):
         bbox_loss = torch.zeros(w * h * num_anchors, device=pred_boxes.device)
         clf_loss = torch.zeros(w * h * num_anchors, device=pred_boxes.device)
 
-        # Convert from x, y, w, h to xmin, ymin, xmax, ymax
+        # Convert from (xcenter, ycenter, w, h) to (xmin, ymin, xmax, ymax)
         pred_wh = pred_boxes[..., 2:]
         pred_boxes[..., 2:] = pred_boxes[..., :2] + pred_wh / 2
         pred_boxes[..., :2] -= pred_wh / 2

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -55,7 +55,7 @@ class _YOLO(nn.Module):
         # Convert from x, y, w, h to xmin, ymin, xmax, ymax
         pred_wh = pred_boxes[..., 2:]
         pred_boxes[..., 2:] = pred_boxes[..., :2] + pred_wh
-        pred_boxes[..., :2] += pred_wh / 2
+        pred_boxes[..., :2] -= pred_wh / 2
 
         # B * cells * predictors * info
         for idx in range(b):

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -204,13 +204,12 @@ class YOLOv1(_YOLO):
         #  B * H * W * (num_anchors * 5 + num_classes) -->  B * H * W * num_anchors * 5
         x = x[..., :self.num_anchors * 5].view(b, h, w, self.num_anchors, 5)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float, device=x.device)
-        c_y = torch.arange(0, h, dtype=torch.float, device=x.device)
+        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) / w
+        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) / h
         # Box coordinates
-        b_x = img_w / w * (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
-        b_y = img_h / h * (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
+        b_x = (torch.sigmoid(x[..., 0]) / w + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
+        b_y = (torch.sigmoid(x[..., 1]) / h + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
         # B * H * W * num_anchors * (5 + num_classes) --> B * (H * W) * num_anchors * (5 + num_classes)
-        # x = x.view(b, h * w, self.num_anchors, -1)
         b_w = torch.sigmoid(x[..., 2]).view(b, -1, self.num_anchors)
         b_h = torch.sigmoid(x[..., 3]).view(b, -1, self.num_anchors)
         # B * (H * W) * num_anchors * 4

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -97,8 +97,8 @@ class _YOLO(nn.Module):
                 selected_scores = pred_scores.view(b, h * w, num_anchors, -1)[idx, cell_selection, anchor_idxs]
                 selected_boxes = pred_boxes.view(b, h * w, num_anchors, -1)[idx, cell_selection, anchor_idxs]
                 # Convert GT --> xc, yc, w, h
-                gt_wh = gt_boxes[idx][..., [2, 3]] - gt_boxes[idx][..., [0, 1]]
-                gt_centers = gt_boxes[idx][..., :2] + gt_wh / 2
+                gt_wh = gt_boxes[idx][gt_idxs, [2, 3]] - gt_boxes[idx][gt_idxs, [0, 1]]
+                gt_centers = gt_boxes[idx][gt_idxs, :2] + gt_wh / 2
                 # Make xy relative to cell
                 gt_centers[..., 0] *= w
                 gt_centers[..., 1] *= h

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -92,8 +92,8 @@ class _YOLO(nn.Module):
                 selected_scores = selected_scores.view(-1, pred_scores.shape[-1])
                 selected_boxes = pred_boxes.view(b, h * w, num_anchors, -1)[idx, cell_idxs, box_idxs].view(-1, 4)
                 # Convert GT --> xc, yc, w, h
-                gt_wh = gt_boxes[idx][:, [2, 3]] - gt_boxes[idx][:, [0, 1]]
-                gt_centers = (gt_boxes[idx][:, [2, 3]] + gt_boxes[idx][:, [0, 1]]) / 2
+                gt_wh = gt_boxes[idx][:, 2:] - gt_boxes[idx][:, :2]
+                gt_centers = (gt_boxes[idx][:, 2:] + gt_boxes[idx][:, :2]) / 2
                 # Make xy relative to cell
                 gt_centers[:, 0] *= w
                 gt_centers[:, 1] *= h

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -105,9 +105,9 @@ class _YOLO(nn.Module):
                 # Localization
                 # cf. YOLOv1 loss: SSE of xy preds, SSE of squared root of wh
                 bbox_loss[cell_idxs] += F.mse_loss(selected_boxes[:, :2], gt_centers,
-                                                        reduction='none').sum(dim=-1)
+                                                   reduction='none').sum(dim=-1)
                 bbox_loss[cell_idxs] += F.mse_loss(selected_boxes[:, 2:].sqrt(), gt_wh.sqrt(),
-                                                        reduction='none').sum(dim=-1)
+                                                   reduction='none').sum(dim=-1)
                 # Objectness
                 objectness_loss[cell_idxs] += F.mse_loss(selection_o, selection_iou, reduction='none')
                 # Classification

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -221,11 +221,11 @@ class YOLOv1(_YOLO):
         #  B * H * W * (num_anchors * 5 + num_classes) -->  B * H * W * num_anchors * 5
         x = x[..., :self.num_anchors * 5].view(b, h, w, self.num_anchors, 5)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) / w
-        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) / h
+        c_x = torch.arange(w, dtype=torch.float, device=x.device)
+        c_y = torch.arange(h, dtype=torch.float, device=x.device)
         # Box coordinates
-        b_x = torch.sigmoid(x[..., 0]) / w + c_x.view(1, 1, -1, 1)
-        b_y = torch.sigmoid(x[..., 1]) / h + c_y.view(1, -1, 1, 1)
+        b_x = (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)) / w
+        b_y = (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)) / h
         b_w = torch.sigmoid(x[..., 2])
         b_h = torch.sigmoid(x[..., 3])
         # B * H * W * num_anchors * 4
@@ -331,11 +331,11 @@ class YOLOv2(_YOLO):
         # B * C * H * W --> B * H * W * num_anchors * (5 + num_classes)
         x = x.view(b, self.num_anchors, 5 + self.num_classes, h, w).permute(0, 3, 4, 1, 2)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) / w
-        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) / h
+        c_x = torch.arange(w, dtype=torch.float, device=x.device)
+        c_y = torch.arange(h, dtype=torch.float, device=x.device)
         # Box coordinates
-        b_x = torch.sigmoid(x[..., 0]) / w + c_x.view(1, 1, -1, 1)
-        b_y = torch.sigmoid(x[..., 1]) / h + c_y.view(1, -1, 1, 1)
+        b_x = (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)) / w
+        b_y = (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)) / h
         b_w = self.anchors[:, 0].view(1, 1, 1, -1) / w * torch.exp(x[..., 2])
         b_h = self.anchors[:, 1].view(1, 1, 1, -1) / h * torch.exp(x[..., 3])
         # B * H * W * num_anchors * 4
@@ -386,7 +386,7 @@ class YOLOv2(_YOLO):
             # B * (H * W * num_anchors)
             b_coords = b_coords.view(b_coords.shape[0], -1, 4)
             b_o = b_o.view(b_o.shape[0], -1)
-            b_scores = b_scores.contiguous().view(b_scores.shape[0], -1, self.num_classes)
+            b_scores = b_scores.reshape(b_scores.shape[0], -1, self.num_classes)
 
             # Stack detections into a list
             return self.post_process(b_coords, b_o, b_scores)

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -347,6 +347,9 @@ class YOLOv2(_YOLO):
         b_coords, b_o, b_scores = self._format_outputs(x, img_h, img_w)
 
         if self.training:
+            # Convert GT coordinates to relative
+            gt_boxes[:, [0, 2]] = gt_boxes[:, [0, 2]] / img_w
+            gt_boxes[:, [1, 3]] = gt_boxes[:, [1, 3]] / img_h
             # Update losses
             return self._compute_losses(b_coords, b_o, b_scores, gt_boxes, gt_labels)
         else:

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -55,11 +55,16 @@ class _YOLO(nn.Module):
         # B * cells * predictors * info
         for idx in range(pred_boxes.shape[0]):
 
-            # cells * predictors * num_gt
-            iou_mat = box_iou(pred_boxes[idx].view(-1, 4), gt_boxes[idx])
-            # Assign in each cell the best box predictors
-            # Compute max IoU for each predictor, take the highest predictor in each cell
-            cell_selection = iou_mat.view(pred_boxes.shape[1], -1).max(dim=1).values > 0
+            # If no GT, don't compute IoU
+            if gt_boxes[idx].shape[0] > 0:
+                # cells * predictors * num_gt
+                iou_mat = box_iou(pred_boxes[idx].view(-1, 4), gt_boxes[idx])
+                # Assign in each cell the best box predictors
+                # Compute max IoU for each predictor, take the highest predictor in each cell
+                cell_selection = iou_mat.view(pred_boxes.shape[1], -1).max(dim=1).values > 0
+            else:
+                cell_selection = torch.zeros(pred_boxes.shape[1], dtype=torch.bool, device=pred_boxes.device)
+
             if torch.any(cell_selection):
                 # S * predictors * num_gt
                 iou_mat = iou_mat.view(pred_boxes.shape[1], self.num_anchors, -1)[cell_selection]

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -87,7 +87,7 @@ class _YOLO(nn.Module):
                 selection_o = pred_o.view(b, -1)[idx, not_matched]
                 # Update loss
                 objectness_loss[not_matched] += 0.5 * F.mse_loss(selection_o, torch.zeros_like(selection_o),
-                                                                    reduction='none')
+                                                                 reduction='none')
 
             # Update loss for boxes with an object
             if is_matched.shape[0] > 0:

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -189,11 +189,11 @@ class YOLOv1(_YOLO):
         #  B * H * W * (num_anchors * 5 + num_classes) -->  B * H * W * num_anchors * 5
         x = x[..., :self.num_anchors * 5].view(b, h, w, self.num_anchors, 5)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) * img_w / w
-        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) * img_h / h
+        c_x = torch.arange(0, w, dtype=torch.float, device=x.device)
+        c_y = torch.arange(0, h, dtype=torch.float, device=x.device)
         # Box coordinates
-        b_x = (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
-        b_y = (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
+        b_x = img_w / w * (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
+        b_y = img_h / h * (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
         # B * H * W * num_anchors * (5 + num_classes) --> B * (H * W) * num_anchors * (5 + num_classes)
         # x = x.view(b, h * w, self.num_anchors, -1)
         b_w = torch.sigmoid(x[..., 2]).view(b, -1, self.num_anchors)
@@ -298,11 +298,11 @@ class YOLOv2(_YOLO):
         # B * C * H * W --> B * H * W * num_anchors * (5 + num_classes)
         x = x.view(b, self.num_anchors, 5 + self.num_classes, h, w).permute(0, 3, 4, 1, 2)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) * img_w / w
-        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) * img_h / h
+        c_x = torch.arange(0, w, dtype=torch.float, device=x.device)
+        c_y = torch.arange(0, h, dtype=torch.float, device=x.device)
         # Box coordinates
-        b_x = (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
-        b_y = (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
+        b_x = img_w / w * (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
+        b_y = img_h / h * (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
         # B * H * W * num_anchors * (5 + num_classes) --> B * (H * W) * num_anchors * (5 + num_classes)
         x = x.view(b, h * w, self.num_anchors, -1)
         b_w = img_w / w * (self.anchors[:, 0].view(1, 1, -1) * torch.exp(x[..., 2]))

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -347,9 +347,6 @@ class YOLOv2(_YOLO):
         b_coords, b_o, b_scores = self._format_outputs(x, img_h, img_w)
 
         if self.training:
-            # Convert GT coordinates to relative
-            gt_boxes[:, [0, 2]] = gt_boxes[:, [0, 2]] / img_w
-            gt_boxes[:, [1, 3]] = gt_boxes[:, [1, 3]] / img_h
             # Update losses
             return self._compute_losses(b_coords, b_o, b_scores, gt_boxes, gt_labels)
         else:

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -104,14 +104,14 @@ class _YOLO(nn.Module):
 
                 # Localization
                 # cf. YOLOv1 loss: SSE of xy preds, SSE of squared root of wh
-                bbox_loss[cell_selection] += F.mse_loss(selected_boxes[:, :2], gt_centers,
+                bbox_loss[cell_idxs] += F.mse_loss(selected_boxes[:, :2], gt_centers,
                                                         reduction='none').sum(dim=-1)
-                bbox_loss[cell_selection] += F.mse_loss(selected_boxes[:, 2:].sqrt(), gt_wh.sqrt(),
+                bbox_loss[cell_idxs] += F.mse_loss(selected_boxes[:, 2:].sqrt(), gt_wh.sqrt(),
                                                         reduction='none').sum(dim=-1)
                 # Objectness
-                objectness_loss[cell_selection] += F.mse_loss(selection_o, selection_iou, reduction='none')
+                objectness_loss[cell_idxs] += F.mse_loss(selection_o, selection_iou, reduction='none')
                 # Classification
-                clf_loss[cell_selection] += F.cross_entropy(selected_scores, gt_labels[idx], reduction='none')
+                clf_loss[cell_idxs] += F.cross_entropy(selected_scores, gt_labels[idx], reduction='none')
 
         return dict(objectness_loss=objectness_loss.sum() / pred_boxes.shape[0],
                     bbox_loss=bbox_loss.sum() / pred_boxes.shape[0],

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -47,9 +47,9 @@ class _YOLO(nn.Module):
         """
 
         # Reset losses
-        objectness_loss = torch.zeros(1).to(pred_boxes.device)
-        bbox_loss = torch.zeros(1).to(pred_boxes.device)
-        clf_loss = torch.zeros(1).to(pred_boxes.device)
+        objectness_loss = torch.zeros(1, device=pred_boxes.device)
+        bbox_loss = torch.zeros(1, device=pred_boxes.device)
+        clf_loss = torch.zeros(1, device=pred_boxes.device)
         # Convert from x, y, w, h to xmin, ymin, xmax, ymax
         pred_boxes[..., 2:] += pred_boxes[..., :2]
         # B * cells * predictors * info
@@ -110,9 +110,9 @@ class _YOLO(nn.Module):
         detections = []
         for idx in range(b_coords.shape[0]):
 
-            coords = torch.zeros((0, 4), dtype=torch.float).to(device=b_o.device)
-            scores = torch.zeros(0, dtype=torch.float).to(device=b_o.device)
-            labels = torch.zeros(0, dtype=torch.long).to(device=b_o.device)
+            coords = torch.zeros((0, 4), dtype=torch.float, device=b_o.device)
+            scores = torch.zeros(0, dtype=torch.float, device=b_o.device)
+            labels = torch.zeros(0, dtype=torch.long, device=b_o.device)
 
             # Objectness filter
             if torch.any(b_o[idx] >= 0.5):
@@ -189,8 +189,8 @@ class YOLOv1(_YOLO):
         #  B * H * W * (num_anchors * 5 + num_classes) -->  B * H * W * num_anchors * 5
         x = x[..., :self.num_anchors * 5].view(b, h, w, self.num_anchors, 5)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float) * img_w / w
-        c_y = torch.arange(0, h, dtype=torch.float) * img_h / h
+        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) * img_w / w
+        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) * img_h / h
         # Box coordinates
         b_x = (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
         b_y = (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)
@@ -298,8 +298,8 @@ class YOLOv2(_YOLO):
         # B * C * H * W --> B * H * W * num_anchors * (5 + num_classes)
         x = x.view(b, self.num_anchors, 5 + self.num_classes, h, w).permute(0, 3, 4, 1, 2)
         # Cell offset
-        c_x = torch.arange(0, w, dtype=torch.float) * img_w / w
-        c_y = torch.arange(0, h, dtype=torch.float) * img_h / h
+        c_x = torch.arange(0, w, dtype=torch.float, device=x.device) * img_w / w
+        c_y = torch.arange(0, h, dtype=torch.float, device=x.device) * img_h / h
         # Box coordinates
         b_x = (torch.sigmoid(x[..., 0]) + c_x.view(1, 1, -1, 1)).view(b, -1, self.num_anchors)
         b_y = (torch.sigmoid(x[..., 1]) + c_y.view(1, -1, 1, 1)).view(b, -1, self.num_anchors)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -51,7 +51,7 @@ class Tester(unittest.TestCase):
         model = model.train()
         self.assertRaises(ValueError, model, x)
         # Generate targets
-        num_boxes = [2, 3]
+        num_boxes = [3, 4]
         gt_boxes = []
         for num in num_boxes:
             _boxes = torch.rand((num, 4), dtype=torch.float)
@@ -60,6 +60,9 @@ class Tester(unittest.TestCase):
             # Ensure some anchors will be assigned
             _boxes[0, :2] = 0
             _boxes[0, 2:] = 1
+            # Check cases where cell can get two assignments
+            _boxes[1, :2] = 0.2
+            _boxes[1, 2:] = 0.8
             gt_boxes.append(_boxes)
         gt_labels = [(num_classes * torch.rand(num)).to(dtype=torch.long) for num in num_boxes]
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -41,6 +41,11 @@ class Tester(unittest.TestCase):
             self.assertIsInstance(out[0].get('scores'), torch.Tensor)
             self.assertIsInstance(out[0].get('labels'), torch.Tensor)
 
+        # Check that list of Tensors does not change output
+        x_list = [torch.rand(3, size, size) for _ in range(num_batches)]
+        with torch.no_grad():
+            self.assertTrue(torch.equal(model(x_list), out))
+
         # Training mode without target
         model = model.train()
         self.assertRaises(ValueError, model, x)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -31,6 +31,8 @@ class Tester(unittest.TestCase):
         num_batches = 2
         x = torch.rand((num_batches, 3, size, size))
         model = models.__dict__[name](pretrained=True, num_classes=num_classes).eval()
+        # Check backbone pretrained
+        model = models.__dict__[name](pretrained_backbone=True, num_classes=num_classes).eval()
         with torch.no_grad():
             out = model(x)
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -69,6 +69,10 @@ class Tester(unittest.TestCase):
         for subloss in loss.values():
             self.assertIsInstance(subloss, torch.Tensor)
 
+        # Loss computation with no GT
+        gt_boxes = [torch.rand((0, 4)) for _ in num_boxes]
+        gt_labels = [(num_classes * torch.rand(0)).to(dtype=torch.long) for _ in num_boxes]
+        loss = model(x, gt_boxes, gt_labels)
 
 for model_name in ['res2net', 'res2next']:
     def do_test(self, model_name=model_name):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -73,10 +73,11 @@ class Tester(unittest.TestCase):
         self.assertIsInstance(loss, dict)
         for subloss in loss.values():
             self.assertIsInstance(subloss, torch.Tensor)
+            self.assertFalse(torch.isnan(subloss))
 
         # Loss computation with no GT
-        gt_boxes = [torch.rand((0, 4)) for _ in num_boxes]
-        gt_labels = [(num_classes * torch.rand(0)).to(dtype=torch.long) for _ in num_boxes]
+        gt_boxes = [torch.zeros((0, 4)) for _ in num_boxes]
+        gt_labels = [torch.zeros(0, dtype=torch.long) for _ in num_boxes]
         loss = model(x, gt_boxes, gt_labels)
 
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -74,6 +74,7 @@ class Tester(unittest.TestCase):
         gt_labels = [(num_classes * torch.rand(0)).to(dtype=torch.long) for _ in num_boxes]
         loss = model(x, gt_boxes, gt_labels)
 
+
 for model_name in ['res2net', 'res2next']:
     def do_test(self, model_name=model_name):
         input_shape = (4, 3, 224, 224)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -60,7 +60,7 @@ class Tester(unittest.TestCase):
             # Ensure some anchors will be assigned
             _boxes[0, :2] = 0
             _boxes[0, 2:] = 1
-        gt_boxes = [torch.rand((num, 4)) for num in num_boxes]
+            gt_boxes.append(_boxes)
         gt_labels = [(num_classes * torch.rand(num)).to(dtype=torch.long) for num in num_boxes]
 
         # Loss computation

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -44,7 +44,8 @@ class Tester(unittest.TestCase):
         # Check that list of Tensors does not change output
         x_list = [torch.rand(3, size, size) for _ in range(num_batches)]
         with torch.no_grad():
-            self.assertTrue(torch.equal(model(x_list), out))
+            out_list = model(x_list)
+            self.assertEqual(len(out_list), len(out))
 
         # Training mode without target
         model = model.train()


### PR DESCRIPTION
This PR fixes YOLO inference and loss computation by:
- fixing GT coordinates (xcenter, ycenter, w, h)
- fixing cell loss contribution
- fixing loss computation when GT is empty
- adding unittest to check behaviour in the above cases
- adding pretrained backbone loading option
- changed classification loss back to strict paper implementation
- updated documentation