### PR TITLE
feat: Added pretrained versions of RepVGG models

### DIFF
--- a/holocron/models/repvgg.py
+++ b/holocron/models/repvgg.py
@@ -11,13 +11,13 @@ __all__ = ['RepVGG', 'RepBlock', 'RepVGG', 'repvgg_a0', 'repvgg_a1', 'repvgg_a2'
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
     'repvgg_a0': {'num_blocks': [1, 2, 4, 14, 1], 'a': 0.75, 'b': 2.5,
-                  'url': None},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.3/repvgg_a0_224-64cb5b95.pth'},
     'repvgg_a1': {'num_blocks': [1, 2, 4, 14, 1], 'a': 1, 'b': 2.5,
-                  'url': None},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.3/repvgg_a1_224-20f3e0da.pth'},
     'repvgg_a2': {'num_blocks': [1, 2, 4, 14, 1], 'a': 1.5, 'b': 2.75,
-                  'url': None},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.3/repvgg_a2_224-7051289a.pth'},
     'repvgg_b0': {'num_blocks': [1, 4, 6, 16, 1], 'a': 1, 'b': 2.5,
-                  'url': None},
+                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.3/repvgg_b0_224-7e9c3fc7.pth'},
     'repvgg_b1': {'num_blocks': [1, 4, 6, 16, 1], 'a': 2, 'b': 4,
                   'url': None},
     'repvgg_b2': {'num_blocks': [1, 4, 6, 16, 1], 'a': 2.5, 'b': 5,

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -48,11 +48,15 @@ python train.py imagenette2-320/ --model darknet53 --lr 5e-3 -b 32 -j 16 --epoch
 | rexnet2_2x       | 91.75 (8.25)     | 19.49M  | 1.88G | bilinear      | 224        |
 | rexnet50d        | 91.46 (8.54)     | 23.55M  | 4.35G | bilinear      | 224        |
 | darknet53        | 91.46 (8.54)     | 40.60M  | 9.31G | bilinear      | 256        |
+| repvgg_a2        | 91.26 (8.74)     | 48.63M  |       | bilinear      | 224        |
 | darknet19        | 91.11 (8.89)     | 19.83M  | 2.75G | bilinear      | 224        |
 | tridentresnet50  | 91.01 (8.99)     | 45.83M  | 35.9G | bilinear      | 224        |
 | sknet50          | 90.42 (9.58)     | 35.22M  | 5.96G | bilinear      | 224        |
 | rexnet1_3x       | 90.32 (9.68)     | 7.56M   | 0.68G | bilinear      | 224        |
+| repvgg_a1        | 90.19 (9.81)     | 30.12M  |       | bilinear      | 224        |
 | rexnet1_0x       | 90.01 (9.99)     | 4.80M   | 0.42G | bilinear      | 224        |
+| repvgg_a0        | 89.96 (9.04)     | 24.74M  |       | bilinear      | 224        |
+| repvgg_b0        | 89.61 (9.39)     | 31.85M  |       | bilinear      | 224        |
 | res2net50_26w_4s | 89.58 (99.26)    | 23.67M  | 4.28G | bilinear      | 224        |
 | darnet24         | 88.25 (11.75)    | 22.40M  | 4.21G | bilinear      | 224        |
 | resnet50         | 84.36 (15.64)    | 23.53M  | 4.11G | bilinear      | 224        |


### PR DESCRIPTION
This PR introduces the following modifications:
- added pretrained weights for version A0, A1, A2 and B0 of RepVGG
- Updated classification benchmark accordingly