### PR TITLE
feat: Added finite loss safeguard in trainer

### DIFF
--- a/holocron/trainer/__init__.py
+++ b/holocron/trainer/__init__.py
@@ -1,5 +1,5 @@
 from .core import *
 from .classification import *
-from .segmentation import *
 from .detection import *
+from .segmentation import *
 from .utils import *

--- a/holocron/trainer/classification.py
+++ b/holocron/trainer/classification.py
@@ -24,6 +24,8 @@ class ClassificationTrainer(Trainer):
         gpu (int, optional): index of the GPU to use
         output_file (str, optional): path where checkpoints will be saved
         amp (bool, optional): whether to use automatic mixed precision
+        skip_nan_loss (bool, optional): whether the optimizer step should be skipped when the loss is NaN
+        on_epoch_end (Callable[[Dict[str, float]], Any]): callback triggered at the end of an epoch
     """
 
     @torch.inference_mode()

--- a/holocron/trainer/detection.py
+++ b/holocron/trainer/detection.py
@@ -44,6 +44,8 @@ class DetectionTrainer(Trainer):
         gpu (int, optional): index of the GPU to use
         output_file (str, optional): path where checkpoints will be saved
         amp (bool, optional): whether to use automatic mixed precision
+        skip_nan_loss (bool, optional): whether the optimizer step should be skipped when the loss is NaN
+        on_epoch_end (Callable[[Dict[str, float]], Any]): callback triggered at the end of an epoch
     """
 
     @staticmethod

--- a/holocron/trainer/segmentation.py
+++ b/holocron/trainer/segmentation.py
@@ -25,6 +25,8 @@ class SegmentationTrainer(Trainer):
         output_file (str, optional): path where checkpoints will be saved
         num_classes (int): number of output classes
         amp (bool, optional): whether to use automatic mixed precision
+        skip_nan_loss (bool, optional): whether the optimizer step should be skipped when the loss is NaN
+        on_epoch_end (Callable[[Dict[str, float]], Any]): callback triggered at the end of an epoch
     """
 
     def __init__(self, *args: Any, num_classes: int = 10, **kwargs: Any) -> None:


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed isort in `__init__`
- adds an option for safeguard in case the loss isn't finite
- updates trainers' docstrings