### PR TITLE
conditional import

### DIFF
--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -8,7 +8,10 @@ import torch
 import torch.nn as nn
 from holocron.nn import BlurPool2d
 from typing import List, Optional, Any, Callable, Tuple
-from torchvision.models.utils import load_state_dict_from_url
+if int(torch.__version__.split('.')[1]) >= 10:
+    from torch.hub import load_state_dict_from_url
+else:
+    from torchvision.models.utils import load_state_dict_from_url
 
 
 __all__ = ['conv_sequence', 'load_pretrained_params', 'fuse_conv_bn']


### PR DESCRIPTION
Hi,

The [load_state_dict_from_url](https://github.com/pytorch/pytorch/blob/f4dd88489a77ff9b300bf6f9b34c233ca82f76d7/torch/hub.py#L529) function has been moved in the latest release of Pytorch. I propose you this little PR to fix the bug with torch 1.10