### PR TITLE
fix: Fixed CIoU aspect ratio term

### DIFF
--- a/holocron/ops/boxes.py
+++ b/holocron/ops/boxes.py
@@ -209,6 +209,6 @@ def ciou_loss(boxes1: Tensor, boxes2: Tensor) -> Tensor:
 
     # Check
     _filter = (v != 0) & (iou != 0)
-    ciou_loss[_filter].addcdiv_(v[_filter] ** 2, 1 - iou[_filter] + v[_filter])
+    ciou_loss[_filter].addcdiv_(v[_filter], 1 - iou[_filter] + v[_filter])
 
     return ciou_loss


### PR DESCRIPTION
As per #112, the current implementation has a typo in the aspect ratio term of the Complete IoU-Loss. This PR fixes that typo

Successfully merging this PR will close #112