### PR TITLE
feat: Fixed CSPDarknet53 and updated pretrained models

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -92,6 +92,8 @@ Darknet
 
 .. autofunction:: cspdarknet53
 
+.. autofunction:: cspdarknet53_mish
+
 
 Object Detection
 ================

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -228,15 +228,15 @@ class CSPStage(nn.Module):
                                                        kernel_size=3, padding=1, stride=2, bias=False),
                                         # Share the conv
                                         *conv_sequence(out_channels, 2 * out_channels // compression,
-                                                  act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=1, bias=False))
+                                                       act_layer, norm_layer, drop_layer, conv_layer,
+                                                       kernel_size=1, bias=False))
         self.main = nn.Sequential(*[ResBlock(out_channels // compression,
-                                              out_channels // compression if num_blocks > 1 else in_channels,
-                                              act_layer, norm_layer, drop_layer, conv_layer)
-                                     for _ in range(num_blocks)],
-                                   *conv_sequence(out_channels // compression, out_channels // compression,
-                                                  act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=1, bias=False))
+                                             out_channels // compression if num_blocks > 1 else in_channels,
+                                             act_layer, norm_layer, drop_layer, conv_layer)
+                                    for _ in range(num_blocks)],
+                                  *conv_sequence(out_channels // compression, out_channels // compression,
+                                                 act_layer, norm_layer, drop_layer, conv_layer,
+                                                 kernel_size=1, bias=False))
         self.transition = nn.Sequential(*conv_sequence(2 * out_channels // compression, out_channels,
                                                        act_layer, norm_layer, drop_layer, conv_layer,
                                                        kernel_size=1, bias=False))

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -252,12 +252,9 @@ class DarknetBodyV4(nn.Sequential):
         super().__init__()
 
         if act_layer is None:
-            # act_layer = Mish()
             act_layer = nn.LeakyReLU(inplace=True)
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
-        # if drop_layer is None:
-        #     drop_layer = DropBlock2d
 
         in_chans = [stem_channels] + [_layout[0] for _layout in layout[:-1]]
 

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -33,6 +33,9 @@ default_cfgs = {
     'cspdarknet53': {'arch': 'DarknetV4',
                      'layout': [(64, 1), (128, 2), (256, 8), (512, 8), (1024, 4)],
                      'url': None},
+    'cspdarknet53_mish': {'arch': 'DarknetV4',
+                          'layout': [(64, 1), (128, 2), (256, 8), (512, 8), (1024, 4)],
+                          'url': None},
 }
 
 
