### PR TITLE
docs: Added examples in docstrings

### DIFF
--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -30,6 +30,27 @@ def conv_sequence(
     blurpool: bool = False,
     **kwargs: Any,
 ) -> List[nn.Module]:
+    """Builds a sequence of convolutional layers.
+
+    >>> from torch import nn
+    >>> from holocron.models.utils import conv_sequence
+    >>> layers = conv_sequence(3, 32, nn.ReLU(), norm_layer=nn.Batchnorm2d(32), kernel_size=3, blurpool=True)
+
+    Args:
+        in_channels: number of channels of the input tensor
+        out_channels: number of convolutional filters
+        act_layer: the non linearity layer to apply
+        norm_layer: the normalization layer
+        drop_layer: the dropout-like layer for regularization
+        conv_layer: if specified, replaces `torch.nn.Conv2d` as the convolutional layer
+        bn_channels: if specified, replaces the normalization channels
+        attention_layer: the self attention layer
+        blurpool: whether blur pooling should be applied
+        kwargs: the keyword arguments of the conv_layer
+
+    Returns:
+        a list of layers
+    """
 
     if conv_layer is None:
         conv_layer = nn.Conv2d
@@ -79,7 +100,11 @@ def load_pretrained_params(
 
 
 def fuse_conv_bn(conv: nn.Conv2d, bn: nn.BatchNorm2d) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Fuse convolution and batch normalization layers into a convolution with bias
+    """Fuse convolution and batch normalization layers into a convolution with bias.
+
+    >>> from torch import nn
+    >>> from holocron.utils import fuse_conv_bn
+    >>> fuse_conv_bn(nn.Conv2d(3, 32, 3), nn.Batchnorm2d(32))
 
     Args:
         conv: the convolutional layer
@@ -107,6 +132,9 @@ def fuse_conv_bn(conv: nn.Conv2d, bn: nn.BatchNorm2d) -> Tuple[torch.Tensor, tor
 
 def model_from_hf_hub(repo_id: str, **kwargs: Any) -> nn.Module:
     """Instantiate & load a pretrained model from HF hub.
+
+    >>> from holocron.models.utils import model_from_hf_hub
+    >>> model = model_from_hf_hub("frgfm/rexnet1_0x")
 
     Args:
         repo_id: HuggingFace model hub repo

--- a/holocron/nn/init.py
+++ b/holocron/nn/init.py
@@ -8,7 +8,7 @@ from torch.nn.modules.conv import _ConvNd
 
 
 def init_module(module: nn.Module, nonlinearity: str = "relu") -> None:
-    """Initializes pytorch modules
+    """Initializes pytorch modules.
 
     Args:
         module: module to initialize

--- a/holocron/nn/modules/activation.py
+++ b/holocron/nn/modules/activation.py
@@ -28,7 +28,7 @@ class _Activation(nn.Module):
 
 
 class HardMish(_Activation):
-    r"""Implements the Had Mish activation module from `"H-Mish" <https://github.com/digantamisra98/H-Mish>`_
+    r"""Implements the Had Mish activation module from `"H-Mish" <https://github.com/digantamisra98/H-Mish>`_.
 
     This activation is computed as follows:
 
@@ -42,7 +42,7 @@ class HardMish(_Activation):
 
 class NLReLU(_Activation):
     r"""Implements the Natural-Logarithm ReLU activation module from `"Natural-Logarithm-Rectified Activation
-    Function in Convolutional Neural Networks" <https://arxiv.org/pdf/1908.03682.pdf>`_
+    Function in Convolutional Neural Networks" <https://arxiv.org/pdf/1908.03682.pdf>`_.
 
     This activation is computed as follows:
 
@@ -59,7 +59,7 @@ class NLReLU(_Activation):
 
 class FReLU(nn.Module):
     r"""Implements the Funnel activation module from `"Funnel Activation for Visual Recognition"
-    <https://arxiv.org/pdf/2007.11824.pdf>`_
+    <https://arxiv.org/pdf/2007.11824.pdf>`_.
 
     This activation is computed as follows:
 

--- a/holocron/trainer/classification.py
+++ b/holocron/trainer/classification.py
@@ -14,7 +14,7 @@ __all__ = ["ClassificationTrainer", "BinaryClassificationTrainer"]
 
 
 class ClassificationTrainer(Trainer):
-    """Image classification trainer class
+    """Image classification trainer class.
 
     Args:
         model (torch.nn.Module): model to train
@@ -71,7 +71,7 @@ class ClassificationTrainer(Trainer):
 
 
 class BinaryClassificationTrainer(Trainer):
-    """Image binary classification trainer class
+    """Image binary classification trainer class.
 
     Args:
         model (torch.nn.Module): model to train

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -241,7 +241,7 @@ class Trainer:
         sched_type: str = "onecycle",
         norm_weight_decay: Optional[float] = None,
     ) -> None:
