### PR TITLE
fix: Updated import of load_state_dict_from_url

### DIFF
--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 from holocron.nn import BlurPool2d
 from typing import List, Optional, Any, Callable, Tuple
-from torchvision.models.utils import load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 
 
 __all__ = ['conv_sequence', 'load_pretrained_params', 'fuse_conv_bn']


### PR DESCRIPTION
This PR updates the import of `load_state_dict_from_url` to pytorch (instead of using the legacy mirror from torchvision)