### PR TITLE
chore: Bumps gradio to 4.11.0

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,4 @@
-gradio>=3.0.2,<4.0.0
+gradio>=4.11.0,<5.0.0
 Pillow>=8.4.0
 onnxruntime>=1.10.0,<2.0.0
 huggingface-hub>=0.4.0,<1.0.0


### PR DESCRIPTION
This PR bumps gradio to address the security issue https://github.com/frgfm/Holocron/security/dependabot/18