### PR TITLE
feat: Make bias addition automatic in conv_sequence

### DIFF
--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -42,7 +42,7 @@ class DarknetBodyV1(nn.Sequential):
         super().__init__(OrderedDict([
             ('stem', nn.Sequential(*conv_sequence(in_channels, stem_channels,
                                                   act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=7, padding=3, stride=2, bias=False))),
+                                                  kernel_size=7, padding=3, stride=2, bias=(norm_layer is None)))),
             ('layers', nn.Sequential(*[self._make_layer([_in_chans] + planes,
                                                         act_layer, norm_layer, drop_layer, conv_layer)
                                        for _in_chans, planes in zip(in_chans, layout)]))])
@@ -61,7 +61,7 @@ class DarknetBodyV1(nn.Sequential):
         for in_planes, out_planes in zip(planes[:-1], planes[1:]):
             _layers.extend(conv_sequence(in_planes, out_planes, act_layer, norm_layer, drop_layer, conv_layer,
                                          kernel_size=3 if out_planes > in_planes else 1,
-                                         padding=1 if out_planes > in_planes else 0, bias=False))
+                                         padding=1 if out_planes > in_planes else 0, bias=(norm_layer is None)))
             k1 = not k1
 
         return nn.Sequential(*_layers)

--- a/holocron/models/darknet.py
+++ b/holocron/models/darknet.py
@@ -17,8 +17,10 @@ __all__ = ['DarknetV1', 'darknet24']
 
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
-    'darknet24': {'layout': [[192], [128, 256, 256, 512], [*([256, 512] * 4), 512, 1024], [512, 1024] * 2],
-                  'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.2/darknet24_224-55729a5c.pth'},
+    'darknet24': {
+        'layout': [[192], [128, 256, 256, 512], [*([256, 512] * 4), 512, 1024], [512, 1024] * 2],
+        'url': 'https://github.com/frgfm/Holocron/releases/download/v0.1.3/darknet24_224-816d72cb.pt'
+    },
 }
 
 

--- a/holocron/models/darknetv2.py
+++ b/holocron/models/darknetv2.py
@@ -49,7 +49,7 @@ class DarknetBodyV2(nn.Sequential):
         super().__init__(OrderedDict([
             ('stem', nn.Sequential(*conv_sequence(in_channels, stem_channels,
                                                   act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=3, padding=1, bias=False))),
+                                                  kernel_size=3, padding=1, bias=(norm_layer is None)))),
             ('layers', nn.Sequential(*[self._make_layer(num_blocks, _in_chans, out_chans,
                                                         act_layer, norm_layer, drop_layer, conv_layer)
                                        for _in_chans, (out_chans, num_blocks) in zip(in_chans, layout)]))])
@@ -69,12 +69,12 @@ class DarknetBodyV2(nn.Sequential):
     ) -> nn.Sequential:
         layers: List[nn.Module] = [nn.MaxPool2d(2)]
         layers.extend(conv_sequence(in_planes, out_planes, act_layer, norm_layer, drop_layer, conv_layer,
-                                    kernel_size=3, padding=1, stride=1, bias=False))
+                                    kernel_size=3, padding=1, stride=1, bias=(norm_layer is None)))
         for _ in range(num_blocks):
             layers.extend(conv_sequence(out_planes, out_planes // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                                        kernel_size=1, padding=0, stride=1, bias=False) +
+                                        kernel_size=1, padding=0, stride=1, bias=(norm_layer is None)) +
                           conv_sequence(out_planes // 2, out_planes, act_layer, norm_layer, drop_layer, conv_layer,
-                                        kernel_size=3, padding=1, stride=1, bias=False))
+                                        kernel_size=3, padding=1, stride=1, bias=(norm_layer is None)))
 
         return nn.Sequential(*layers)
 

--- a/holocron/models/darknetv3.py
+++ b/holocron/models/darknetv3.py
@@ -38,9 +38,9 @@ class ResBlock(_ResBlock):
     ) -> None:
         super().__init__(
             conv_sequence(planes, mid_planes, act_layer, norm_layer, drop_layer, conv_layer,
-                          kernel_size=1, bias=False) +
+                          kernel_size=1, bias=(norm_layer is None)) +
             conv_sequence(mid_planes, planes, act_layer, norm_layer, drop_layer, conv_layer,
-                          kernel_size=3, padding=1, bias=False),
+                          kernel_size=3, padding=1, bias=(norm_layer is None)),
             None, None)
         if drop_layer is not None:
             self.dropblock = DropBlock2d(0.1, 7, inplace=True)
