### PR TITLE
unfreeze parameters

### DIFF
--- a/holocron/trainer/utils.py
+++ b/holocron/trainer/utils.py
@@ -37,7 +37,9 @@ def freeze_model(model: Module, last_frozen_layer: Optional[str] = None, frozen_
     Returns:
         torch.nn.Module: model
     """
-
+    # Unfreeze all parameters
+    for param in model.parameters():
+        param.requires_grad_(True)
     # Loop on parameters
     if isinstance(last_frozen_layer, str):
         layer_reached = False


### PR DESCRIPTION
A simple little modification but I think it's safer to make sure the settings are all unfreeze before freezing some of them. Especially when training the backbone and then the head of a model.