### PR TITLE
ci(dependabot): add automatic checks for several dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,28 +8,27 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
-      time: "06:00"
-      timezone: "Europe/Paris"
-    groups:
-      gh-actions:
-        patterns:
-          - "*"
-    reviewers:
-      - "frgfm"
-    assignees:
-      - "frgfm"
+      interval: "weekly"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Paris"
-    reviewers:
-      - "frgfm"
-    assignees:
-      - "frgfm"
     allow:
       - dependency-name: "ruff"
       - dependency-name: "mypy"
       - dependency-name: "pre-commit"
+      - dependency-name: "torch"
+      - dependency-name: "torchvision"
+  - package-ecosystem: "pip"
+    directory: "api/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "fastapi"
+      - dependency-name: "onnxruntime"
+  - package-ecosystem: "docker"
+    directory: "api/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "ghcr.io/astral-sh/uv"


### PR DESCRIPTION
This PR adds several dependency checks for Docker, CI actions and python packages.