### PR TITLE
chore: Updated license from MIT to Apache2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2019 F-G Fernandez
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Holocron
 
-[![License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](LICENSE) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5713eafaf8074e27a4013dbfcfad9d69)](https://www.codacy.com/manual/fg/Holocron?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=frgfm/Holocron&amp;utm_campaign=Badge_Grade) ![Build Status](https://github.com/frgfm/Holocron/workflows/python-package/badge.svg) [![codecov](https://codecov.io/gh/frgfm/Holocron/branch/master/graph/badge.svg)](https://codecov.io/gh/frgfm/Holocron) [![Docs](https://img.shields.io/badge/docs-available-blue.svg)](https://frgfm.github.io/Holocron)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5713eafaf8074e27a4013dbfcfad9d69)](https://www.codacy.com/manual/fg/Holocron?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=frgfm/Holocron&amp;utm_campaign=Badge_Grade) ![Build Status](https://github.com/frgfm/Holocron/workflows/python-package/badge.svg) [![codecov](https://codecov.io/gh/frgfm/Holocron/branch/master/graph/badge.svg)](https://codecov.io/gh/frgfm/Holocron) [![Docs](https://img.shields.io/badge/docs-available-blue.svg)](https://frgfm.github.io/Holocron)
 
 Implementations of recent Deep Learning tricks in Computer Vision, easily paired up with your favorite framework and model zoo.
 
@@ -111,4 +111,4 @@ Please refer to `CONTRIBUTING` if you wish to contribute to this project.
 
 ## License
 
-Distributed under the MIT License. See `LICENSE` for more information.
+Distributed under the Apache 2.0 License. See [`LICENSE`](LICENSE) for more information.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from collections import OrderedDict
 import torch.nn as nn
 

--- a/holocron/models/darknetv2.py
+++ b/holocron/models/darknetv2.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from collections import OrderedDict
 import torch
 import torch.nn as nn

--- a/holocron/models/darknetv3.py
+++ b/holocron/models/darknetv3.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from collections import OrderedDict
 import torch
 import torch.nn as nn

--- a/holocron/models/darknetv4.py
+++ b/holocron/models/darknetv4.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from collections import OrderedDict
 import torch
 import torch.nn as nn

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch import Tensor
 import torch.nn as nn

--- a/holocron/models/detection/yolov2.py
+++ b/holocron/models/detection/yolov2.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch import Tensor
 import torch.nn as nn

--- a/holocron/models/detection/yolov4.py
+++ b/holocron/models/detection/yolov4.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch import Tensor
 import torch.nn as nn

--- a/holocron/models/pyconvresnet.py
+++ b/holocron/models/pyconvresnet.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import sys
 from torch.nn import Module
 from holocron.nn import PyConv2d

--- a/holocron/models/repvgg.py
+++ b/holocron/models/repvgg.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from collections import OrderedDict
 import torch
 import torch.nn as nn

--- a/holocron/models/res2net.py
+++ b/holocron/models/res2net.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 """
 Implementation of Res2Net
 based on https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/res2net.py

--- a/holocron/models/resnet.py
+++ b/holocron/models/resnet.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import sys
 from collections import OrderedDict
 import torch.nn as nn

--- a/holocron/models/rexnet.py
+++ b/holocron/models/rexnet.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import sys
 from math import ceil
 from collections import OrderedDict

--- a/holocron/models/segmentation/unet.py
+++ b/holocron/models/segmentation/unet.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import sys
 import torch
 from torch import Tensor

--- a/holocron/models/sknet.py
+++ b/holocron/models/sknet.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 import torch.nn as nn
 from holocron.nn import GlobalAvgPool2d

--- a/holocron/models/tridentnet.py
+++ b/holocron/models/tridentnet.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 import torch.nn as nn
 from torch.nn import functional as F

--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import logging
 import torch
 import torch.nn as nn

--- a/holocron/nn/functional.py
+++ b/holocron/nn/functional.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from math import floor, ceil
 import torch
 from torch import Tensor

--- a/holocron/nn/init.py
+++ b/holocron/nn/init.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch.nn as nn
 from torch.nn.modules.conv import _ConvNd
 from typing import Optional

--- a/holocron/nn/modules/activation.py
+++ b/holocron/nn/modules/activation.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch import Tensor
 import torch.nn as nn

--- a/holocron/nn/modules/attention.py
+++ b/holocron/nn/modules/attention.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import torch
 from torch import Tensor

--- a/holocron/nn/modules/conv.py
+++ b/holocron/nn/modules/conv.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import math
 import torch
 from torch import Tensor

--- a/holocron/nn/modules/downsample.py
+++ b/holocron/nn/modules/downsample.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import numpy as np
 import torch
 from torch import Tensor

--- a/holocron/nn/modules/dropblock.py
+++ b/holocron/nn/modules/dropblock.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from torch import Tensor
 import torch.nn as nn
 from .. import functional as F

--- a/holocron/nn/modules/lambda_layer.py
+++ b/holocron/nn/modules/lambda_layer.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch import nn, einsum
 import torch.nn.functional as F

--- a/holocron/nn/modules/loss.py
+++ b/holocron/nn/modules/loss.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch import Tensor
 import torch.nn as nn

--- a/holocron/ops/boxes.py
+++ b/holocron/ops/boxes.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
 
-'''
-Bounding box operations
-'''
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import math
 import torch

--- a/holocron/optim/adabelief.py
+++ b/holocron/optim/adabelief.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from . import functional as F
 from torch.optim import Adam

--- a/holocron/optim/adamp.py
+++ b/holocron/optim/adamp.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from . import functional as F
 from torch.optim import Adam

--- a/holocron/optim/functional.py
+++ b/holocron/optim/functional.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import math
 import torch
 from torch.nn import functional as F

--- a/holocron/optim/lamb.py
+++ b/holocron/optim/lamb.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch.optim.optimizer import Optimizer
 from typing import Tuple, Optional, Iterable, Callable

--- a/holocron/optim/lars.py
+++ b/holocron/optim/lars.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from torch.optim.optimizer import Optimizer
 from typing import Dict, Iterable, Optional, Callable, Tuple

--- a/holocron/optim/lr_scheduler.py
+++ b/holocron/optim/lr_scheduler.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import math
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.optim.optimizer import Optimizer

--- a/holocron/optim/radam.py
+++ b/holocron/optim/radam.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from . import functional as F
 from torch.optim import Adam

--- a/holocron/optim/ralars.py
+++ b/holocron/optim/ralars.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import math
 import torch
 from torch.optim.optimizer import Optimizer

--- a/holocron/optim/tadam.py
+++ b/holocron/optim/tadam.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from . import functional as F
 from torch.optim.optimizer import Optimizer

--- a/holocron/optim/wrapper.py
+++ b/holocron/optim/wrapper.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import torch
 from collections import defaultdict
 from torch.optim.optimizer import Optimizer

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import math
 from collections import defaultdict
 import matplotlib.pyplot as plt

--- a/holocron/trainer/utils.py
+++ b/holocron/trainer/utils.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from torch.nn import Module
 from torch.nn.modules.batchnorm import _BatchNorm
 from typing import Optional

--- a/holocron/utils/data/collate.py
+++ b/holocron/utils/data/collate.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import numpy as np
 import torch
 from torch import Tensor

--- a/holocron/utils/misc.py
+++ b/holocron/utils/misc.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 from tqdm.auto import tqdm
 import torch
 

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 '''
 Training script for image classification

--- a/references/clean_checkpoint.py
+++ b/references/clean_checkpoint.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
 
-'''
-Checkpoint cleanup
-'''
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import hashlib
 import torch

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 '''
 Training script for object detection

--- a/references/detection/transforms.py
+++ b/references/detection/transforms.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 '''
 Transformation for object detection
 '''

--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 '''
 Training script for semantic segmentation

--- a/references/segmentation/transforms.py
+++ b/references/segmentation/transforms.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 '''
 Transformation for semantic segmentation

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-#!usr/bin/python
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 """
 Package installation setup

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import unittest
 import torch
 from torch import nn

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import unittest
 import inspect
 import torch

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,5 +1,9 @@
-import unittest
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
 
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
+import unittest
 import math
 import torch
 

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import unittest
 import torch
 from torch.nn import CrossEntropyLoss

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import unittest
 from tempfile import NamedTemporaryFile

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019-2021, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License version 2.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
+
 import unittest
 import torch
 from holocron import utils


### PR DESCRIPTION
This PR simply updates the license from MIT to Apache 2.0