### PR TITLE
fix: Fixed BinaryClassificationTrainer

### DIFF
--- a/holocron/trainer/classification.py
+++ b/holocron/trainer/classification.py
@@ -122,20 +122,7 @@ class BinaryClassificationTrainer(Trainer):
         for x, target in self.val_loader:
             x, target = self.to_cuda(x, target)
 
-            # In case target are stored as long
-            target = target.to(dtype=x.dtype)
-
-            # AMP
-            if self.amp:
-                with torch.cuda.amp.autocast():  # type: ignore[attr-defined]
-                    # Forward
-                    out = self.model(x)
-                    # Loss computation
-                    _loss = self.criterion(out, target.view_as(out))
-
-            # Forward
-            out = self.model(x)
-            _loss = self.criterion(out, target.view_as(out))
+            _loss, out = self._get_loss(x, target, return_logits=True)
 
             # Safeguard for NaN loss
             if not torch.isnan(_loss) and not torch.isinf(_loss):

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -126,7 +126,7 @@ class Trainer:
             x, target = self.to_cuda(x, target)
 
             # Forward
-            batch_loss = self._get_loss(x, target)
+            batch_loss: Tensor = self._get_loss(x, target)  # type: ignore[assignment]
 
             # Backprop
             if not self.skip_nan_loss or torch.isfinite(batch_loss):
@@ -318,7 +318,7 @@ class Trainer:
             x, target = self.to_cuda(x, target)
 
             # Forward
-            batch_loss = self._get_loss(x, target)
+            batch_loss: Tensor = self._get_loss(x, target)  # type: ignore[assignment]
             self._backprop_step(batch_loss)
             # Update LR
             scheduler.step()
@@ -401,7 +401,7 @@ class Trainer:
 
         for _ in range(num_it):
             # Forward
-            batch_loss = self._get_loss(x, target)
+            batch_loss: Tensor = self._get_loss(x, target)  # type: ignore[assignment]
             # Backprop
             self._backprop_step(batch_loss)
 

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -174,18 +174,24 @@ class Trainer:
             # Update the params
             self.optimizer.step()
 
-    def _get_loss(self, x: Tensor, target: Tensor) -> Tensor:
+    def _get_loss(self, x: Tensor, target: Tensor, return_logits: bool = False) -> Union[Tensor, Tuple[Tensor, Tensor]]:
         # AMP
         if self.amp:
             with torch.cuda.amp.autocast():  # type: ignore[attr-defined]
                 # Forward
                 out = self.model(x)
                 # Loss computation
-                return self.criterion(out, target)
+                loss = self.criterion(out, target)
+                if return_logits:
+                    return loss, out
+                return loss
 
         # Forward
         out = self.model(x)
-        return self.criterion(out, target)
+        loss = self.criterion(out, target)
+        if return_logits:
+            return loss, out
+        return loss
 
     def _set_params(self, norm_weight_decay: Optional[float] = None) -> None:
         if not any(p.requires_grad for p in self.model.parameters()):

--- a/holocron/trainer/segmentation.py
+++ b/holocron/trainer/segmentation.py
@@ -53,17 +53,7 @@ class SegmentationTrainer(Trainer):
         for x, target in self.val_loader:
             x, target = self.to_cuda(x, target)
 
-            if self.amp:
-                with torch.cuda.amp.autocast():  # type: ignore[attr-defined]
-                    # Forward
-                    out = self.model(x)
-                    # Loss computation
-                    _loss = self.criterion(out, target)
-            else:
-                # Forward
-                out = self.model(x)
-                # Loss computation
-                _loss = self.criterion(out, target)
+            _loss, out = self._get_loss(x, target, return_logits=True)
 
             # Safeguard for NaN loss
             if not torch.isnan(_loss) and not torch.isinf(_loss):


### PR DESCRIPTION
This PR introduces the following modifications:
- fixes trainer for binary classification when the target is wrongly shaped or doesn't have the good data type
- fixes the evaluation loop of binary classification trainer
- extends unittests