-        """Train the model for a given number of epochs
+        """Train the model for a given number of epochs.
 
         Args:
             num_epochs (int): number of epochs to train

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -117,7 +117,7 @@ class Trainer:
         Args:
             mb (fastprogress.master_bar): primary progress bar
         """
-        self.model = freeze_bn(self.model.train())
+        freeze_bn(self.model.train())
 
         nan_cnt = 0
 
@@ -251,7 +251,7 @@ class Trainer:
             norm_weight_decay (float, optional): weight decay to apply to normalization parameters
         """
 
-        self.model = freeze_model(self.model.train(), freeze_until)
+        freeze_model(self.model.train(), freeze_until)
         # Update param groups & LR
         self._reset_opt(lr, norm_weight_decay)
         # Scheduler
@@ -303,7 +303,7 @@ class Trainer:
         if num_it > len(self.train_loader):
             raise ValueError("the value of `num_it` needs to be lower than the number of available batches")
 
-        self.model = freeze_model(self.model.train(), freeze_until)
+        freeze_model(self.model.train(), freeze_until)
         # Update param groups & LR
         self._reset_opt(start_lr, norm_weight_decay)
         gamma = (end_lr / start_lr) ** (1 / (num_it - 1))
@@ -388,7 +388,7 @@ class Trainer:
             num_it (int, optional): number of iterations to perform
         """
 
-        self.model = freeze_model(self.model.train(), freeze_until)
+        freeze_model(self.model.train(), freeze_until)
         # Update param groups & LR
         self._reset_opt(lr, norm_weight_decay)
 

--- a/holocron/trainer/detection.py
+++ b/holocron/trainer/detection.py
@@ -33,7 +33,7 @@ def assign_iou(gt_boxes: Tensor, pred_boxes: Tensor, iou_threshold: float = 0.5)
 
 
 class DetectionTrainer(Trainer):
-    """Object detection trainer class
+    """Object detection trainer class.
 
     Args:
         model (torch.nn.Module): model to train
@@ -99,7 +99,7 @@ class DetectionTrainer(Trainer):
 
     @torch.inference_mode()
     def evaluate(self, iou_threshold: float = 0.5) -> Dict[str, Optional[float]]:
-        """Evaluate the model on the validation set
+        """Evaluate the model on the validation set.
 
         Args:
             iou_threshold (float, optional): IoU threshold for pair assignment

--- a/holocron/trainer/segmentation.py
+++ b/holocron/trainer/segmentation.py
@@ -13,7 +13,7 @@ __all__ = ["SegmentationTrainer"]
 
 
 class SegmentationTrainer(Trainer):
-    """Semantic segmentation trainer class
+    """Semantic segmentation trainer class.
 
     Args:
         model (torch.nn.Module): model to train

--- a/holocron/trainer/utils.py
+++ b/holocron/trainer/utils.py
@@ -30,8 +30,6 @@ def freeze_bn(mod: nn.Module) -> None:
             m.track_running_stats = False
             m.eval()
 
-    return mod
-
 
 def freeze_model(
     model: nn.Module,

--- a/holocron/trainer/utils.py
+++ b/holocron/trainer/utils.py
@@ -11,14 +11,16 @@ from torch.nn.modules.batchnorm import _BatchNorm
 __all__ = ["freeze_bn", "freeze_model", "split_normalization_params"]
 
 
-def freeze_bn(mod: nn.Module) -> nn.Module:
+def freeze_bn(mod: nn.Module) -> None:
     """Prevents parameter and stats from updating in Batchnorm layers that are frozen