@@ -80,7 +80,7 @@ class DarknetBodyV3(nn.Sequential):
         super().__init__(OrderedDict([
             ('stem', nn.Sequential(*conv_sequence(in_channels, stem_channels,
                                                   act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=3, padding=1, bias=False))),
+                                                  kernel_size=3, padding=1, bias=(norm_layer is None)))),
             ('layers', nn.Sequential(*[self._make_layer(num_blocks, _in_chans, out_chans,
                                                         act_layer, norm_layer, drop_layer, conv_layer)
                                        for _in_chans, (out_chans, num_blocks) in zip(in_chans, layout)]))])
@@ -98,7 +98,7 @@ class DarknetBodyV3(nn.Sequential):
     ) -> nn.Sequential:
 
         layers = conv_sequence(in_planes, out_planes, act_layer, norm_layer, drop_layer, conv_layer,
-                               kernel_size=3, padding=1, stride=2, bias=False)
+                               kernel_size=3, padding=1, stride=2, bias=(norm_layer is None))
         layers.extend([ResBlock(out_planes, out_planes // 2, act_layer, norm_layer, drop_layer, conv_layer)
                        for _ in range(num_blocks)])
 

--- a/holocron/models/darknetv4.py
+++ b/holocron/models/darknetv4.py
@@ -48,21 +48,21 @@ class CSPStage(nn.Module):
         compression = 2 if num_blocks > 1 else 1
         self.base_layer = nn.Sequential(*conv_sequence(in_channels, out_channels,
                                                        act_layer, norm_layer, drop_layer, conv_layer,
-                                                       kernel_size=3, padding=1, stride=2, bias=False),
+                                                       kernel_size=3, padding=1, stride=2, bias=(norm_layer is None)),
                                         # Share the conv
                                         *conv_sequence(out_channels, 2 * out_channels // compression,
                                                        act_layer, norm_layer, drop_layer, conv_layer,
-                                                       kernel_size=1, bias=False))
+                                                       kernel_size=1, bias=(norm_layer is None)))
         self.main = nn.Sequential(*[ResBlock(out_channels // compression,
                                              out_channels // compression if num_blocks > 1 else in_channels,
                                              act_layer, norm_layer, drop_layer, conv_layer)
                                     for _ in range(num_blocks)],
                                   *conv_sequence(out_channels // compression, out_channels // compression,
                                                  act_layer, norm_layer, drop_layer, conv_layer,
-                                                 kernel_size=1, bias=False))
+                                                 kernel_size=1, bias=(norm_layer is None)))
         self.transition = nn.Sequential(*conv_sequence(2 * out_channels // compression, out_channels,
                                                        act_layer, norm_layer, drop_layer, conv_layer,
-                                                       kernel_size=1, bias=False))
+                                                       kernel_size=1, bias=(norm_layer is None)))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.base_layer(x)
@@ -96,7 +96,7 @@ class DarknetBodyV4(nn.Sequential):
         super().__init__(OrderedDict([
             ('stem', nn.Sequential(*conv_sequence(in_channels, stem_channels,
                                                   act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=3, padding=1, bias=False))),
+                                                  kernel_size=3, padding=1, bias=(norm_layer is None)))),
             ('stages', nn.Sequential(*[CSPStage(_in_chans, out_chans, num_blocks,
                                                 act_layer, norm_layer, drop_layer, conv_layer)
                                        for _in_chans, (out_chans, num_blocks) in zip(in_chans, layout)]))])

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -210,6 +210,7 @@ class YOLOv1(_YOLO):
         lambda_coords: float = 5.,
         rpn_nms_thresh: float = 0.7,
         box_score_thresh: float = 0.05,
+        head_hidden_nodes: int = 512,  # In the original paper, 4096
         act_layer: Optional[nn.Module] = None,
         norm_layer: Optional[Callable[[int], nn.Module]] = None,
         drop_layer: Optional[Callable[..., nn.Module]] = None,
