### PR TITLE
fix: Fixed progress bar of LR Finder for other backends

### DIFF
--- a/holocron/utils/misc.py
+++ b/holocron/utils/misc.py
@@ -4,7 +4,7 @@
 Misc utilities
 """
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import torch
 
 __all__ = ['lr_finder']


### PR DESCRIPTION
This PR fixes constant line breaks on notebook backend by importing tqdm from the auto submodule, as suggested [here](https://github.com/tqdm/tqdm/issues/375).