### PR TITLE
ci: remove unsafe workflow trigger

### DIFF
--- a/.github/workflows/pr-edited.yml
+++ b/.github/workflows/pr-edited.yml
@@ -1,8 +1,6 @@
 name: pr-edited
 
 on:
-  pull_request_target:
-    types: [opened, reopened, edited, synchronize]
   pull_request:
     types: [opened, reopened, edited, synchronize]
 


### PR DESCRIPTION
## Summary
- Remove the `pull_request_target` trigger from `.github/workflows/pr-edited.yml`
- Keep the existing `pull_request` trigger for PR title linting
- Verified no `pull_request_target` or `workflow_run` triggers remain under `.github/workflows`

## Reference
- https://astral.sh/blog/open-source-security-at-astral

## Testing
- `rg -n \"pull_request_target|workflow_run\" .github/workflows`