### PR TITLE
Fixes dockerhub push and precommit CI job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           poetry-version: "1.6.1"
       - name: Resolve dependencies
-        run: cd api && poetry export -f requirements.txt --without-hashes --output api/requirements.txt
+        run: cd api && poetry export -f requirements.txt --without-hashes --output requirements.txt
       - name: Build docker
         run: cd api && docker build src/. -t frgfm/holocron:latest
       - name: Login to DockerHub

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Run ruff
         run: |
           pip install pre-commit
+          git checkout -b temp
           pre-commit install
           pre-commit --version
           pre-commit run --all-files


### PR DESCRIPTION
This PR fixes two issues with the CI:
- the build of the docker for dockerhub push was exporting the requirements.txt to the wrong location
- the precommit hook job was run on the main branch which caused it to fail because of the branch guard