### PR TITLE
ci(docs): fix python version for documentation build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: "3.9"
           architecture: x64
       - uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
This PR fixes the CI job to publish the documentation to GitHub pages.