### PR TITLE
refactor: Added back norm layer flexibility for backbone with YOLO

### DIFF
--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -309,8 +309,11 @@ class YOLOv2(_YOLO):
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
 
-        if backbone_norm_layer is None and norm_layer is not None:
-            backbone_norm_layer = norm_layer
+        if backbone_norm_layer is None:
+            if norm_layer is None:
+                backbone_norm_layer = FrozenBatchNorm2d
+            else:
+                backbone_norm_layer = norm_layer
 
         # Priors computed using K-means
         if anchors is None:
@@ -435,9 +438,6 @@ class YOLOv2(_YOLO):
 
 
 def _yolo(arch, pretrained, progress, pretrained_backbone, **kwargs):
-
-    if pretrained_backbone and kwargs.get('backbone_norm_layer') is None:
-        kwargs['backbone_norm_layer'] = FrozenBatchNorm2d
 
     if pretrained:
         pretrained_backbone = False

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torchvision.ops.boxes import box_iou, nms
+from torchvision.ops.misc import FrozenBatchNorm2d
 from torchvision.models.utils import load_state_dict_from_url
 
 from ..utils import conv_sequence
@@ -434,6 +435,9 @@ class YOLOv2(_YOLO):
 
 
 def _yolo(arch, pretrained, progress, pretrained_backbone, **kwargs):
+
+    if pretrained_backbone and kwargs.get('backbone_norm_layer') is None:
+        kwargs['backbone_norm_layer'] = FrozenBatchNorm2d
 
     if pretrained:
         pretrained_backbone = False

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -225,7 +225,7 @@ def main(args):
 
 def parse_args():
     import argparse
-    parser = argparse.ArgumentParser(description='PyTorch Classification Training',
+    parser = argparse.ArgumentParser(description='Holocron Classification Training',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('data_path', type=str, help='path to dataset folder')

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -158,14 +158,17 @@ def main(args):
         criterion = holocron.nn.LabelSmoothingCrossEntropy()
 
     if args.opt == 'adam':
-        optimizer = torch.optim.Adam(model.parameters(), args.lr, betas=(0.95, 0.99), eps=1e-6,
-                                     weight_decay=args.weight_decay)
+        optimizer = torch.optim.Adam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                     betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
     elif args.opt == 'radam':
-        optimizer = holocron.optim.RAdam(model.parameters(), args.lr, betas=(0.95, 0.99), eps=1e-6,
-                                         weight_decay=args.weight_decay)
+        optimizer = holocron.optim.RAdam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                         betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
     elif args.opt == 'ranger':
-        optimizer = Lookahead(holocron.optim.RAdam(model.parameters(), args.lr, betas=(0.95, 0.99), eps=1e-6,
-                                                   weight_decay=args.weight_decay))
+        optimizer = Lookahead(holocron.optim.RAdam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                                   betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay))
+    elif args.opt == 'tadam':
+        optimizer = holocron.optim.TAdam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                         betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
 
     if args.lr_finder:
         plot_lr_finder(train_one_batch, model, train_loader, optimizer, criterion, device,

--- a/references/clean_checkpoint.py
+++ b/references/clean_checkpoint.py
@@ -12,7 +12,7 @@ import torch
 def main(args):
 
     checkpoint = torch.load(args.checkpoint, map_location='cpu')['model']
-    torch.save(checkpoint, args.outfile)
+    torch.save(checkpoint, args.outfile, _use_new_zipfile_serialization=False)
 
     with open(args.outfile, 'rb') as f:
         sha_hash = hashlib.sha256(f.read()).hexdigest()

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -135,7 +135,8 @@ def load_data(datadir, img_size=416, crop_pct=0.875):
     st = time.time()
     dataset = VOCDetection(datadir, image_set='train', download=True,
                            transforms=Compose([VOCTargetTransform(classes),
-                                               RandomResizedCrop(img_size), RandomHorizontalFlip(),
+                                               RandomResizedCrop((img_size, img_size), scale=(0.3, 1.0)),
+                                               RandomHorizontalFlip(),
                                                convert_to_relative,
                                                ImageTransform(transforms.ColorJitter(brightness=0.3, contrast=0.3,
                                                                                      saturation=0.1, hue=0.02)),

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -18,7 +18,6 @@ import torch.utils.data
 from torchvision import transforms
 from torchvision.datasets import VOCDetection
 from torchvision.ops.boxes import box_iou
-from torchvision.ops.misc import FrozenBatchNorm2d
 from torchvision.transforms import functional as F
 
 import holocron
@@ -224,10 +223,7 @@ def main(args):
         sampler=test_sampler, num_workers=args.workers, pin_memory=True)
 
     print("Creating model")
-    kwargs = {}
-    if args.freeze_backbone:
-        kwargs['norm_layer'] = FrozenBatchNorm2d
-    model = holocron.models.__dict__[args.model](args.pretrained, num_classes=len(classes), **kwargs)
+    model = holocron.models.__dict__[args.model](args.pretrained, num_classes=len(classes), pretrained_backbone=True)
     # Backbone freezing
     if args.freeze_backbone:
         for p in model.backbone.parameters():

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -300,7 +300,7 @@ def main(args):
 
 def parse_args():
     import argparse
-    parser = argparse.ArgumentParser(description='PyTorch Classification Training',
+    parser = argparse.ArgumentParser(description='Holocron Detection Training',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('data_path', type=str, help='path to dataset folder')

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -235,14 +235,17 @@ def main(args):
     model.to(device)
 
     if args.opt == 'adam':
-        optimizer = torch.optim.Adam(model.parameters(), args.lr, betas=(0.95, 0.99), eps=1e-6,
-                                     weight_decay=args.weight_decay)
+        optimizer = torch.optim.Adam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                     betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
     elif args.opt == 'radam':
-        optimizer = holocron.optim.RAdam(model.parameters(), args.lr, betas=(0.95, 0.99), eps=1e-6,
-                                         weight_decay=args.weight_decay)
+        optimizer = holocron.optim.RAdam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                         betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
     elif args.opt == 'ranger':
-        optimizer = Lookahead(holocron.optim.RAdam(model.parameters(), args.lr, betas=(0.95, 0.99), eps=1e-6,
-                                                   weight_decay=args.weight_decay))
+        optimizer = Lookahead(holocron.optim.RAdam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                                   betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay))
+    elif args.opt == 'tadam':
+        optimizer = holocron.optim.TAdam([p for p in model.parameters() if p.requires_grad], args.lr,
+                                         betas=(0.95, 0.99), eps=1e-6, weight_decay=args.weight_decay)
 
     if args.lr_finder:
         plot_lr_finder(train_one_batch, model, train_loader, optimizer, device,

--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -262,7 +262,7 @@ def main(args):
 
 def parse_args():
     import argparse
-    parser = argparse.ArgumentParser(description='PyTorch Classification Training',
+    parser = argparse.ArgumentParser(description='Holocron Segmentation Training',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('data_path', type=str, help='path to dataset folder')


### PR DESCRIPTION
This PR fixes YOLO `backbone_norm_layer` argument by passing it correctly to the backbone and setting the default value to `FrozenBatchNorm2d` when `pretrained_backbone=True`.