+
+    >>> from holocron.models import rexnet1_0x
+    >>> from holocron.trainer.utils import freeze_bn
+    >>> model = rexnet1_0x()
+    >>> freeze_bn(model)
 
     Args:
         mod (torch.nn.Module): model to train
-
-    Returns:
-        torch.nn.Module: model
     """
 
     # Loop on modules
@@ -32,17 +34,21 @@ def freeze_bn(mod: nn.Module) -> nn.Module:
 
 
 def freeze_model(
-    model: nn.Module, last_frozen_layer: Optional[str] = None, frozen_bn_stat_update: bool = False
-) -> nn.Module:
-    """Freeze a specific range of model layers
+    model: nn.Module,
+    last_frozen_layer: Optional[str] = None,
+    frozen_bn_stat_update: bool = False,
+) -> None:
+    """Freeze a specific range of model layers.
+
+    >>> from holocron.models import rexnet1_0x
+    >>> from holocron.trainer.utils import freeze_model
+    >>> model = rexnet1_0x()
+    >>> freeze_model(model)
 
     Args:
         model (torch.nn.Module): model to train
         last_frozen_layer (str, optional): last layer to freeze. Assumes layers have been registered in forward order
         frozen_bn_stat_update (bool, optional): force stats update in BN layers that are frozen
-
-    Returns:
-        torch.nn.Module: model
     """
 
     # Unfreeze everything