@@ -239,10 +240,10 @@ class YOLOv1(_YOLO):
 
         self.classifier = nn.Sequential(
             nn.Flatten(),
-            nn.Linear(1024 * 7 ** 2, 4096),
-            nn.LeakyReLU(inplace=True),
+            nn.Linear(1024 * 7 ** 2, head_hidden_nodes),
+            act_layer,
             nn.Dropout(0.5),
-            nn.Linear(4096, 7 ** 2 * (num_anchors * 5 + num_classes)))
+            nn.Linear(head_hidden_nodes, 7 ** 2 * (num_anchors * 5 + num_classes)))
         self.num_anchors = num_anchors
         self.num_classes = num_classes
         # Loss coefficients

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -76,7 +76,7 @@ class _YOLO(nn.Module):
         wh = pred_boxes[..., 2:]
         pred_xyxy = torch.cat((pred_boxes[..., :2] - wh / 2, pred_boxes[..., :2] + wh / 2), dim=-1)
 
-        # B * cells * predictors * info
+        # B * cells * predictors * info
         for idx in range(b):
 
             # Match the anchor boxes
@@ -171,7 +171,7 @@ class _YOLO(nn.Module):
             scores = torch.zeros(0, dtype=torch.float, device=b_o.device)
             labels = torch.zeros(0, dtype=torch.long, device=b_o.device)
 
-            # Objectness filter
+            # Objectness filter
             if torch.any(b_o[idx] >= 0.5):
                 coords = b_coords[idx, b_o[idx] >= 0.5]
                 scores, labels = b_scores[idx, b_o[idx] >= 0.5].max(dim=-1)
@@ -266,18 +266,18 @@ class YOLOv1(_YOLO):
 
         b, _ = x.shape
         h, w = 7, 7
-        # B * (H * W * (num_anchors * 5 + num_classes)) --> B * H * W * (num_anchors * 5 + num_classes)
+        # B * (H * W * (num_anchors * 5 + num_classes)) --> B * H * W * (num_anchors * 5 + num_classes)
         x = x.reshape(b, h, w, self.num_anchors * 5 + self.num_classes)
         # Classification scores
         b_scores = x[..., -self.num_classes:]
-        # Repeat for anchors to keep compatibility across YOLO versions
+        # Repeat for anchors to keep compatibility across YOLO versions
         b_scores = F.softmax(b_scores.unsqueeze(3), dim=-1)
         #  B * H * W * (num_anchors * 5 + num_classes) -->  B * H * W * num_anchors * 5
         x = x[..., :self.num_anchors * 5].reshape(b, h, w, self.num_anchors, 5)
         # Cell offset
         c_x = torch.arange(w, dtype=torch.float, device=x.device)
         c_y = torch.arange(h, dtype=torch.float, device=x.device)
-        # Box coordinates
+        # Box coordinates
         b_x = (torch.sigmoid(x[..., 0]) + c_x.reshape(1, 1, -1, 1)) / w
         b_y = (torch.sigmoid(x[..., 1]) + c_y.reshape(1, -1, 1, 1)) / h
         b_w = torch.sigmoid(x[..., 2])
@@ -319,7 +319,7 @@ class YOLOv1(_YOLO):
 
         out = self._forward(x)
 
-        # B * (H * W) * num_anchors
+        # B * (H * W) * num_anchors
         b_coords, b_o, b_scores = self._format_outputs(out)
 
         if self.training:
@@ -333,7 +333,7 @@ class YOLOv1(_YOLO):
         b_scores = b_scores.repeat_interleave(self.num_anchors, dim=3)
         b_scores = b_scores.contiguous().reshape(b_scores.shape[0], -1, self.num_classes)
 
