### PR TITLE
fix: Fixes MCLoss and RandomCrop in the segmentation training script

### DIFF
--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -157,7 +157,7 @@ def main(args):
 
     # Loss setup
     loss_weight = None
-    if isinstance(args.bg_factor, float):
+    if isinstance(args.bg_factor, float) and args.bg_factor != 1:
         loss_weight = torch.ones(len(VOC_CLASSES))
         loss_weight[0] = args.bg_factor
     if args.loss == 'crossentropy':

--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -165,7 +165,7 @@ def main(args):
     elif args.loss == 'focal':
         criterion = holocron.nn.FocalLoss(weight=loss_weight, ignore_index=255)
     elif args.loss == 'mc':
-        criterion = holocron.nn.MutualChannelLoss(weight=loss_weight, ignore_index=255)
+        criterion = holocron.nn.MutualChannelLoss(weight=loss_weight, ignore_index=255, xi=3)
 
     # Optimizer setup
     model_params = [p for p in model.parameters() if p.requires_grad]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy>=1.17.2
 fastprogress>=1.0.0
 matplotlib>=3.0.0
 contiguous-params==1.0.0
+Pillow>=8.4.0

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ _deps = [
     "fastprogress>=1.0.0",
     "matplotlib>=3.0.0",
     "contiguous-params==1.0.0",
+    "Pillow>=8.4.0",  # cf. https://github.com/pytorch/vision/issues/4934
     # Testing
     "pytest>=5.3.2",
     "coverage>=4.5.4",
@@ -78,6 +79,7 @@ install_requires = [
     deps["fastprogress"],
     deps["matplotlib"],
     deps["contiguous-params"],
+    deps["Pillow"],
 ]
 
 extras = {}


### PR DESCRIPTION
This PR introduces the following modifications:
- adds possibility to train architectures from torchvision in detection & segmentation training
- avoids unnecessary loss weighting in segmentation training
- fixes the use of MCLoss in segmentation training
- updates Pillow version to avoids issues with RandomCrop for the segmentation training (cf. https://github.com/pytorch/vision/issues/4934)
