### PR TITLE
fix: Fixed coordinate conversion in YOLO

### DIFF
--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -61,10 +61,8 @@ class _YOLO(nn.Module):
         clf_loss = torch.zeros(1, device=pred_boxes.device)
 
         # Convert from (xcenter, ycenter, w, h) to (xmin, ymin, xmax, ymax)
-        pred_xyxy = torch.zeros_like(pred_boxes)
-        pred_wh = pred_boxes[..., 2:]
-        pred_xyxy[..., 2:] = pred_boxes[..., :2] + pred_wh / 2
-        pred_xyxy[..., :2] = pred_boxes[..., :2] - pred_wh / 2
+        wh = pred_boxes[..., 2:]
+        pred_xyxy = torch.cat((pred_boxes[..., :2] - wh / 2, pred_boxes[..., :2] + wh / 2), dim=-1)
 
         # B * cells * predictors * info
         for idx in range(b):

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -324,7 +324,8 @@ class YOLOv2(_YOLO):
 
         # Priors computed using K-means
         if anchors is None:
-            anchors = torch.tensor([[1.08, 1.19], [3.42, 4.41], [6.63, 11.38], [9.42, 5.11], [16.62, 10.52]])
+            anchors = torch.tensor([[1.3221, 1.73145], [3.19275, 4.00944], [5.05587, 8.09892],
+                                    [9.47112, 4.84053], [11.2364, 10.0071]])
         self.num_classes = num_classes
 
         self.backbone = DarknetBodyV2(layout, in_channels, act_layer, backbone_norm_layer, drop_layer, conv_layer)

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -185,7 +185,7 @@ class _YOLO(nn.Module):
 
 class YOLOv1(_YOLO):
     def __init__(self, layout, num_classes=20, in_channels=3, num_anchors=2, lambda_noobj=0.5, lambda_coords=5.,
-                  rpn_nms_thresh=0.7, box_score_thresh=0.05,
+                 rpn_nms_thresh=0.7, box_score_thresh=0.05,
                  act_layer=None, norm_layer=None, drop_layer=None, conv_layer=None, backbone_norm_layer=None):
 
         super().__init__(rpn_nms_thresh, box_score_thresh)

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -288,7 +288,7 @@ class YOLOv1(_YOLO):
         out = self._forward(x)
 
         # B * (H * W) * num_anchors
-        b_coords, b_o, b_scores = self._format_outputs(x, *x.shape[-2:])
+        b_coords, b_o, b_scores = self._format_outputs(out, *x.shape[-2:])
 
         if self.training:
             # Update losses


### PR DESCRIPTION
This PR fixes and improves YOLO models by:
- moving confidence filtering before NMS to lower computation
- fixing box coordinate conversion
- updating anchors to the ones of VOC computed by paper's author (https://github.com/pjreddie/darknet/blob/master/cfg/yolov2-voc.cfg#L242)
- refactoring forward method