-        # Stack detections into a list
+        # Stack detections into a list
         return self.post_process(b_coords, b_o, b_scores, self.rpn_nms_thresh, self.box_score_thresh)
 
 

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -229,13 +229,13 @@ class YOLOv1(_YOLO):
 
         self.block4 = nn.Sequential(
             *conv_sequence(1024, 1024, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(1024, 1024, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, stride=2, bias=False),
+                           kernel_size=3, padding=1, stride=2, bias=(norm_layer is None)),
             *conv_sequence(1024, 1024, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(1024, 1024, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False))
+                           kernel_size=3, padding=1, bias=(norm_layer is None)))
 
         self.classifier = nn.Sequential(
             nn.Flatten(),

--- a/holocron/models/detection/yolov2.py
+++ b/holocron/models/detection/yolov2.py
@@ -69,19 +69,19 @@ class YOLOv2(_YOLO):
 
         self.block5 = nn.Sequential(
             *conv_sequence(layout[-1][0], layout[-1][0], act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(layout[-1][0], layout[-1][0], act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False))
+                           kernel_size=3, padding=1, bias=(norm_layer is None)))
 
         self.passthrough_layer = nn.Sequential(*conv_sequence(layout[-2][0], layout[-2][0] // passthrough_ratio,
                                                               act_layer, norm_layer, drop_layer, conv_layer,
-                                                              kernel_size=1, bias=False),
+                                                              kernel_size=1, bias=(norm_layer is None)),
                                                ConcatDownsample2d(scale_factor=2))
 
         self.block6 = nn.Sequential(
             *conv_sequence(layout[-1][0] + layout[-2][0] // passthrough_ratio * 2 ** 2, layout[-1][0],
                            act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False))
+                           kernel_size=3, padding=1, bias=(norm_layer is None)))
 
         # Each box has P_objectness, 4 coords, and score for each class
         self.head = nn.Conv2d(layout[-1][0], anchors.shape[0] * (5 + num_classes), 1)

--- a/holocron/models/detection/yolov4.py
+++ b/holocron/models/detection/yolov4.py
@@ -51,24 +51,24 @@ class PAN(nn.Module):
 
         self.conv1 = nn.Sequential(*conv_sequence(in_channels, in_channels // 2,
                                                   act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=1, bias=False))
+                                                  kernel_size=1, bias=(norm_layer is None)))
         self.up = nn.Upsample(scale_factor=2, mode='nearest')
 
         self.conv2 = nn.Sequential(*conv_sequence(in_channels, in_channels // 2,
                                                   act_layer, norm_layer, drop_layer, conv_layer,
-                                                  kernel_size=1, bias=False))
+                                                  kernel_size=1, bias=(norm_layer is None)))
 
         self.convs = nn.Sequential(
             *conv_sequence(in_channels, in_channels // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(in_channels // 2, in_channels, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(in_channels, in_channels // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(in_channels // 2, in_channels, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(in_channels, in_channels // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False))
+                           kernel_size=1, bias=(norm_layer is None)))
 
     def forward(self, x: Tensor, up: Tensor) -> Tensor:
         out = self.conv1(x)
