### PR TITLE
build(demo): bump gradio to 5.0.0

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,5 +1,5 @@
-gradio>=4.11.0,<5.0.0
-Pillow>=8.4.0
-onnxruntime>=1.10.0,<2.0.0
+gradio>=5.0.0,<6.0.0
+Pillow>=8.4.0,!=9.2.0
+onnxruntime>=1.16.3,<2.0.0
 huggingface-hub>=0.4.0,<1.0.0
-numpy>=1.19.5,<2.0.0
+numpy>=1.19.5,<3.0.0


### PR DESCRIPTION
This PR bumps gradio to 5.0.0 to address security issues with the package.