### PR TITLE
docs: Added full update equations of all optimizers

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -13,9 +13,9 @@ Optimizers
 
 Implementations of recent parameter optimizer for Pytorch modules.
 
-.. autoclass:: Lamb
+.. autoclass:: LARS
 
-.. autoclass:: Lars
+.. autoclass:: LAMB
 
 .. autoclass:: RaLars
 

--- a/holocron/optim/__init__.py
+++ b/holocron/optim/__init__.py
@@ -2,7 +2,7 @@ from . import wrapper
 from .adabelief import AdaBelief
 from .adamp import AdamP
 from .adan import Adan
-from .lamb import Lamb
-from .lars import Lars
+from .lamb import LAMB
+from .lars import LARS
 from .ralars import RaLars
 from .tadam import TAdam

--- a/holocron/optim/adabelief.py
+++ b/holocron/optim/adabelief.py
@@ -12,8 +12,32 @@ from . import functional as F
 
 
 class AdaBelief(Adam):
-    """Implements the AdaBelief optimizer from `"AdaBelief Optimizer: Adapting Stepsizes by the Belief in
+    r"""Implements the AdaBelief optimizer from `"AdaBelief Optimizer: Adapting Stepsizes by the Belief in
     Observed Gradients" <https://arxiv.org/pdf/2010.07468.pdf>`_.
+
+    The estimation of momentums is described as follows, :math:`\forall t \geq 1`:
+
+    .. math::
+        m_t \leftarrow \beta_1 m_{t-1} + (1 - \beta_1) g_t \\
+        s_t \leftarrow \beta_2 s_{t-1} + (1 - \beta_2) (g_t - m_t)^2 + \epsilon
+
+    where :math:`g_t` is the gradient of :math:`\theta_t`,
+    :math:`\beta_1, \beta_2 \in [0, 1]^3` are the exponential average smoothing coefficients,
+    :math:`m_0 = 0,\ s_0 = 0`, :math:`\epsilon > 0`.
+
+    Then we correct their biases using:
+
+    .. math::
+        \hat{m_t} \leftarrow \frac{m_t}{1 - \beta_1^t} \\
+        \hat{s_t} \leftarrow \frac{s_t}{1 - \beta_2^t}
+
+    And finally the update step is performed using the following rule:
+
+    .. math::
+        \theta_t \leftarrow \theta_{t-1} - \alpha \frac{\hat{m_t}}{\sqrt{\hat{s_t}} + \epsilon}
+
+    where :math:`\theta_t` is the parameter value at step :math:`t` (:math:`\theta_0` being the initialization value),
+    :math:`\alpha` is the learning rate, :math:`\epsilon > 0`.
 
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining parameter groups

--- a/holocron/optim/lamb.py
+++ b/holocron/optim/lamb.py
@@ -33,7 +33,8 @@ class LAMB(Optimizer):
 
     .. math::
         r_t \leftarrow \frac{\hat{m_t}}{\sqrt{\hat{v_t}} + \epsilon} \\
-        \theta_t \leftarrow \theta_{t-1} - \alpha \phi(\lVert \theta_t \rVert) \frac{r_t + \lambda \theta_t}{\lVert r_t + \theta_t \rVert}
+        \theta_t \leftarrow \theta_{t-1} - \alpha \phi(\lVert \theta_t \rVert)
+        \frac{r_t + \lambda \theta_t}{\lVert r_t + \theta_t \rVert}
 
     where :math:`\theta_t` is the parameter value at step :math:`t` (:math:`\theta_0` being the initialization value),
     :math:`\phi` is a clipping function,
@@ -66,7 +67,7 @@ class LAMB(Optimizer):
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError(f"Invalid beta parameter at index 1: {betas[1]}")
         defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
-        super(Lamb, self).__init__(params, defaults)
+        super().__init__(params, defaults)
         # LARS arguments
         self.scale_clip = scale_clip
         if self.scale_clip is None:

--- a/holocron/optim/lamb.py
+++ b/holocron/optim/lamb.py
@@ -10,8 +10,34 @@ from torch.optim.optimizer import Optimizer
 
 
 class LAMB(Optimizer):
-    """Implements the Lamb optimizer from `"Large batch optimization for deep learning: training BERT in 76 minutes"
+    r"""Implements the Lamb optimizer from `"Large batch optimization for deep learning: training BERT in 76 minutes"
     <https://arxiv.org/pdf/1904.00962v3.pdf>`_.