@@ -91,18 +91,18 @@ class Neck(nn.Module):
 
         self.fpn = nn.Sequential(
             *conv_sequence(in_planes[0], in_planes[0] // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(in_planes[0] // 2, in_planes[0], act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(in_planes[0], in_planes[0] // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             SPP([5, 9, 13]),
             *conv_sequence(4 * in_planes[0] // 2, in_planes[0] // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(in_planes[0] // 2, in_planes[0], act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(in_planes[0], in_planes[0] // 2, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False)
+                           kernel_size=1, bias=(norm_layer is None))
         )
 
         self.pan1 = PAN(in_planes[1], act_layer, norm_layer, drop_layer, conv_layer)
@@ -345,48 +345,48 @@ class Yolov4Head(nn.Module):
 
         self.head1 = nn.Sequential(
             *conv_sequence(128, 256, act_layer, norm_layer, None, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(256, (5 + num_classes) * 3, None, None, None, conv_layer,
                            kernel_size=1, bias=True))
 
         self.yolo1 = YoloLayer(anchors[0], num_classes=num_classes, scale_xy=1.2)
 
         self.pre_head2 = nn.Sequential(*conv_sequence(128, 256, act_layer, norm_layer, drop_layer, conv_layer,
-                                                      kernel_size=3, padding=1, stride=2, bias=False))
+                                                      kernel_size=3, padding=1, stride=2, bias=(norm_layer is None)))
         self.head2_1 = nn.Sequential(
             *conv_sequence(512, 256, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(256, 512, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(512, 256, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(256, 512, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(512, 256, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False))
+                           kernel_size=1, bias=(norm_layer is None)))
         self.head2_2 = nn.Sequential(
             *conv_sequence(256, 512, act_layer, norm_layer, None, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(512, (5 + num_classes) * 3, None, None, None, conv_layer,
                            kernel_size=1, bias=True))
 
         self.yolo2 = YoloLayer(anchors[1], num_classes=num_classes, scale_xy=1.1)
 
         self.pre_head3 = nn.Sequential(*conv_sequence(256, 512, act_layer, norm_layer, drop_layer, conv_layer,
-                                                      kernel_size=3, padding=1, stride=2, bias=False))
+                                                      kernel_size=3, padding=1, stride=2, bias=(norm_layer is None)))
         self.head3 = nn.Sequential(
             *conv_sequence(1024, 512, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(512, 1024, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(1024, 512, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(512, 1024, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(1024, 512, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=1, bias=False),
+                           kernel_size=1, bias=(norm_layer is None)),
             *conv_sequence(512, 1024, act_layer, norm_layer, drop_layer, conv_layer,
-                           kernel_size=3, padding=1, bias=False),
+                           kernel_size=3, padding=1, bias=(norm_layer is None)),
             *conv_sequence(1024, (5 + num_classes) * 3, None, None, None, conv_layer,
                            kernel_size=1, bias=True))
 

--- a/holocron/models/pyconvresnet.py
+++ b/holocron/models/pyconvresnet.py
@@ -51,12 +51,12 @@ class PyBottleneck(_ResBlock):
 
         super().__init__(
             [*conv_sequence(inplanes, width, act_layer, norm_layer, drop_layer, kernel_size=1,
-                            stride=1, bias=False, **kwargs),
+                            stride=1, bias=(norm_layer is None), **kwargs),
              *conv_sequence(width, width, act_layer, norm_layer, drop_layer, conv_layer=PyConv2d, kernel_size=3,
-                            stride=stride, padding=dilation, groups=groups, bias=False, dilation=dilation,
-                            num_levels=num_levels, **kwargs),
+                            stride=stride, padding=dilation, groups=groups, bias=(norm_layer is None),
+                            dilation=dilation, num_levels=num_levels, **kwargs),
              *conv_sequence(width, planes * self.expansion, None, norm_layer, drop_layer, kernel_size=1,
-                            stride=1, bias=False, **kwargs)],
+                            stride=1, bias=(norm_layer is None), **kwargs)],
             downsample, act_layer)
 
 

--- a/holocron/models/repvgg.py
+++ b/holocron/models/repvgg.py
@@ -53,11 +53,11 @@ class RepBlock(nn.Module):
 
         self.branches = nn.ModuleList([
             nn.Sequential(
-                nn.Conv2d(inplanes, planes, 3, padding=1, bias=False, stride=stride),
+                nn.Conv2d(inplanes, planes, 3, padding=1, bias=(norm_layer is None), stride=stride),
                 norm_layer(planes),
             ),
             nn.Sequential(
-                nn.Conv2d(inplanes, planes, 1, padding=0, bias=False, stride=stride),
+                nn.Conv2d(inplanes, planes, 1, padding=0, bias=(norm_layer is None), stride=stride),
                 norm_layer(planes),
             ),
         ])

--- a/holocron/models/res2net.py
+++ b/holocron/models/res2net.py
@@ -47,7 +47,7 @@ class ScaleConv2d(nn.Module):
         self.conv = nn.ModuleList([nn.Sequential(*conv_sequence(self.width, self.width,
                                                                 act_layer, norm_layer, drop_layer,
                                                                 kernel_size=3, stride=stride, padding=1,
-                                                                groups=groups, bias=False))
+                                                                groups=groups, bias=(norm_layer is None)))
                                    for _ in range(max(1, scale - 1))])
 
         if downsample:
@@ -106,10 +106,10 @@ class Bottle2neck(_ResBlock):
         width = int(math.floor(planes * (base_width / 64.))) * groups
         super().__init__(
             [*conv_sequence(inplanes, width * scale, act_layer, norm_layer, drop_layer, kernel_size=1,
-                            stride=1, bias=False),
+                            stride=1, bias=(norm_layer is None)),
              ScaleConv2d(scale, width * scale, 3, stride, groups, _downsample, act_layer, norm_layer, drop_layer),
              *conv_sequence(width * scale, planes * self.expansion, None, norm_layer, drop_layer, kernel_size=1,
-                            stride=1, bias=False)],
+                            stride=1, bias=(norm_layer is None))],
             downsample, act_layer)
 
 

