### PR TITLE
feat: Added two transforms Resize and RandomZoomOut

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -7,6 +7,6 @@ import os
 
 PROJECT_NAME: str = "Holocron API template"
 PROJECT_DESCRIPTION: str = "Template API for Computer Vision"
-VERSION: str = "0.2.1.dev0"
+VERSION: str = "0.2.2.dev0"
 DEBUG: bool = os.environ.get("DEBUG", "") != "False"
 HUB_REPO: str = "frgfm/rexnet1_5x"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,7 @@ Object detection
    ops
    optim
    trainer
+   transforms
    utils
    utils.data
 

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -1,0 +1,17 @@
+holocron.transforms
+===================
+
+.. automodule:: holocron.transforms
+
+.. currentmodule:: holocron.transforms
+
+:mod:`holocron.transforms` provides PIL and PyTorch tensor transformations.
+
+
+.. autoclass:: Resize
+    :members:
+
+
+.. autoclass:: RandomZoomOut
+    :members:
+

--- a/holocron/__init__.py
+++ b/holocron/__init__.py
@@ -1,3 +1,3 @@
-from holocron import models, nn, ops, optim, trainer, utils
+from holocron import models, nn, ops, optim, trainer, transforms, utils
 
 from .version import __version__

--- a/holocron/transforms/__init__.py
+++ b/holocron/transforms/__init__.py
@@ -1,0 +1,1 @@
+from .interpolation import *

--- a/holocron/transforms/interpolation.py
+++ b/holocron/transforms/interpolation.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2022, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+from math import sqrt
+from typing import Any, Tuple, Union
+
+import torch
+from PIL import Image
+from torch import nn
+from torchvision.transforms import transforms as T
+from torchvision.transforms.functional import pad, resize
+
+__all__ = ["Resize", "RandomZoomOut"]
+
+
+def _get_image_shape(image: Union[Image.Image, torch.Tensor]) -> Tuple[int, int]:
+    if isinstance(image, torch.Tensor):
+        assert image.ndim == 3
+        h, w = image.shape[1:]
+    elif isinstance(image, Image.Image):
+        w, h = image.size
+    else:
+        raise TypeError("expected arg 'image' to be a PIL image or a torch.Tensor")
+
+    return h, w
+
+
+class Resize(T.Resize):
+    """Implements a more flexible resizing scheme
+
+    .. image:: https://github.com/frgfm/Holocron/releases/download/v0.2.1/resize_example.png
+        :align: center
+
+    Args:
+        size: the desired height and width of the image in pixels
+        mode: the resizing scheme ("squish" is similar to PyTorch, "pad" will preserve the aspect ratio and pad)
+        pad_mode: padding mode when `mode` is "pad"
+        kwargs: the keyword arguments of `torchvision.transforms.Resize`
+
+    Returns:
+        the resized image
+    """
+
+    def __init__(self, size: Tuple[int, int], mode: str = "squish", pad_mode: str = "constant", **kwargs: Any):
+        assert mode in ("squish", "pad")
+        assert isinstance(size, (tuple, list)) and len(size) == 2 and all(s > 0 for s in size)
+        super().__init__(size, **kwargs)
+        self.mode = mode
+        self.pad_mode = pad_mode
+
+    def get_params(self, image: Union[Image.Image, torch.Tensor]) -> Tuple[int, int]:
+        h, w = _get_image_shape(image)
+        o_ratio = h / w
+        if self.size[0] / self.size[1] > o_ratio:
+            _h, _w = int(round(self.size[1] * o_ratio)), self.size[1]
+        else:
+            _h, _w = self.size[0], int(round(self.size[0] / o_ratio))
+
+        return _h, _w
+
+    def forward(self, image: Union[Image.Image, torch.Tensor]) -> Union[Image.Image, torch.Tensor]:
+        if self.mode == "squish":
+            return super().forward(image)
+        else:
+            h, w = self.get_params(image)
+            img = resize(image, (h, w), self.interpolation)
+            # get the padding
+            h_pad, w_pad = self.size[0] - h, self.size[1] - w
+            _padding = w_pad // 2, h_pad // 2, w_pad - w_pad // 2, h_pad - h_pad // 2
+            # Fill the rest up to target_size
+            return pad(img, _padding, padding_mode=self.pad_mode)
+
+
+class RandomZoomOut(nn.Module):
+    """Implements a size reduction of the orignal image to provide a zoom out effect.
+
+    .. image:: https://github.com/frgfm/Holocron/releases/download/v0.2.1/randomzoomout_example.png
+        :align: center
+
+    Args:
+        size: the desired height and width of the image in pixels
+        scale: the range of relative area of the projected image to the desired size
+        kwargs: the keyword arguments of `torchvision.transforms.functional.resize`
+
+    Returns:
+        the resized image
+    """
+
+    def __init__(self, size: Tuple[int, int], scale: Tuple[float, float] = (0.5, 1.0), **kwargs: Any):
+        assert isinstance(size, (tuple, list)) and len(size) == 2 and all(s > 0 for s in size)
+        assert len(scale) == 2 and scale[0] <= scale[1]
+        super().__init__()
+        self.size = size
+        self.scale = scale
+        self._kwargs = kwargs
+
+    def get_params(self, image: Union[Image.Image, torch.Tensor]) -> Tuple[int, int]:
+        h, w = _get_image_shape(image)
+
+        _scale = (self.scale[1] - self.scale[0]) * torch.rand(1).item() + self.scale[0]
+        _aratio = h / w
+        # Preserve the aspect ratio
+        _tratio = self.size[0] / self.size[1]
+        if _tratio > _aratio:
+            _max_area = self.size[1] ** 2 * _aratio
+        else:
+            _max_area = self.size[0] ** 2 / _aratio
+        _area = _max_area * _scale
+
+        _w = int(round(sqrt(_area / _aratio)))
+        _h = int(round(_area / _w))
+
+        return _h, _w
+
+    def forward(self, image: Union[Image.Image, torch.Tensor]) -> Union[Image.Image, torch.Tensor]:
+        # Skip dummy cases
+        if self.scale[0] == 1:
+            return image
+        # Get the size of the small image
+        h, w = self.get_params(image)
+        # Resize the image to this
+        img = resize(image, (h, w), **self._kwargs)
+        # get the padding
+        h_delta, w_delta = self.size[0] - h, self.size[1] - w
+        _padding = w_delta // 2, h_delta // 2, w_delta - w_delta // 2, h_delta - h_delta // 2
+        # Fill the rest up to size
+        return pad(img, _padding)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ module = [
     "huggingface_hub",
     "fastprogress.*",
     "tqdm.*",
+    "PIL.*",
 ]
 ignore_missing_imports = true
 

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -23,6 +23,10 @@ from torchvision import transforms as T
 from torchvision.datasets import VOCDetection
 from torchvision.models import detection as tv_detection
 from torchvision.transforms.functional import InterpolationMode, to_pil_image