@@ -373,3 +376,22 @@ def cspdarknet53(pretrained=False, progress=True, **kwargs):
     """
 
     return _darknet('cspdarknet53', pretrained, progress, **kwargs)
+
+
+def cspdarknet53_mish(pretrained=False, progress=True, **kwargs):
+    """Modified version of CSP-Darknet-53 from
+    `"CSPNet: A New Backbone that can Enhance Learning Capability of CNN" <https://arxiv.org/pdf/1911.11929.pdf>`_
+    with Mish as activation layer and DropBlock as regularization layer.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+
+    Returns:
+        torch.nn.Module: classification model
+    """
+
+    kwargs['act_layer'] = Mish()
+    kwargs['drop_layer'] = DropBlock2d
+
+    return _darknet('cspdarknet53_mish', pretrained, progress, **kwargs)

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -32,7 +32,7 @@ default_cfgs = {
                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/darknet53_256-f57b8429.pth'},
     'cspdarknet53': {'arch': 'DarknetV4',
                      'layout': [(64, 1), (128, 2), (256, 8), (512, 8), (1024, 4)],
-                     'url': None},
+                     'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/cspdarknet53_256-3ef96818.pth'},
     'cspdarknet53_mish': {'arch': 'DarknetV4',
                           'layout': [(64, 1), (128, 2), (256, 8), (512, 8), (1024, 4)],
                           'url': None},

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -17,7 +17,8 @@ from .resnet import _ResBlock
 from holocron.nn import Mish, DropBlock2d, GlobalAvgPool2d
 
 
-__all__ = ['DarknetV1', 'DarknetV2', 'DarknetV3', 'DarknetV4', 'darknet24', 'darknet19', 'darknet53', 'cspdarknet53']
+__all__ = ['DarknetV1', 'DarknetV2', 'DarknetV3', 'DarknetV4', 'darknet24', 'darknet19', 'darknet53', 'cspdarknet53',
+           'cspdarknet53_mish']
 
 
 default_cfgs = {

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -264,7 +264,7 @@ class DarknetBodyV4(nn.Sequential):
             ('stem', nn.Sequential(*conv_sequence(in_channels, stem_channels,
                                                   act_layer, norm_layer, drop_layer, conv_layer,
                                                   kernel_size=3, padding=1, bias=False))),
-            ('layers', nn.Sequential(*[CSPStage(_in_chans, out_chans, num_blocks,
+            ('stages', nn.Sequential(*[CSPStage(_in_chans, out_chans, num_blocks,
                                                 act_layer, norm_layer, drop_layer, conv_layer)
                                        for _in_chans, (out_chans, num_blocks) in zip(in_chans, layout)]))])
         )
@@ -278,9 +278,9 @@ class DarknetBodyV4(nn.Sequential):
         else:
             x = self.stem(x)
             features = []
-            for idx, stage in enumerate(self.layers):
+            for idx, stage in enumerate(self.stages):
                 x = stage(x)
-                if idx >= (len(self.layers) - self.num_features):
+                if idx >= (len(self.stages) - self.num_features):
                     features.append(x)
 
             return features

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -252,11 +252,12 @@ class DarknetBodyV4(nn.Sequential):
         super().__init__()
 
         if act_layer is None:
-            act_layer = Mish()
+            # act_layer = Mish()
+            act_layer = nn.LeakyReLU(inplace=True)
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
-        if drop_layer is None:
-            drop_layer = DropBlock2d
+        # if drop_layer is None:
+        #     drop_layer = DropBlock2d
 
         in_chans = [stem_channels] + [_layout[0] for _layout in layout[:-1]]
 

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -841,8 +841,6 @@ class YOLOv4(nn.Module):
             norm_layer = nn.BatchNorm2d
         if backbone_norm_layer is None:
             backbone_norm_layer = norm_layer
-        if drop_layer is None:
-            drop_layer = DropBlock2d
 
         # backbone
         self.backbone = DarknetBodyV4(layout, in_channels, stem_channels, 3, Mish(),

--- a/holocron/models/resnet.py
+++ b/holocron/models/resnet.py
@@ -33,7 +33,7 @@ default_cfgs = {
     'resnext101_32x8d': {'block': 'Bottleneck', 'num_blocks': [3, 4, 23, 3],
                          'url': None},
     'resnet50d': {'block': 'Bottleneck', 'num_blocks': [3, 4, 6, 3],
-                  'url': None},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/resnet50d_224-499c0b54.pth'},
 }
 
 

--- a/holocron/models/rexnet.py
+++ b/holocron/models/rexnet.py
@@ -35,10 +35,10 @@ class SEBlock(nn.Module):
 
     def __init__(self, channels, se_ratio=12, act_layer=None, norm_layer=None, drop_layer=None):
         super().__init__()
-        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.pool = GlobalAvgPool2d(flatten=False)
         self.conv = nn.Sequential(
             *conv_sequence(channels, channels // se_ratio, act_layer, norm_layer, drop_layer,
-                           kernel_size=1, stride=1),
+                           kernel_size=1, stride=1, bias=True),
             *conv_sequence(channels // se_ratio, channels, nn.Sigmoid(), None, drop_layer,
                            kernel_size=1, stride=1))
 

--- a/holocron/models/rexnet.py
+++ b/holocron/models/rexnet.py
@@ -19,13 +19,13 @@ __all__ = ['SEBlock', 'ReXBlock', 'ReXNet', 'rexnet1_0x', 'rexnet1_3x', 'rexnet1
 
 default_cfgs = {
     'rexnet1_0x': {'width_mult': 1.0, 'depth_mult': 1.0,
-                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet1_0x_224-a120bf73.pth'},
+                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet1_0x_224-ab7b9733.pth'},
     'rexnet1_3x': {'width_mult': 1.3, 'depth_mult': 1.0,
-                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet1_3x_224-191b60f1.pth'},
+                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet1_3x_224-95479104.pth'},
     'rexnet1_5x': {'width_mult': 1.5, 'depth_mult': 1.0,
-                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet1_5x_224-52c80862.pth'},
+                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet1_5x_224-c42a16ac.pth'},
     'rexnet2_0x': {'width_mult': 2.0, 'depth_mult': 1.0,
-                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet2_0x_224-e5243878.pth'},
+                   'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/rexnet2_0x_224-c8802402.pth'},
     'rexnet2_2x': {'width_mult': 2.2, 'depth_mult': 1.0,
                    'url': None},
 }
@@ -38,7 +38,7 @@ class SEBlock(nn.Module):
         self.pool = GlobalAvgPool2d(flatten=False)
         self.conv = nn.Sequential(
             *conv_sequence(channels, channels // se_ratio, act_layer, norm_layer, drop_layer,
-                           kernel_size=1, stride=1, bias=True),
+                           kernel_size=1, stride=1, bias=False),
             *conv_sequence(channels // se_ratio, channels, nn.Sigmoid(), None, drop_layer,
                            kernel_size=1, stride=1))
 

--- a/holocron/models/tridentnet.py
+++ b/holocron/models/tridentnet.py
@@ -16,7 +16,7 @@ from .utils import conv_sequence
 __all__ = ['Tridentneck', 'tridentnet50']
 
 default_cfgs = {
-    'tridentnet50': {'block': 'Bottleneck', 'num_blocks': [3, 4, 6, 3],
+    'tridentnet50': {'block': 'Tridentneck', 'num_blocks': [3, 4, 6, 3],
                      'url': None},
 }
 

--- a/holocron/models/tridentnet.py
+++ b/holocron/models/tridentnet.py
@@ -17,7 +17,7 @@ __all__ = ['Tridentneck', 'tridentnet50']
 
 default_cfgs = {
     'tridentnet50': {'block': 'Tridentneck', 'num_blocks': [3, 4, 6, 3],
-                     'url': None},
+                     'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/tridentnet50_224-98b4ce9c.pth'},
 }
 
 

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -42,14 +42,16 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 
 ## Model zoo
 
-| Model        | Accuracy@1 (Err) | Param # | MACs  | Interpolation | Image size |
-| ------------ | ---------------- | ------- | ----- | ------------- | ---------- |
-| cspdarknet53 |                  | 26.63M  | 6.57G | bilinear      | 256        |
-| darknet53    | 91.46 (8.54)     | 40.60M  | 9.31G | bilinear      | 256        |
-| darknet19    | 91.11 (8.89)     | 19.83M  | 2.75G | bilinear      | 224        |
-| darnet24     | 88.25 (11.75)    | 22.40M  | 4.21G | bilinear      | 224        |
-| resnet50     | 84.36 (15.64)    | 23.53M  |       | bilinear      | 224        |
-| rexnet1_0x   | 90.01 (9.99)     | 4.80M   | 0.42G | bilinear      | 224        |
-| rexnet1_3x   | 90.32 (9.68)     | 7.56M   | 0.68G | bilinear      | 224        |
-| rexnet2_2x   | 91.75 (8.25)     | 19.49M  | 1.88G | bilinear      | 224        |
+| Model           | Accuracy@1 (Err) | Param # | MACs  | Interpolation | Image size |
+| --------------- | ---------------- | ------- | ----- | ------------- | ---------- |
+| cspdarknet53    |                  | 26.63M  | 5.03G | bilinear      | 256        |
+| darknet53       | 91.46 (8.54)     | 40.60M  | 9.31G | bilinear      | 256        |
+| darknet19       | 91.11 (8.89)     | 19.83M  | 2.75G | bilinear      | 224        |
+| darnet24        | 88.25 (11.75)    | 22.40M  | 4.21G | bilinear      | 224        |
+| resnet50        | 84.36 (15.64)    | 23.53M  | 4.11G | bilinear      | 224        |
+| rexnet1_0x      | 90.01 (9.99)     | 4.80M   | 0.42G | bilinear      | 224        |
+| rexnet1_3x      | 90.32 (9.68)     | 7.56M   | 0.68G | bilinear      | 224        |
+| rexnet2_2x      | 91.75 (8.25)     | 19.49M  | 1.88G | bilinear      | 224        |
+| rexnet50d       | 91.46 (8.54)     | 23.55M  | 4.35G | bilinear      | 224        |
+| tridentresnet50 | 91.01 (8.99)     | 45.83M  | 35.9G | bilinear      | 224        |
 

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -44,7 +44,7 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 
 | Model           | Accuracy@1 (Err) | Param # | MACs  | Interpolation | Image size |
 | --------------- | ---------------- | ------- | ----- | ------------- | ---------- |
-| cspdarknet53    |                  | 26.63M  | 5.03G | bilinear      | 256        |
+| cspdarknet53    | 91.85 (8.15)     | 26.63M  | 5.03G | bilinear      | 256        |
 | darknet53       | 91.46 (8.54)     | 40.60M  | 9.31G | bilinear      | 256        |
 | darknet19       | 91.11 (8.89)     | 19.83M  | 2.75G | bilinear      | 224        |
 | darnet24        | 88.25 (11.75)    | 22.40M  | 4.21G | bilinear      | 224        |

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -85,7 +85,7 @@ class ModelTester(unittest.TestCase):
         self.assertEqual(out.shape, (num_batches, num_classes, out_size, out_size))
 
 
-for model_name in ['darknet24', 'darknet19', 'darknet53', 'cspdarknet53',
+for model_name in ['darknet24', 'darknet19', 'darknet53', 'cspdarknet53', 'cspdarknet53_mish',
                    'resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152',
                    'resnext50_32x4d', 'resnext101_32x8d',
                    'resnet50d',


### PR DESCRIPTION
This PR updates some classification models as follows:
- removed pre-BN conv weights in ReXNet and updated checkpoints accordingly
- improved CSP implementation efficiency and updated CSPDarknet53 pretrained weights
- added weights of resnet50 and tridentnet50
- YOLOv4 and CSPDarknet53 were switched back to using LeakyReLU and no DropBlock (later versions will include them) 