### PR TITLE
docs: Added tutorial notebooks

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,5 @@ sphinx-rtd-theme==0.4.3
 sphinxemoji>=0.1.8
 sphinx-copybutton>=0.3.1
 docutils<0.18
+recommonmark>=0.7.1
+sphinx-markdown-tables>=0.0.15

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,8 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinxemoji.sphinxemoji',  # cf. https://sphinxemojicodes.readthedocs.io/en/stable/
     'sphinx_copybutton',
+    'recommonmark',
+    'sphinx_markdown_tables',
 ]
 
 napoleon_use_ivar = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ This project is meant for:
    :hidden:
 
    installing
+   notebooks
 
 
 

--- a/docs/source/notebooks.md
+++ b/docs/source/notebooks.md
@@ -1,0 +1,1 @@
+../../notebooks/README.md

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,9 @@
+# Holocron Notebooks
+
+Here are some notebooks compiled for users to better leverage the library capabilities:
+
+| Notebook     |      Description      |   |
+|:----------|:-------------|------:|
+| [Quicktour](https://github.com/frgfm/notebooks/blob/master/holocron/quicktour.ipynb) | A presentation of the main features of Holocron | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/frgfm/notebooks/blob/master/holocron/quicktour.ipynb) |
+| [HuggingFace Hub integration](https://github.com/frgfm/notebooks/blob/master/holocron/hf_hub.ipynb) | Use HuggingFace model hub with Holocron | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/frgfm/notebooks/blob/master/holocron/hf_hub.ipynb) |
+| [Image classification](https://github.com/frgfm/notebooks/blob/master/holocron/classification_training.ipynb) | How to train your own image classifier | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/frgfm/notebooks/blob/master/holocron/classification_training.ipynb) |

--- a/setup.py
+++ b/setup.py
@@ -105,8 +105,8 @@ extras["docs"] = deps_list(
     "sphinxemoji",
     "sphinx-copybutton",
     "docutils",
-    "recommonmark>=0.7.1",
-    "sphinx-markdown-tables>=0.0.15",
+    "recommonmark",
+    "sphinx-markdown-tables",
 )
 
 extras["dev"] = (

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ _deps = [
     "sphinxemoji>=0.1.8",
     "sphinx-copybutton>=0.3.1",
     "docutils<0.18",
+    "recommonmark>=0.7.1",
+    "sphinx-markdown-tables>=0.0.15",
 ]
 
 # Borrowed from https://github.com/huggingface/transformers/blob/master/setup.py
@@ -103,6 +105,8 @@ extras["docs"] = deps_list(
     "sphinxemoji",
     "sphinx-copybutton",
     "docutils",
+    "recommonmark>=0.7.1",
+    "sphinx-markdown-tables>=0.0.15",
 )
 
 extras["dev"] = (


### PR DESCRIPTION
This PR adds notebook tutorial to the documentation:
- quicktour
- integration with HuggingFace hub
- image classification training