### PR TITLE
docs: Fixed documentation build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ docs = [
     # Indirect deps
     # cf. https://github.com/readthedocs/readthedocs.org/issues/9038
     "Jinja2<3.1",
+    # cf. https://github.com/ryanfox/sphinx-markdown-tables/issues/36
+    "markdown<3.4.0"
 ]
 dev = [
     # test


### PR DESCRIPTION
This PR adds a version specifier to `markdown` to solve https://github.com/ryanfox/sphinx-markdown-tables/issues/36