+
+    The estimation of momentums is described as follows, :math:`\forall t \geq 1`:
+
+    .. math::
+        m_t \leftarrow \beta_1 m_{t-1} + (1 - \beta_1) g_t \\
+        v_t \leftarrow \beta_2 v_{t-1} + (1 - \beta_2) g_t^2
+
+    where :math:`g_t` is the gradient of :math:`\theta_t`,
+    :math:`\beta_1, \beta_2 \in [0, 1]^3` are the exponential average smoothing coefficients,
+    :math:`m_0 = 0,\ v_0 = 0`.
+
+    Then we correct their biases using:
+
+    .. math::
+        \hat{m_t} \leftarrow \frac{m_t}{1 - \beta_1^t} \\
+        \hat{v_t} \leftarrow \frac{v_t}{1 - \beta_2^t}
+
+    And finally the update step is performed using the following rule:
+
+    .. math::
+        r_t \leftarrow \frac{\hat{m_t}}{\sqrt{\hat{v_t}} + \epsilon} \\
+        \theta_t \leftarrow \theta_{t-1} - \alpha \phi(\lVert \theta_t \rVert) \frac{r_t + \lambda \theta_t}{\lVert r_t + \theta_t \rVert}
+
+    where :math:`\theta_t` is the parameter value at step :math:`t` (:math:`\theta_0` being the initialization value),
+    :math:`\phi` is a clipping function,
+    :math:`\alpha` is the learning rate, :math:`\lambda \geq 0` is the weight decay, :math:`\epsilon > 0`.
 
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining parameter groups

--- a/holocron/optim/lamb.py
+++ b/holocron/optim/lamb.py
@@ -9,7 +9,7 @@ import torch
 from torch.optim.optimizer import Optimizer
 
 
-class Lamb(Optimizer):
+class LAMB(Optimizer):
     """Implements the Lamb optimizer from `"Large batch optimization for deep learning: training BERT in 76 minutes"
     <https://arxiv.org/pdf/1904.00962v3.pdf>`_.
 

--- a/holocron/optim/lars.py
+++ b/holocron/optim/lars.py
@@ -13,6 +13,30 @@ class LARS(Optimizer):
     r"""Implements the LARS optimizer from `"Large batch training of convolutional networks"
     <https://arxiv.org/pdf/1708.03888.pdf>`_.
 
+    The estimation of global and local learning rates is described as follows, :math:`\forall t \geq 1`:
+
+    .. math::
+        \alpha_t \leftarrow \alpha (1 - t / T)^2 \\
+        \gamma_t \leftarrow \frac{\lVert \theta_t \rVert}{\lVert g_t \rVert  + \lambda \lVert \theta_t \rVert}
+
+    where :math:`\theta_t` is the parameter value at step :math:`t` (:math:`\theta_0` being the initialization value),
+    :math:`g_t` is the gradient of :math:`\theta_t`,
+    :math:`T` is the total number of steps,
+    :math:`\alpha` is the learning rate
+    :math:`\lambda \geq 0` is the weight decay.
+
+    Then we estimate the momentum using:
+
+    .. math::
+        v_t \leftarrow m v_{t-1} + \alpha_t \gamma_t (g_t + \lambda \theta_t)
+
+    where :math:`m` is the momentum and :math:`v_0 = 0`.
+
+    And finally the update step is performed using the following rule:
+
+    .. math::
+        \theta_t \leftarrow \theta_{t-1} - v_t
+
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups

--- a/holocron/optim/lars.py
+++ b/holocron/optim/lars.py
@@ -68,14 +68,14 @@ class LARS(Optimizer):
         defaults = dict(lr=lr, momentum=momentum, dampening=dampening, weight_decay=weight_decay, nesterov=nesterov)
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
-        super(Lars, self).__init__(params, defaults)
+        super().__init__(params, defaults)
         # LARS arguments
         self.scale_clip = scale_clip
         if self.scale_clip is None:
             self.scale_clip = (0.0, 10.0)
 
     def __setstate__(self, state: Dict[str, torch.Tensor]):
-        super(Lars, self).__setstate__(state)
+        super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("nesterov", False)
 