--- a/holocron/models/rexnet.py
+++ b/holocron/models/rexnet.py
@@ -37,7 +37,7 @@ class SEBlock(nn.Module):
         self.pool = GlobalAvgPool2d(flatten=False)
         self.conv = nn.Sequential(
             *conv_sequence(channels, channels // se_ratio, act_layer, norm_layer, drop_layer,
-                           kernel_size=1, stride=1, bias=False),
+                           kernel_size=1, stride=1, bias=(norm_layer is None)),
             *conv_sequence(channels // se_ratio, channels, nn.Sigmoid(), None, drop_layer,
                            kernel_size=1, stride=1))
 
@@ -67,19 +67,19 @@ class ReXBlock(nn.Module):
         if t != 1:
             dw_channels = in_channels * t
             _layers.extend(conv_sequence(in_channels, dw_channels, nn.SiLU(inplace=True), norm_layer, drop_layer,
-                                         kernel_size=1, stride=1, bias=False))
+                                         kernel_size=1, stride=1, bias=(norm_layer is None)))
         else:
             dw_channels = in_channels
 
         _layers.extend(conv_sequence(dw_channels, dw_channels, None, norm_layer, drop_layer, kernel_size=3,
-                                     stride=stride, padding=1, bias=False, groups=dw_channels))
+                                     stride=stride, padding=1, bias=(norm_layer is None), groups=dw_channels))
 
         if use_se:
             _layers.append(SEBlock(dw_channels, se_ratio, act_layer, norm_layer, drop_layer))
 
         _layers.append(act_layer)
         _layers.extend(conv_sequence(dw_channels, channels, None, norm_layer, drop_layer, kernel_size=1,
-                                     stride=1, bias=False))
+                                     stride=1, bias=(norm_layer is None)))
         self.conv = nn.Sequential(*_layers)
 
     def forward(self, x):
@@ -118,7 +118,7 @@ class ReXNet(nn.Sequential):
         ses = [False] * (num_blocks[0] + num_blocks[1]) + [use_se] * sum(num_blocks[2:])
 
         _layers = conv_sequence(in_channels, chans[0], act_layer, norm_layer, drop_layer,
-                                kernel_size=3, stride=2, padding=1, bias=False)
+                                kernel_size=3, stride=2, padding=1, bias=(norm_layer is None))
 
         t = 1
         for in_c, c, s, se in zip(chans[:-1], chans[1:], strides, ses):
@@ -127,7 +127,7 @@ class ReXNet(nn.Sequential):
 
         pen_channels = int(width_mult * 1280)
         _layers.extend(conv_sequence(chans[-1], pen_channels, act_layer, norm_layer, drop_layer,
-                                     kernel_size=1, stride=1, padding=0, bias=False))
+                                     kernel_size=1, stride=1, padding=0, bias=(norm_layer is None)))
 
         super().__init__(OrderedDict([
             ('features', nn.Sequential(*_layers)),

--- a/holocron/models/sknet.py
+++ b/holocron/models/sknet.py
@@ -39,7 +39,7 @@ class SoftAttentionLayer(nn.Sequential):
     ) -> None:
         super().__init__(GlobalAvgPool2d(flatten=False),
                          *conv_sequence(channels, max(channels // sa_ratio, 32), act_layer, norm_layer, drop_layer,
-                                        kernel_size=1, stride=1, bias=False),
+                                        kernel_size=1, stride=1, bias=(norm_layer is None)),
                          *conv_sequence(max(channels // sa_ratio, 32), channels * out_multiplier,
                                         nn.Sigmoid(), None, drop_layer, kernel_size=1, stride=1))
 
@@ -60,8 +60,8 @@ class SKConv2d(nn.Module):
         super().__init__()
         self.path_convs = nn.ModuleList([nn.Sequential(*conv_sequence(in_channels, out_channels,
                                                                       act_layer, norm_layer, drop_layer,
-                                                                      kernel_size=3, bias=False, dilation=idx + 1,
-                                                                      padding=idx + 1, **kwargs))
+                                                                      kernel_size=3, bias=(norm_layer is None),
+                                                                      dilation=idx + 1, padding=idx + 1, **kwargs))
                                          for idx in range(m)])
         self.sa = SoftAttentionLayer(out_channels, sa_ratio, m, act_layer, norm_layer, drop_layer)
 
@@ -100,10 +100,10 @@ class SKBottleneck(_ResBlock):
         width = int(planes * (base_width / 64.)) * groups
         super().__init__(
             [*conv_sequence(inplanes, width, act_layer, norm_layer, drop_layer, conv_layer, kernel_size=1,
-                            stride=1, bias=False, **kwargs),
+                            stride=1, bias=(norm_layer is None), **kwargs),
              SKConv2d(width, width, 2, 16, act_layer, norm_layer, drop_layer, groups=groups, stride=stride),
              *conv_sequence(width, planes * self.expansion, None, norm_layer, drop_layer, conv_layer, kernel_size=1,
-                            stride=1, bias=False, **kwargs)],
+                            stride=1, bias=(norm_layer is None), **kwargs)],
             downsample, act_layer)
 
 