+
+import holocron
+from holocron.models import detection
+from holocron.trainer import DetectionTrainer
 from transforms import (
     CenterCrop,
     Compose,
@@ -33,10 +37,6 @@ from transforms import (
     VOCTargetTransform,
     convert_to_relative,
 )
-
-import holocron
-from holocron.models import detection
-from holocron.trainer import DetectionTrainer
 
 VOC_CLASSES = [
     "aeroplane",

--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -22,11 +22,11 @@ from torchvision import transforms as T
 from torchvision.datasets import VOCSegmentation
 from torchvision.models import segmentation as tv_segmentation
 from torchvision.transforms.functional import InterpolationMode, to_pil_image
-from transforms import Compose, ImageTransform, RandomCrop, RandomHorizontalFlip, RandomResize, Resize, ToTensor
 
 import holocron
 from holocron.models import segmentation
 from holocron.trainer import SegmentationTrainer
+from transforms import Compose, ImageTransform, RandomCrop, RandomHorizontalFlip, RandomResize, Resize, ToTensor
 
 VOC_CLASSES = [
     "background",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from setuptools import setup
 
 PKG_NAME = "pylocron"
-VERSION = os.getenv("BUILD_VERSION", "0.2.1.dev0")
+VERSION = os.getenv("BUILD_VERSION", "0.2.2.dev0")
 
 
 if __name__ == "__main__":

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,77 @@
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from torch import nn
+
+from holocron import transforms as T
+
+
+def test_resize():
+
+    # Arg check
+    with pytest.raises(AssertionError):
+        T.Resize(16)
+
+    with pytest.raises(AssertionError):
+        T.Resize((16, 16), mode="stretch")
+
+    img1 = np.full((16, 32, 3), 255, dtype=np.uint8)
+    img2 = np.full((32, 16, 3), 255, dtype=np.uint8)
+    tf = T.Resize((32, 32), mode="pad")
+    assert isinstance(tf, nn.Module)
+
+    # PIL Image
+    out = tf(Image.fromarray(img1))
+    assert isinstance(out, Image.Image)
+    assert out.size == (32, 32)
+    np_out = np.asarray(out)
+    assert np.all(np_out[8:-8] == 255) and np.all(np_out[:8] == 0) and np.all(np_out[-8:]) == 0
+    out = tf(Image.fromarray(img2))
+    assert isinstance(out, Image.Image)
+    assert out.size == (32, 32)
+    np_out = np.asarray(out)
+    assert np.all(np_out[:, 8:-8] == 255) and np.all(np_out[:, :8] == 0) and np.all(np_out[:, -8:]) == 0
+    # Squish
+    out = T.Resize((32, 32), mode="squish")(img1)
+    assert np.all(np.asarray(out) == 255)
+
+    # Tensor
+    out = tf(torch.from_numpy(img1).to(dtype=torch.float32).permute(2, 0, 1) / 255)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (3, 32, 32)
+    np_out = out.numpy()
+    assert np.all(np_out[:, 8:-8] == 1) and np.all(np_out[:, :8] == 0) and np.all(np_out[:, -8:]) == 0
+    out = tf(torch.from_numpy(img2).to(dtype=torch.float32).permute(2, 0, 1) / 255)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (3, 32, 32)
+    np_out = out.numpy()
+    assert np.all(np_out[:, :, 8:-8] == 1) and np.all(np_out[:, :, :8] == 0) and np.all(np_out[:, :, -8:]) == 0
+
+
+def test_randomzoomout():
+
+    # Arg check
+    with pytest.raises(AssertionError):
+        T.RandomZoomOut(224)
+
+    with pytest.raises(AssertionError):
+        T.Resize((16, 16), (1, 0.5))
+
+    img = np.full((16, 16, 3), 255, dtype=np.uint8)
+    tf = T.RandomZoomOut((32, 32))
+    assert isinstance(tf, nn.Module)
+
+    # PIL Image
+    out = tf(Image.fromarray(img))
+    assert isinstance(out, Image.Image)
+    assert out.size == (32, 32)
+    np_out = np.asarray(out)
+    assert np.all(np_out[16, 16] == 255) and np_out.mean() < 255
+
+    # Tensor
+    out = tf(torch.from_numpy(img).to(dtype=torch.float32).permute(2, 0, 1) / 255)
+    assert isinstance(out, torch.Tensor)
+    assert out.size == (32, 32)
+    np_out = np.asarray(out)
+    assert np.all(np_out[:, 16, 16] == 255) and np_out.mean() < 1

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -33,7 +33,7 @@ def test_resize():
     np_out = np.asarray(out)
     assert np.all(np_out[:, 8:-8] == 255) and np.all(np_out[:, :8] == 0) and np.all(np_out[:, -8:]) == 0
     # Squish
-    out = T.Resize((32, 32), mode="squish")(img1)
+    out = T.Resize((32, 32), mode="squish")(Image.fromarray(img1))
     assert np.all(np.asarray(out) == 255)
 
     # Tensor
@@ -58,20 +58,21 @@ def test_randomzoomout():
     with pytest.raises(AssertionError):
         T.Resize((16, 16), (1, 0.5))
 
-    img = np.full((16, 16, 3), 255, dtype=np.uint8)
+    pil_img = Image.fromarray(np.full((16, 16, 3), 255, dtype=np.uint8))
+    torch_img = torch.ones((3, 16, 16), dtype=torch.float32)
     tf = T.RandomZoomOut((32, 32))
     assert isinstance(tf, nn.Module)
 
     # PIL Image
-    out = tf(Image.fromarray(img))
+    out = tf(pil_img)
     assert isinstance(out, Image.Image)
     assert out.size == (32, 32)
     np_out = np.asarray(out)
     assert np.all(np_out[16, 16] == 255) and np_out.mean() < 255
 
     # Tensor
-    out = tf(torch.from_numpy(img).to(dtype=torch.float32).permute(2, 0, 1) / 255)
+    out = tf(torch_img)
     assert isinstance(out, torch.Tensor)
-    assert out.size == (32, 32)
+    assert out.shape == (3, 32, 32)
     np_out = np.asarray(out)
-    assert np.all(np_out[:, 16, 16] == 255) and np_out.mean() < 1
+    assert np.all(np_out[:, 16, 16] == 1) and np_out.mean() < 1


### PR DESCRIPTION
This PR adds support for two transformations:
- Resize (allows padding)
- RandomZoomOut

Additionally, this adds entries in the documentation and corresponding unittests.

![resize_example](https://github.com/frgfm/Holocron/releases/download/v0.2.1/resize_example.png)
![randomzoomout_example](https://github.com/frgfm/Holocron/releases/download/v0.2.1/randomzoomout_example.png)