### PR TITLE
feat: Added pretrained res2net50_26w_4s

### DIFF
--- a/holocron/models/res2net.py
+++ b/holocron/models/res2net.py
@@ -18,8 +18,9 @@ __all__ = ['Bottle2neck', 'res2net50_26w_4s']
 
 
 default_cfgs = {
-    'res2net50_26w_4s': {'num_blocks': [3, 4, 6, 3], 'width_per_group': 26, 'scale': 4,
-                         'url': None},
+    'res2net50_26w_4s': {
+        'num_blocks': [3, 4, 6, 3], 'width_per_group': 26, 'scale': 4,
+        'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/res2net50_26w_4s_224-97cfc954.pth'},
 }
 
 

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -42,16 +42,16 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 
 ## Model zoo
 
-| Model           | Accuracy@1 (Err) | Param # | MACs  | Interpolation | Image size |
-| --------------- | ---------------- | ------- | ----- | ------------- | ---------- |
-| cspdarknet53    | 91.85 (8.15)     | 26.63M  | 5.03G | bilinear      | 256        |
-| darknet53       | 91.46 (8.54)     | 40.60M  | 9.31G | bilinear      | 256        |
-| darknet19       | 91.11 (8.89)     | 19.83M  | 2.75G | bilinear      | 224        |
-| darnet24        | 88.25 (11.75)    | 22.40M  | 4.21G | bilinear      | 224        |
-| resnet50        | 84.36 (15.64)    | 23.53M  | 4.11G | bilinear      | 224        |
-| rexnet1_0x      | 90.01 (9.99)     | 4.80M   | 0.42G | bilinear      | 224        |
-| rexnet1_3x      | 90.32 (9.68)     | 7.56M   | 0.68G | bilinear      | 224        |
-| rexnet2_2x      | 91.75 (8.25)     | 19.49M  | 1.88G | bilinear      | 224        |
-| rexnet50d       | 91.46 (8.54)     | 23.55M  | 4.35G | bilinear      | 224        |
-| tridentresnet50 | 91.01 (8.99)     | 45.83M  | 35.9G | bilinear      | 224        |
-
+| Model            | Accuracy@1 (Err) | Param # | MACs  | Interpolation | Image size |
+| ---------------- | ---------------- | ------- | ----- | ------------- | ---------- |
+| cspdarknet53     | 91.85 (8.15)     | 26.63M  | 5.03G | bilinear      | 256        |
+| rexnet2_2x       | 91.75 (8.25)     | 19.49M  | 1.88G | bilinear      | 224        |
+| rexnet50d        | 91.46 (8.54)     | 23.55M  | 4.35G | bilinear      | 224        |
+| darknet53        | 91.46 (8.54)     | 40.60M  | 9.31G | bilinear      | 256        |
+| darknet19        | 91.11 (8.89)     | 19.83M  | 2.75G | bilinear      | 224        |
+| tridentresnet50  | 91.01 (8.99)     | 45.83M  | 35.9G | bilinear      | 224        |
+| rexnet1_3x       | 90.32 (9.68)     | 7.56M   | 0.68G | bilinear      | 224        |
+| rexnet1_0x       | 90.01 (9.99)     | 4.80M   | 0.42G | bilinear      | 224        |
+| res2net50_26w_4s | 89.58 (99.26)    | 23.67M  | 4.28G | bilinear      | 224        |
+| darnet24         | 88.25 (11.75)    | 22.40M  | 4.21G | bilinear      | 224        |
+| resnet50         | 84.36 (15.64)    | 23.53M  | 4.11G | bilinear      | 224        |


### PR DESCRIPTION
This PR adds a pretrained res2net50_26w_4s model and updates the classification leaderboard.