@@ -65,9 +71,7 @@ def freeze_model(
 
     # Loop on modules
     if not frozen_bn_stat_update:
-        model = freeze_bn(model)
-
-    return model
+        freeze_bn(model)
 
 
 def split_normalization_params(

--- a/holocron/transforms/interpolation.py
+++ b/holocron/transforms/interpolation.py
@@ -82,7 +82,7 @@ class Resize(T.Resize):
         return _h, _w
 
     def forward(self, image: Union[Image.Image, torch.Tensor]) -> Union[Image.Image, torch.Tensor]:
-        if self.mode == "squish":
+        if self.mode == ResizeMethod.SQUISH:
             return super().forward(image)
         else:
             h, w = self.get_params(image)

--- a/holocron/transforms/interpolation.py
+++ b/holocron/transforms/interpolation.py
@@ -3,6 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+from enum import Enum
 from math import sqrt
 from typing import Any, Tuple, Union
 
@@ -13,6 +14,15 @@ from torchvision.transforms import transforms as T
 from torchvision.transforms.functional import pad, resize
 
 __all__ = ["Resize", "RandomZoomOut"]
+
+
+class ResizeMethod(Enum):
+    """Resize methods
+    Available methods are ``squish``, ``pad``.
+    """
+
+    SQUISH = "squish"
+    PAD = "pad"
 
 
 def _get_image_shape(image: Union[Image.Image, torch.Tensor]) -> Tuple[int, int]:
@@ -28,10 +38,15 @@ def _get_image_shape(image: Union[Image.Image, torch.Tensor]) -> Tuple[int, int]
 
 
 class Resize(T.Resize):
-    """Implements a more flexible resizing scheme
+    """Implements a more flexible resizing scheme.
 
     .. image:: https://github.com/frgfm/Holocron/releases/download/v0.2.1/resize_example.png
         :align: center
+
+    >>> from holocron.transforms import Resize
+    >>> pil_img = ...
+    >>> tf = Resize((224, 224), mode="pad")
+    >>> resized_img = tf(pil_img)
 
     Args:
         size: the desired height and width of the image in pixels
@@ -43,8 +58,14 @@ class Resize(T.Resize):
         the resized image
     """
 
-    def __init__(self, size: Tuple[int, int], mode: str = "squish", pad_mode: str = "constant", **kwargs: Any):
-        assert mode in ("squish", "pad")
+    def __init__(
+        self,
+        size: Tuple[int, int],
+        mode: ResizeMethod = ResizeMethod.SQUISH,
+        pad_mode: str = "constant",
+        **kwargs: Any,
+    ) -> None:
+        assert isinstance(mode, ResizeMethod)
         assert isinstance(size, (tuple, list)) and len(size) == 2 and all(s > 0 for s in size)
         super().__init__(size, **kwargs)
         self.mode = mode
@@ -78,6 +99,11 @@ class RandomZoomOut(nn.Module):
 
     .. image:: https://github.com/frgfm/Holocron/releases/download/v0.2.1/randomzoomout_example.png
         :align: center
+
+    >>> from holocron.transforms import RandomZoomOut
+    >>> pil_img = ...
+    >>> tf = RandomZoomOut((224, 224), scale=(0.3, 1.))
+    >>> resized_img = tf(pil_img)
 
     Args:
         size: the desired height and width of the image in pixels

--- a/holocron/utils/data/collate.py
+++ b/holocron/utils/data/collate.py
@@ -15,17 +15,17 @@ __all__ = ["Mixup"]
 
 class Mixup(torch.nn.Module):
     """Implements a batch collate function with MixUp strategy from
-    `"mixup: Beyond Empirical Risk Minimization" <https://arxiv.org/pdf/1710.09412.pdf>`_
-
-    Args:
-        num_classes: number of expected classes
-        alpha: mixup factor
+    `"mixup: Beyond Empirical Risk Minimization" <https://arxiv.org/pdf/1710.09412.pdf>`_.
 
     >>> import torch
     >>> from torch.utils.data._utils.collate import default_collate
     >>> from holocron.utils.data import Mixup
     >>> mix = Mixup(num_classes=10, alpha=0.4)
     >>> loader = torch.utils.data.DataLoader(dataset, batch_size, collate_fn=lambda b: mix(*default_collate(b)))
+
+    Args:
+        num_classes: number of expected classes
+        alpha: mixup factor
     """
 
     def __init__(self, num_classes: int, alpha: float = 0.2) -> None:

--- a/holocron/utils/misc.py
+++ b/holocron/utils/misc.py
@@ -27,7 +27,10 @@ def parallel(
     progress: bool = False,
     **kwargs: Any,
 ) -> Sequence[Out]:
-    """Download a file accessible via URL with mutiple retries
+    """Performs parallel tasks by leveraging multi-threading.
+
+    >>> from holocron.utils.misc import parallel
+    >>> parallel(lambda x: x ** 2, list(range(10)))
 
     Args:
         func (callable): function to be executed on multiple workers

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -83,7 +83,7 @@ def _test_trainer(
     learner: trainer.Trainer, num_it: int, ref_param: str, freeze_until: Optional[str] = None, lr: float = 1e-3
 ) -> None:
 
-    learner.model = trainer.utils.freeze_model(learner.model.train(), freeze_until)
+    trainer.utils.freeze_model(learner.model.train(), freeze_until)
     learner._reset_opt(lr)
     # Update param groups & LR
     learner.save(learner.output_file)

--- a/tests/test_trainer_utils.py
+++ b/tests/test_trainer_utils.py
@@ -15,7 +15,7 @@ def test_freeze_bn():
     # Freeze & forward
     for p in mod.parameters():
         p.requires_grad_(False)
-    mod = trainer.freeze_bn(mod)
+    trainer.freeze_bn(mod)
     for _ in range(10):
         _ = mod(torch.rand((1, 3, 32, 32)))
     # Check that stats were not updated
@@ -28,7 +28,7 @@ def test_freeze_model():
 
     # Simple model
     mod = nn.Sequential(nn.Conv2d(3, 32, 3), nn.ReLU(inplace=True), nn.Conv2d(32, 64, 3), nn.ReLU(inplace=True))
-    mod = trainer.freeze_model(mod, "0")
+    trainer.freeze_model(mod, "0")
     # Check that the correct layers were frozen
     assert not any(p.requires_grad for p in mod[0].parameters())
     assert all(p.requires_grad for p in mod[2].parameters())
@@ -38,6 +38,6 @@ def test_freeze_model():
     # Freeze last layer
     for p in mod[-1].parameters():
         p.requires_grad_(False)
-    mod = trainer.freeze_model(mod, "0")
+    trainer.freeze_model(mod, "0")
     # Ensure the last layer is now unfrozen
     assert all(p.requires_grad for p in mod[-1].parameters())

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -5,6 +5,7 @@ from PIL import Image
 from torch import nn
 
 from holocron import transforms as T
+from holocron.transforms.interpolation import ResizeMethod
 
 
 def test_resize():
@@ -16,9 +17,12 @@ def test_resize():
     with pytest.raises(AssertionError):
         T.Resize((16, 16), mode="stretch")
 
+    with pytest.raises(AssertionError):
+        T.Resize((16, 16), mode="pad")
+
     img1 = np.full((16, 32, 3), 255, dtype=np.uint8)
     img2 = np.full((32, 16, 3), 255, dtype=np.uint8)
-    tf = T.Resize((32, 32), mode="pad")
+    tf = T.Resize((32, 32), mode=ResizeMethod.PAD)
     assert isinstance(tf, nn.Module)
 
     # PIL Image
@@ -33,7 +37,7 @@ def test_resize():
     np_out = np.asarray(out)
     assert np.all(np_out[:, 8:-8] == 255) and np.all(np_out[:, :8] == 0) and np.all(np_out[:, -8:]) == 0
     # Squish
-    out = T.Resize((32, 32), mode="squish")(Image.fromarray(img1))
+    out = T.Resize((32, 32), mode=ResizeMethod.SQUISH)(Image.fromarray(img1))
     assert np.all(np.asarray(out) == 255)
 
     # Tensor
@@ -58,9 +62,9 @@ def test_randomzoomout():
     with pytest.raises(AssertionError):
         T.Resize((16, 16), (1, 0.5))
 
-    pil_img = Image.fromarray(np.full((16, 16, 3), 255, dtype=np.uint8))
-    torch_img = torch.ones((3, 16, 16), dtype=torch.float32)
-    tf = T.RandomZoomOut((32, 32))
+    pil_img = Image.fromarray(np.full((64, 64, 3), 255, dtype=np.uint8))
+    torch_img = torch.ones((3, 64, 64), dtype=torch.float32)
+    tf = T.RandomZoomOut((32, 32), scale=(.5, .99))
     assert isinstance(tf, nn.Module)
 
     # PIL Image

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -64,7 +64,7 @@ def test_randomzoomout():
 
     pil_img = Image.fromarray(np.full((64, 64, 3), 255, dtype=np.uint8))
     torch_img = torch.ones((3, 64, 64), dtype=torch.float32)
-    tf = T.RandomZoomOut((32, 32), scale=(.5, .99))
+    tf = T.RandomZoomOut((32, 32), scale=(0.5, 0.99))
     assert isinstance(tf, nn.Module)
 
     # PIL Image


### PR DESCRIPTION
This PR introduces the following modifications:
- changed the output signature of inplace freezing functions to None
- added examples in docstings of most functions