--- a/holocron/optim/lars.py
+++ b/holocron/optim/lars.py
@@ -9,7 +9,7 @@ import torch
 from torch.optim.optimizer import Optimizer
 
 
-class Lars(Optimizer):
+class LARS(Optimizer):
     r"""Implements the LARS optimizer from `"Large batch training of convolutional networks"
     <https://arxiv.org/pdf/1708.03888.pdf>`_.
 

--- a/holocron/optim/tadam.py
+++ b/holocron/optim/tadam.py
@@ -18,7 +18,8 @@ class TAdam(Optimizer):
     The estimation of momentums is described as follows, :math:`\forall t \geq 1`:
 
     .. math::
-        w_t \leftarrow (\nu + d) \Big(\nu + \sum\limits_{j} \frac{(g_t^j - m_{t-1}^j)^2}{v_{t-1} + \epsilon} \Big)^{-1} \\
+        w_t \leftarrow (\nu + d) \Big(\nu + \sum\limits_{j}
+        \frac{(g_t^j - m_{t-1}^j)^2}{v_{t-1} + \epsilon} \Big)^{-1} \\
         m_t \leftarrow \frac{W_{t-1}}{W_{t-1} + w_t} m_{t-1} + \frac{w_t}{W_{t-1} + w_t} g_t \\
         v_t \leftarrow \beta_2 v_{t-1} + (1 - \beta_2) (g_t - g_{t-1})
 

--- a/holocron/optim/tadam.py
+++ b/holocron/optim/tadam.py
@@ -12,8 +12,34 @@ from . import functional as F
 
 
 class TAdam(Optimizer):
-    """Implements the TAdam optimizer from `"TAdam: A Robust Stochastic Gradient Optimizer"
+    r"""Implements the TAdam optimizer from `"TAdam: A Robust Stochastic Gradient Optimizer"
     <https://arxiv.org/pdf/2003.00179.pdf>`_.
+
+    The estimation of momentums is described as follows, :math:`\forall t \geq 1`:
+
+    .. math::
+        w_t \leftarrow (\nu + d) \Big(\nu + \sum\limits_{j} \frac{(g_t^j - m_{t-1}^j)^2}{v_{t-1} + \epsilon} \Big)^{-1} \\
+        m_t \leftarrow \frac{W_{t-1}}{W_{t-1} + w_t} m_{t-1} + \frac{w_t}{W_{t-1} + w_t} g_t \\
+        v_t \leftarrow \beta_2 v_{t-1} + (1 - \beta_2) (g_t - g_{t-1})
+
+    where :math:`g_t` is the gradient of :math:`\theta_t`,
+    :math:`\beta_1, \beta_2 \in [0, 1]^3` are the exponential average smoothing coefficients,
+    :math:`m_0 = 0,\ v_0 = 0,\ W_0 = \frac{\beta_1}{1 - \beta_1}`;
+    :math:`\nu` is the degrees of freedom and :math:`d` if the number of dimensions of the parameter gradient.
+
+    Then we correct their biases using:
+
+    .. math::
+        \hat{m_t} \leftarrow \frac{m_t}{1 - \beta_1^t} \\
+        \hat{v_t} \leftarrow \frac{v_t}{1 - \beta_2^t}
+
+    And finally the update step is performed using the following rule:
+
+    .. math::
+        \theta_t \leftarrow \theta_{t-1} - \alpha \frac{\hat{m_t}}{\sqrt{\hat{v_t}} + \epsilon}
+
+    where :math:`\theta_t` is the parameter value at step :math:`t` (:math:`\theta_0` being the initialization value),
+    :math:`\alpha` is the learning rate, :math:`\epsilon > 0`.
 
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining parameter groups

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -41,11 +41,11 @@ def _test_optimizer(name: str, **kwargs: Any) -> None:
 
 
 def test_lars():
-    _test_optimizer("Lars", momentum=0.9, weight_decay=2e-5)
+    _test_optimizer("LARS", momentum=0.9, weight_decay=2e-5)
 
 
 def test_lamb():
-    _test_optimizer("Lamb", weight_decay=2e-5)
+    _test_optimizer("LAMB", weight_decay=2e-5)
 
 
 def test_ralars():


### PR DESCRIPTION
This PR introduces the following modifications:
- renames `Lars` and `Lamb` into `LARS` and  `LAMB`
- adds the update rule equations to the docstrings of optimizers to improve the documentation