### PR TITLE
feat: Added support of Triplet Attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ conda install -c frgfm pylocron
 - Convolutions: [NormConv2d](https://arxiv.org/pdf/2005.05274v2.pdf), [Add2d](https://arxiv.org/pdf/1912.13200.pdf), [SlimConv2d](https://arxiv.org/pdf/2003.07469.pdf), [PyConv2d](https://arxiv.org/abs/2006.11538)
 - Regularization: [DropBlock](https://arxiv.org/abs/1810.12890)
 - Pooling: [BlurPool2d](https://arxiv.org/abs/1904.11486), [SPP](https://arxiv.org/abs/1406.4729), [ZPool](https://arxiv.org/abs/2010.03045)
-- Attention: [SAM](https://arxiv.org/abs/1807.06521), [LambdaLayer](https://openreview.net/forum?id=xTJEN-ggl1b)
+- Attention: [SAM](https://arxiv.org/abs/1807.06521), [LambdaLayer](https://openreview.net/forum?id=xTJEN-ggl1b), [TripletAttention](https://arxiv.org/abs/2010.03045)
 
 ### models
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ conda install -c frgfm pylocron
 - Loss: [Focal Loss](https://arxiv.org/abs/1708.02002), MultiLabelCrossEntropy, [LabelSmoothingCrossEntropy](https://arxiv.org/pdf/1706.03762.pdf), [MixupLoss](https://arxiv.org/pdf/1710.09412.pdf), [ClassBalancedWrapper](https://arxiv.org/abs/1901.05555), [ComplementCrossEntropy](https://arxiv.org/abs/2009.02189), [MutualChannelLoss](https://arxiv.org/abs/2002.04264)
 - Convolutions: [NormConv2d](https://arxiv.org/pdf/2005.05274v2.pdf), [Add2d](https://arxiv.org/pdf/1912.13200.pdf), [SlimConv2d](https://arxiv.org/pdf/2003.07469.pdf), [PyConv2d](https://arxiv.org/abs/2006.11538)
 - Regularization: [DropBlock](https://arxiv.org/abs/1810.12890)
-- Pooling: [BlurPool2d](https://arxiv.org/abs/1904.11486), [SPP](https://arxiv.org/abs/1406.4729)
+- Pooling: [BlurPool2d](https://arxiv.org/abs/1904.11486), [SPP](https://arxiv.org/abs/1406.4729), [ZPool](https://arxiv.org/abs/2010.03045)
 - Attention: [SAM](https://arxiv.org/abs/1807.06521), [LambdaLayer](https://openreview.net/forum?id=xTJEN-ggl1b)
 
 ### models

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -6,7 +6,7 @@ different tasks, including: image classification, pixelwise semantic
 segmentation, object detection, instance segmentation, person
 keypoint detection and video classification.
 
-The following datasets are available:
+The following models are available:
 
 .. contents:: Models
     :local:

--- a/docs/source/nn.functional.rst
+++ b/docs/source/nn.functional.rst
@@ -49,4 +49,5 @@ Downsampling
 ------------
 
 .. autofunction:: concat_downsample2d
+.. autofunction:: z_pool
 

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -68,6 +68,8 @@ Downsampling
 
 .. autoclass:: SPP
 
+.. autoclass:: ZPool
+
 
 Attention
 ---------

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -77,3 +77,5 @@ Attention
 .. autoclass:: SAM
 
 .. autoclass:: LambdaLayer
+
+.. autoclass:: TripletAttention

--- a/holocron/nn/functional.py
+++ b/holocron/nn/functional.py
@@ -6,7 +6,7 @@ from typing import Optional, Callable, Union, Tuple, List
 
 
 __all__ = ['silu', 'mish', 'hard_mish', 'nl_relu', 'focal_loss', 'multilabel_cross_entropy', 'ls_cross_entropy',
-           'complement_cross_entropy', 'mutual_channel_loss', 'norm_conv2d', 'add2d', 'dropblock2d']
+           'complement_cross_entropy', 'mutual_channel_loss', 'norm_conv2d', 'add2d', 'dropblock2d', 'z_pool']
 
 
 def silu(x: Tensor) -> Tensor:
@@ -148,6 +148,18 @@ def concat_downsample2d(x: Tensor, scale_factor: int) -> Tensor:
     x = x.view(b, int(c * scale_factor ** 2), h // scale_factor, w // scale_factor)
 
     return x
+
+
+def z_pool(x: Tensor, dim: int) -> Tensor:
+    """Z-pool layer from `"Rotate to Attend: Convolutional Triplet Attention Module"
+    <https://arxiv.org/pdf/2010.03045.pdf>`_.
+
+    Args:
+        x: input tensor
+        dim: dimension to pool
+    """
+
+    return torch.cat([x.max(dim, keepdim=True).values, x.mean(dim, keepdim=True)], dim=dim)
 
 
 def multilabel_cross_entropy(

--- a/holocron/nn/modules/attention.py
+++ b/holocron/nn/modules/attention.py
@@ -1,8 +1,12 @@
 
 import torch
+from torch import Tensor
 import torch.nn as nn
 
-__all__ = ['SAM']
+from .downsample import ZPool
+
+
+__all__ = ['SAM', 'TripletAttention']
 
 
 class SAM(nn.Module):
@@ -16,5 +20,51 @@ class SAM(nn.Module):
         super().__init__()
         self.conv = nn.Conv2d(in_channels, 1, 1)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return x * torch.sigmoid(self.conv(x))
+
+
+class DimAttention(nn.Module):
+    """Attention layer across a specific dimension
+
+    Args:
+        dim: dimension to compute attention on
+    """
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.compress = nn.Sequential(
+            ZPool(dim=1),
+            nn.Conv2d(2, 1, kernel_size=7, stride=1, padding=3, bias=False),
+            nn.BatchNorm2d(1, eps=1e-5, momentum=0.01),
+            nn.Sigmoid()
+        )
+        self.dim = dim
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.dim != 1:
+            x = x.transpose(self.dim, 1).contiguous()
+        out = x * self.compress(x)
+        if self.dim != 1:
+            out = out.transpose(self.dim, 1).contiguous()
+        return out
+
+
+class TripletAttention(nn.Module):
+    """Triplet attention layer from `"Rotate to Attend: Convolutional Triplet Attention Module"
+    <https://arxiv.org/pdf/2010.03045.pdf>`_. This implementation is based on the pytorch
+    `implementation <https://github.com/LandskapeAI/triplet-attention/blob/master/MODELS/triplet_attention.py> `
+    by the paper's authors.
+    """
+    def __init__(self) -> None:
+        super().__init__()
+        self.c_branch = DimAttention(dim=1)
+        self.h_branch = DimAttention(dim=2)
+        self.w_branch = DimAttention(dim=3)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x_c = self.c_branch(x)
+        x_h = self.h_branch(x)
+        x_w = self.w_branch(x)
+
+        out = (x_c + x_h + x_w) / 3
+        return out

--- a/holocron/nn/modules/downsample.py
+++ b/holocron/nn/modules/downsample.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 from typing import Tuple, Dict, Callable, List
 from .. import functional as F
 
-__all__ = ['ConcatDownsample2d', 'ConcatDownsample2dJit', 'GlobalAvgPool2d', 'BlurPool2d', 'SPP']
+__all__ = ['ConcatDownsample2d', 'ConcatDownsample2dJit', 'GlobalAvgPool2d', 'BlurPool2d', 'SPP', 'ZPool']
 
 
 class ConcatDownsample2d(nn.Module):
@@ -129,3 +129,19 @@ class SPP(nn.ModuleList):
     def forward(self, x):
         feats = [x] + [pool_layer(x) for pool_layer in self]
         return torch.cat(feats, dim=1)
+
+
+class ZPool(nn.Module):
+    """Z-pool layer from `"Rotate to Attend: Convolutional Triplet Attention Module"
+    <https://arxiv.org/pdf/2010.03045.pdf>`_.
+
+    Args:
+        dim: dimension to pool
+    """
+
+    def __init__(self, dim: int = 1) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.z_pool(x, self.dim)


### PR DESCRIPTION
This PR adds support of triplet attention, with a modified implementation of https://github.com/LandskapeAI/triplet-attention/blob/master/MODELS/triplet_attention.py.