### PR TITLE
feat: Improved YOLO concatdownsample layer's efficiency

### DIFF
--- a/holocron/nn/functional.py
+++ b/holocron/nn/functional.py
@@ -106,21 +106,17 @@ def concat_downsample2d(x, scale_factor):
         scale_factor (int): spatial scaling factor
 
     Returns:
-        torch.Tensor[N, 4C, H / 2, W / 2]: downsampled tensor
+        torch.Tensor[N, scale_factor ** 2 * C, H / scale_factor, W / scale_factor]: downsampled tensor
     """
 
     b, c, h, w = x.shape
 
     if (h % scale_factor != 0) or (w % scale_factor != 0):
         raise AssertionError("Spatial size of input tensor must be multiples of `scale_factor`")
-    new_h, new_w = h // scale_factor, w // scale_factor
 
     # N * C * H * W --> N * C * (H/scale_factor) * scale_factor * (W/scale_factor) * scale_factor
-    out = x.view(b, c, new_h, scale_factor, new_w, scale_factor)
-    # Move extra axes to last position to flatten them with channel dimension
-    out = out.permute(0, 2, 4, 1, 3, 5).flatten(3)
-    # Reorder all axes
-    out = out.permute(0, 3, 1, 2)
+    out = torch.cat([x[..., i::scale_factor, j::scale_factor]
+                     for i in range(scale_factor) for j in range(scale_factor)], dim=1)
 
     return out
 

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -302,7 +302,7 @@ def parse_args():
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('data_path', type=str, help='path to dataset folder')
-    parser.add_argument('--model', default='darknet19', help='model')
+    parser.add_argument('--model', default='yolov2', help='model')
     parser.add_argument("--freeze-backbone", dest='freeze_backbone', action='store_true',
                         help="Should the backbone be frozen")
     parser.add_argument('--device', default='cuda', help='device')


### PR DESCRIPTION
This PR improves the concatenated downsampling operation of YOLO architectures by:
- discarding the channel order and switching to `torch.cat` to increase inference speed
- updating unittest
- updating default object detection argument