### PR TITLE
chore: Fixed jinja2 dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-copybutton>=0.3.1
 docutils<0.18
 recommonmark>=0.7.1
 sphinx-markdown-tables>=0.0.15
+Jinja2<3.1

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ _deps = [
     "docutils<0.18",
     "recommonmark>=0.7.1",
     "sphinx-markdown-tables>=0.0.15",
+    "Jinja2<3.1",  # cf. https://github.com/readthedocs/readthedocs.org/issues/9038
 ]
 
 # Borrowed from https://github.com/huggingface/transformers/blob/master/setup.py
@@ -107,6 +108,7 @@ extras["docs"] = deps_list(
     "docutils",
     "recommonmark",
     "sphinx-markdown-tables",
+    "Jinja2",
 )
 
 extras["dev"] = (


### PR DESCRIPTION
This PR fixes sphinx sub-dependencies by pinning jinja2 (cf. https://github.com/readthedocs/readthedocs.org/issues/9038)