### PR TITLE
refactor: Removed contiguous params since torch>=1.7.0 includes it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ tqdm>=4.1.0
 numpy>=1.17.2
 fastprogress>=1.0.0
 matplotlib>=3.0.0
-contiguous-params==1.0.0
 Pillow>=8.4.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ _deps = [
     "numpy>=1.17.2",
     "fastprogress>=1.0.0",
     "matplotlib>=3.0.0",
-    "contiguous-params==1.0.0",
     "Pillow>=8.4.0",  # cf. https://github.com/pytorch/vision/issues/4934
     # Testing
     "pytest>=5.3.2",

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ install_requires = [
     deps["numpy"],
     deps["fastprogress"],
     deps["matplotlib"],
-    deps["contiguous-params"],
     deps["Pillow"],
 ]
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -76,6 +76,9 @@ def _test_trainer(
     lr: float = 1e-3
 ) -> None:
 
+    learner.model = trainer.utils.freeze_model(learner.model.train(), freeze_until)
+    learner._reset_opt(lr)
+    # Update param groups & LR
     learner.save(learner.output_file)
     checkpoint = torch.load(learner.output_file, map_location='cpu')
     model_w = learner.model.state_dict()[ref_param].clone()


### PR DESCRIPTION
This PR introduces the following modifications:
- removes the dependency of contiguous params now that PyTorch includes it
- updates dependencies