### PR TITLE
add CompactConvolutionalTransformer (CCT) architecture 

### DIFF
--- a/holocron/models/classification/__init__.py
+++ b/holocron/models/classification/__init__.py
@@ -11,3 +11,4 @@ from .resnet import *
 from .rexnet import *
 from .sknet import *
 from .tridentnet import *
+from .cct import *

--- a/holocron/models/classification/cct.py
+++ b/holocron/models/classification/cct.py
@@ -1,0 +1,334 @@
+# Copyright (C) 2023, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+from enum import Enum
+from typing import Any, Callable, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from holocron.nn.modules import TransformerEncoderBlock
+
+from ..checkpoints import (
+    Checkpoint,
+    Dataset,
+    Evaluation,
+    LoadingMeta,
+    Metric,
+    PreProcessing,
+    TrainingRecipe,
+    _handle_legacy_pretrained,
+)
+from ..presets import IMAGENETTE
+from ..utils import _configure_model
+
+__all__ = [
+    "ConvPatchEmbed",
+    "CCT_2_Checkpoint",
+    "cct_2",
+    "cct_4",
+    "cct_6",
+    "cct_7",
+]
+
+
+class ConvPatchEmbed(nn.Module):
+    """Compute 2D patch embeddings"""
+
+    def __init__(
+        self,
+        kernel_size: int,
+        stride: int,
+        padding: int,
+        pool_kernel_size: int = 2,
+        pool_stride: int = 2,
+        pool_padding: int = 1,
+        conv_layers: int = 1,
+        input_channels: int = 3,
+        output_channels: int = 64,
+        in_planes: int = 64,
+        activation_fct: Callable[[Any], Any] = nn.ReLU(),
+    ) -> None:
+
+        super(ConvPatchEmbed, self).__init__()
+        _inner_planes = [in_planes for _ in range(conv_layers - 1)]
+        _planes = [input_channels] + _inner_planes + [output_channels]
+
+        self.conv_layers = nn.Sequential(
+            *[
+                nn.Sequential(  # type: ignore[call-overload]
+                    nn.Conv2d(
+                        _planes[i],
+                        _planes[i + 1],
+                        kernel_size=kernel_size,
+                        stride=stride,
+                        padding=padding,
+                        bias=False,
+                    ),
+                    activation_fct,
+                    nn.MaxPool2d(kernel_size=pool_kernel_size, stride=pool_stride, padding=pool_padding),
+                )
+                for i in range(conv_layers)
+            ]
+        )
+
+        self.apply(self.init_weight)
+
+    def get_num_patches(self, channels: int = 3, img_size: int = 224) -> int:
+        return self.forward(torch.zeros(1, channels, img_size, img_size)).shape[1]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        patches = self.conv_layers(x)
+        return patches.flatten(2, 3).transpose(-2, -1)
+
+    @staticmethod
+    def init_weight(m):
+        if isinstance(m, nn.Conv2d):
+            nn.init.kaiming_normal_(m.weight)
+
+
+class CCT(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        num_heads: int,
+        mlp_ratio: int,
+        num_layers: int,
+        input_channels: int = 3,
+        img_size: int = 224,
+        conv_layers: int = 1,
+        kernel_size: int = 3,
+        stride: int = 2,
+        padding: int = 3,
+        pool_kernel_size: int = 3,
+        pool_stride: int = 2,
+        pool_padding: int = 1,
+        dropout: float = 0.1,
+        num_classes: int = 10,
+        **kwargs: Any,
+    ) -> None:
+        super(CCT, self).__init__()
+
+        self.patches = ConvPatchEmbed(
+            kernel_size,
+            stride,
+            padding,
+            pool_kernel_size,
+            pool_stride,
+            pool_padding,
+            conv_layers,
+            input_channels,
+            embedding_dim,
+            **kwargs,
+        )
+        self.positions = nn.Parameter(
+            torch.zeros(1, self.patches.get_num_patches(input_channels, img_size), embedding_dim), requires_grad=True
+        )
+
+        self.encoder = TransformerEncoderBlock(
+            num_layers=num_layers,
+            num_heads=num_heads,
+            d_model=embedding_dim,
+            dff=embedding_dim * mlp_ratio,
+            dropout=dropout,
+            activation_fct=nn.GELU(),
+        )
+        self.attention_pool = nn.Linear(embedding_dim, 1)
+        self.head = nn.Linear(embedding_dim, num_classes)
+
+        # Init all layers
+        self.apply(self.init_weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        patches = self.patches(x)
+        patches += self.positions
+        features = self.encoder(patches)
+        avg_pool = self.attention_pool(features)
+        return self.head(torch.matmul(F.softmax(avg_pool, dim=1).transpose(-1, -2), features).squeeze(-2))
+
+    @staticmethod
+    def init_weight(m):
+        if isinstance(m, nn.Linear):
+            nn.init.trunc_normal_(m.weight, std=0.02)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+        if isinstance(m, nn.LayerNorm):
+            nn.init.constant_(m.bias, 0)
+            nn.init.constant_(m.weight, 1.0)
+
+
+def _cct(
+    checkpoint: Union[Checkpoint, None],
+    progress: bool,
+    **kwargs: Any,
+) -> CCT:
+    # Build the model
+    model = CCT(**kwargs)
+    return _configure_model(model, checkpoint, progress=progress)
+
+
+def _checkpoint(
+    arch: str, url: str, acc1: float, acc5: float, sha256: str, size: int, num_params: int, commit: str, train_args: str
+) -> Checkpoint:
+    return Checkpoint(
+        evaluation=Evaluation(
+            dataset=Dataset.IMAGENETTE,
+            results={Metric.TOP1_ACC: acc1, Metric.TOP5_ACC: acc5},
+        ),
+        meta=LoadingMeta(
+            url=url, sha256=sha256, size=size, num_params=num_params, arch=arch, categories=IMAGENETTE.classes
+        ),
+        pre_processing=PreProcessing(input_shape=(3, 224, 224), mean=IMAGENETTE.mean, std=IMAGENETTE.std),
+        recipe=TrainingRecipe(commit=commit, script="references/classification/train.py", args=train_args),
+    )
+
+
+class CCT_2_Checkpoint(Enum):
+
+    IMAGENETTE = _checkpoint(
+        arch="cct_2",
+        url="",
+        acc1=0.8346,
+        acc5=0.9855,
+        sha256="",
+        size=19797114,
+        num_params=619659,
+        commit="",
+        train_args=(
+            "./imagenette2-320/ --arch cct_2 --batch-size 16 --mixup-alpha 0.2 --amp --device 0 --epochs 100"
+            " --lr 1e-3 --label-smoothing 0.1 --random-erase 0.1 --train-crop-size 224 --val-resize-size 232"
+            " --opt adamw --weight-decay 5e-2"
+        ),
+    )
+    DEFAULT = IMAGENETTE
+
+
+def cct_2(
+    pretrained: bool = False,
+    checkpoint: Union[Checkpoint, None] = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> CCT:
+    """CCT-2 from
+    `"Escaping the Big Data Paradigm with Compact Transformers" <https://arxiv.org/pdf/2104.05704.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNette
+        checkpoint: If specified, the model's parameters will be set to the checkpoint's values
+        progress (bool): If True, displays a progress bar of the download to stderr
+
+    Returns:
+        torch.nn.Module: classification model
+
+    .. autoclass:: holocron.models.CCT_2_Checkpoint
+        :members:
+    """
+    checkpoint = _handle_legacy_pretrained(
+        pretrained,
+        checkpoint,
+        CCT_2_Checkpoint.DEFAULT,  # type: ignore[arg-type]
+    )
+    return _cct(checkpoint, progress, num_layers=2, num_heads=2, mlp_ratio=1, embedding_dim=128, **kwargs)
+
+
+def cct_4(
+    pretrained: bool = False,
+    checkpoint: Union[Checkpoint, None] = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> CCT:
+    """CCT-4 from
+    `"Escaping the Big Data Paradigm with Compact Transformers" <https://arxiv.org/pdf/2104.05704.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNette
+        checkpoint: If specified, the model's parameters will be set to the checkpoint's values
+        progress (bool): If True, displays a progress bar of the download to stderr
+
+    Returns:
+        torch.nn.Module: classification model
+    """
+    checkpoint = _handle_legacy_pretrained(
+        pretrained,
+        checkpoint,
+        None,
+    )
+    return _cct(checkpoint, progress, num_layers=4, num_heads=2, mlp_ratio=1, embedding_dim=128, **kwargs)
+
+
+def cct_6(
+    pretrained: bool = False,
+    checkpoint: Union[Checkpoint, None] = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> CCT:
+    """CCT-6 from
+    `"Escaping the Big Data Paradigm with Compact Transformers" <https://arxiv.org/pdf/2104.05704.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNette
+        checkpoint: If specified, the model's parameters will be set to the checkpoint's values
+        progress (bool): If True, displays a progress bar of the download to stderr
+
+    Returns:
+        torch.nn.Module: classification model
+    """
+    checkpoint = _handle_legacy_pretrained(
+        pretrained,
+        checkpoint,
+        None,
+    )
+    return _cct(checkpoint, progress, num_layers=6, num_heads=4, mlp_ratio=2, embedding_dim=256, **kwargs)
+
+
+def cct_7(
+    pretrained: bool = False,
+    checkpoint: Union[Checkpoint, None] = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> CCT:
+    """CCT-7 from
+    `"Escaping the Big Data Paradigm with Compact Transformers" <https://arxiv.org/pdf/2104.05704.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNette
+        checkpoint: If specified, the model's parameters will be set to the checkpoint's values
+        progress (bool): If True, displays a progress bar of the download to stderr
+
+    Returns:
+        torch.nn.Module: classification model
+    """
+    checkpoint = _handle_legacy_pretrained(
+        pretrained,
+        checkpoint,
+        None,
+    )
+    return _cct(checkpoint, progress, num_layers=7, num_heads=4, mlp_ratio=2, embedding_dim=256, **kwargs)
+
+
+def cct_14(
+    pretrained: bool = False,
+    checkpoint: Union[Checkpoint, None] = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> CCT:
+    """CCT-14 from
+    `"Escaping the Big Data Paradigm with Compact Transformers" <https://arxiv.org/pdf/2104.05704.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNette
+        checkpoint: If specified, the model's parameters will be set to the checkpoint's values
+        progress (bool): If True, displays a progress bar of the download to stderr
+
+    Returns:
+        torch.nn.Module: classification model
+    """
+    checkpoint = _handle_legacy_pretrained(
+        pretrained,
+        checkpoint,
+        None,
+    )
+    return _cct(checkpoint, progress, num_layers=14, num_heads=6, mlp_ratio=3, embedding_dim=384, **kwargs)

--- a/holocron/nn/modules/__init__.py
+++ b/holocron/nn/modules/__init__.py
@@ -5,3 +5,4 @@ from .downsample import *
 from .dropblock import *
 from .lambda_layer import *
 from .loss import *
+from .transformers import *

--- a/holocron/nn/modules/transformers.py
+++ b/holocron/nn/modules/transformers.py
@@ -1,0 +1,145 @@
+# Copyright (C) 2023, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+import math
+from typing import Any, Callable, Optional, Tuple
+
+import torch
+from torch import nn
+
+__all__ = ["TransformerEncoderBlock"]
+
+
+def scaled_dot_product_attention(
+    query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, mask: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Scaled Dot-Product Attention from `"Attention is All You Need" <https://arxiv.org/pdf/1706.03762.pdf>`_.
+
+    ..math::
+        Attention(Q, K, V) = softmax(\frac{QK^T}{\sqrt{d_k}})V
+
+    Args:
+        query (torch.Tensor): query tensor
+        key (torch.Tensor): key tensor
+        value (torch.Tensor): value tensor
+        mask (torch.Tensor): optional mask
+    """
+
+    scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(query.size(-1))
+    if mask is not None:
+        # NOTE: to ensure the ONNX compatibility, masked_fill works only with int equal condition
+        scores = scores.masked_fill(mask == 0, float("-inf"))
+    p_attn = torch.softmax(scores, dim=-1)
+    return torch.matmul(p_attn, value), p_attn
+
+
+class MultiHeadAttention(nn.Module):
+    """Multi-Head Attention Layer from `"Attention is All You Need" <https://arxiv.org/pdf/1706.03762.pdf>`_.
+
+    Args:
+        num_heads (int): number of attention heads
+        d_model (int): dimension of the model
+        dropout (float): dropout rate
+    """
+
+    def __init__(self, num_heads: int, d_model: int, dropout: float = 0.1) -> None:
+        super().__init__()
+        assert d_model % num_heads == 0, "d_model must be divisible by num_heads"
+
+        self.d_k = d_model // num_heads
+        self.num_heads = num_heads
+
+        self.linear_layers = nn.ModuleList([nn.Linear(d_model, d_model) for _ in range(3)])
+        self.output_linear = nn.Linear(d_model, d_model)
+
+    def forward(self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, mask=None) -> torch.Tensor:
+        batch_size = query.size(0)
+
+        # linear projections of Q, K, V
+        query, key, value = [
+            linear(x).view(batch_size, -1, self.num_heads, self.d_k).transpose(1, 2)
+            for linear, x in zip(self.linear_layers, (query, key, value))
+        ]
+
+        # apply attention on all the projected vectors in batch
+        x, attn = scaled_dot_product_attention(query, key, value, mask=mask)
+
+        # Concat attention heads
+        x = x.transpose(1, 2).contiguous().view(batch_size, -1, self.num_heads * self.d_k)
+
+        return self.output_linear(x)
+
+
+class PositionwiseFeedForward(nn.Sequential):
+    """Position-wise Feed-Forward Network from `"Attention is All You Need" <https://arxiv.org/pdf/1706.03762.pdf>`_.
+
+    Args:
+        d_model (int): dimension of the model
+        ffd (int): hidden dimension of the feedforward network
+        dropout (float): dropout rate
+        activation_fct (nn.Module): activation function
+    """
+
+    def __init__(
+        self, d_model: int, ffd: int, dropout: float = 0.1, activation_fct: Callable[[Any], Any] = nn.ReLU()
+    ) -> None:
+        super().__init__(  # type: ignore[call-overload]
+            nn.Linear(d_model, ffd),
+            activation_fct,
+            nn.Dropout(p=dropout),
+            nn.Linear(ffd, d_model),
+            nn.Dropout(p=dropout),
+        )
+
+
+class TransformerEncoderBlock(nn.Module):
+    """Transformer Encoder Block
+
+    Args:
+        num_layers (int): number of layers
+        num_heads (int): number of attention heads
+        d_model (int): dimension of the model
+        dff (int): hidden dimension of the feedforward network
+        dropout (float): dropout rate
+        activation_fct (nn.Module): activation function
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_heads: int,
+        d_model: int,
+        dff: int,
+        dropout: float,
+        activation_fct: Callable[[Any], Any] = nn.ReLU(),
+    ) -> None:
+        super().__init__()
+
+        self.num_layers = num_layers
+
+        self.layer_norm_input = nn.LayerNorm(d_model, eps=1e-5)
+        self.layer_norm_attention = nn.LayerNorm(d_model, eps=1e-5)
+        self.layer_norm_output = nn.LayerNorm(d_model, eps=1e-5)
+        self.dropout = nn.Dropout(dropout)
+
+        self.attention = nn.ModuleList(
+            [MultiHeadAttention(num_heads, d_model, dropout) for _ in range(self.num_layers)]
+        )
+        self.position_feed_forward = nn.ModuleList(
+            [PositionwiseFeedForward(d_model, dff, dropout, activation_fct) for _ in range(self.num_layers)]
+        )
+
+    def forward(self, x: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+        output = x
+
+        for i in range(self.num_layers):
+            normed_output = self.layer_norm_input(output)
+            output = output + self.dropout(self.attention[i](normed_output, normed_output, normed_output, mask))
+            normed_output = self.layer_norm_attention(output)
+            output = output + self.dropout(self.position_feed_forward[i](normed_output))
+
+        # (batch_size, seq_len, d_model)
+        return self.layer_norm_output(output)

--- a/tests/test_models_classification.py
+++ b/tests/test_models_classification.py
@@ -107,6 +107,10 @@ def test_mobileone_reparametrize():
         ["mobileone_s1", False],
         ["mobileone_s2", False],
         ["mobileone_s3", False],
+        ["cct_2", False],
+        ["cct_4", False],
+        ["cct_6", False],
+        ["cct_7", False],
     ],
 )
 def test_classification_model(arch, pretrained):
@@ -130,6 +134,7 @@ def test_classification_model(arch, pretrained):
         "repvgg_a0",
         "convnext_atto",
         "mobileone_s0",
+        "cct_2",
     ],
 )
 def test_classification_onnx_export(arch, tmpdir_factory):

--- a/tests/test_nn_transformers.py
+++ b/tests/test_nn_transformers.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+
+from holocron import nn
+
+
+def test_transformer_encoder_block():
+
+    x = torch.rand(1, 10, 128)
+
+    mod = nn.TransformerEncoderBlock(num_layers=1, num_heads=1, d_model=128, dff=128, dropout=0.1)
+
+    with torch.no_grad():
+        out = mod(x)
+    assert out.shape == x.shape
+
+    # Check inference mode
+    mod.eval()
+
+    with torch.no_grad():
+        out = mod(x)
+    assert out.shape == x.shape
+
+    # Check d_model divisible by num_heads
+    with pytest.raises(AssertionError):
+        nn.TransformerEncoderBlock(num_layers=1, num_heads=18, d_model=12, dff=12, dropout=0.0)


### PR DESCRIPTION
This PR:

- adds CCT model + variants
- add necessary tests
- add TransformerEncoderBlock module (`nn.TransformerEncoder` would work also but is still not onnx exportable)

NOTE: 
@frgfm as discussed there is some space for improvements (have fun :smile:) 