--- a/holocron/models/tridentnet.py
+++ b/holocron/models/tridentnet.py
@@ -77,13 +77,13 @@ class Tridentneck(_ResBlock):
         # Concatenate along the channel axis and enlarge BN to leverage parallelization
         super().__init__(
             [*conv_sequence(inplanes, width, act_layer, norm_layer, drop_layer, TridentConv2d, bn_channels=3 * width,
-                            kernel_size=1, stride=1, bias=False, dilation=1),
+                            kernel_size=1, stride=1, bias=(norm_layer is None), dilation=1),
              *conv_sequence(width, width, act_layer, norm_layer, drop_layer, TridentConv2d, bn_channels=3 * width,
                             kernel_size=3, stride=stride,
-                            padding=1, groups=groups, bias=False, dilation=3),
+                            padding=1, groups=groups, bias=(norm_layer is None), dilation=3),
              *conv_sequence(width, planes * self.expansion, None, norm_layer, drop_layer, TridentConv2d,
                             bn_channels=3 * planes * self.expansion,
-                            kernel_size=1, stride=1, bias=False, dilation=1)],
+                            kernel_size=1, stride=1, bias=(norm_layer is None), dilation=1)],
             downsample, act_layer)
 
 

--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -37,6 +37,9 @@ def conv_sequence(
     if blurpool and conv_stride > 1:
         kwargs['stride'] = 1
 
+    # Avoid bias if there is batch normalization
+    kwargs['bias'] = kwargs.get('bias', norm_layer is None)
+
     conv_seq = [conv_layer(in_channels, out_channels, **kwargs)]
 
     if callable(norm_layer):

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -48,5 +48,5 @@ python train.py imagenette2-320/ --arch darknet53 --lr 5e-3 -b 32 -j 16 --epochs
 | repvgg_a0        | 91.18 (8.82)     | 24.74M  |       | bilinear      | 224        |
 | repvgg_b0        | 89.61 (9.39)     | 31.85M  |       | bilinear      | 224        |
 | res2net50_26w_4s | 89.58 (99.26)    | 23.67M  | 4.28G | bilinear      | 224        |
-| darnet24         | 88.25 (11.75)    | 22.40M  | 4.21G | bilinear      | 224        |
+| darnet24         | 91.57 (8.43)    | 22.40M  | 4.21G | bilinear      | 224        |
 | resnet50         | 84.36 (15.64)    | 23.53M  | 4.11G | bilinear      | 224        |

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,10 @@ def test_conv_sequence():
     assert mod[0].kernel_size == (3, 3)
     assert mod[0].stride == (1, 1)
     assert mod[3].stride == 2
+    assert mod[0].bias is None
+    # Ensures that bias is added when there is no BN
+    mod = utils.conv_sequence(3, 32, kernel_size=3, stride=2, act_layer=nn.ReLU(inplace=True))
+    assert isinstance(getattr(mod[0], 'bias'), nn.Parameter)
 
 
 def test_fuse_conv_bn():


### PR DESCRIPTION
This PR introduces the following modifications:
- makes bias addition automatic in `conv_sequence`
- improves darknet24 params
- changes the YOLOv1 head to have a reasonable amount of params
- updates classification benchmark
- updates unittest