### PR TITLE
fix: Fixed Darknet53 autograd issue

### DIFF
--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -136,11 +136,15 @@ class DarkBlockV3(_ResBlock):
 
     def __init__(self, planes, mid_planes, act_layer=None, norm_layer=None, drop_layer=None, conv_layer=None):
         super().__init__(
-            [*conv_sequence(planes, mid_planes, act_layer, norm_layer, drop_layer, conv_layer,
-                            kernel_size=1, bias=False),
-             *conv_sequence(mid_planes, planes, act_layer, norm_layer, drop_layer, conv_layer,
-                            kernel_size=3, padding=1, bias=False)],
+            conv_sequence(planes, mid_planes, act_layer, norm_layer, drop_layer, conv_layer,
+                          kernel_size=1, bias=False) +
+            conv_sequence(mid_planes, planes, act_layer, norm_layer, drop_layer, conv_layer,
+                          kernel_size=3, padding=1, bias=False),
             None, act_layer)
+
+        # The backpropagation does not seem to appreciate inplace activation on the residual branch
+        if hasattr(self.conv[-1], 'inplace'):
+            self.conv[-1].inplace = False
 
 
 class DarknetBodyV3(nn.Sequential):

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -157,7 +157,7 @@ class DarknetBodyV3(nn.Sequential):
             *conv_sequence(in_channels, 32, act_layer, norm_layer, drop_layer, conv_layer,
                            kernel_size=3, padding=1, bias=False),
             *conv_sequence(32, 64, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=2, stride=2, bias=False),
+                           kernel_size=3, padding=1, stride=2, bias=False),
             self._make_layer(*layout[0], act_layer, norm_layer, drop_layer, conv_layer),
             self._make_layer(*layout[1], act_layer, norm_layer, drop_layer, conv_layer),
             self._make_layer(*layout[2], act_layer, norm_layer, drop_layer, conv_layer),

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -46,7 +46,7 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 | ---------- | ---------------- | ------- | ----- | ------------- | ---------- |
 | darknet53  | 87.62 (12.38)    | 40.60M  | 7.13G | bilinear      | 224        |
 | darknet19  | 90.47 (9.53)     | 19.83M  | 2.71G | bilinear      | 224        |
-| darnet24   | 85.48 (14.52)    | 22.40M  | 4.21G | bilinear      | 224        |
+| darnet24   | 88.13 (11.87)    | 22.40M  | 4.21G | bilinear      | 224        |
 | resnet50   | 84.36 (15.64)    | 23.53M  |       | bilinear      | 256        |
 | rexnet1_0x | 84.66 (15.34)    | 3.53M   |       | bilinear      | 256        |
 


### PR DESCRIPTION
This PR fixes some issues of Darknet53 by:
- fixing autograd when using inplace leaky relu as activations in bottlenecks.
- fixing padding of stem conv of darknet53