### PR TITLE
ci(dependabot): add explicit timezone to github-actions schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "08:00"
+      timezone: "Europe/Paris"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Root cause

PR #440 added `groups` to the `github-actions` Dependabot config on **May 12**.
The prior config had no `day`/`time` in the schedule, so Dependabot had
internally assigned a random run time (~05:41 UTC Monday).

When #440 added `day: monday, time: "08:00"` (no timezone), Dependabot's
already-queued Monday job for the old random slot still ran on **May 19 at
05:41 UTC** — before the new 08:00 slot could take effect. That job appears
to have produced the 5 individual PRs (#445–#449) using pre-groups behaviour.
Because those individual PRs already covered all available updates, subsequent
08:00 runs found nothing new and left them untouched.

## Fix

- Add `timezone: "Europe/Paris"` to the github-actions schedule so the run
  time is unambiguous and anchored to a consistent wall-clock slot (matching
  the timezone used in the earlier config).
- Closed PRs #445, #446, #447, #448, #449 (the stale individual PRs) so the
  next Monday run starts with a clean slate and can open a single grouped PR.

## Test plan

- [ ] Next Monday (2026-05-26) Dependabot run creates one grouped PR instead
      of individual ones

🤖 Generated with [Claude Code](https://claude.ai/claude-code)