### PR TITLE
ci(dependabot): use uv updater for backend dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,7 +94,7 @@ updates:
     allow:
       - dependency-name: "torch"
       - dependency-name: "torchvision"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "api/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary

- use Dependabot's dedicated `uv` ecosystem for `/api`
- keep `api/pyproject.toml` and `api/uv.lock` synchronized in backend dependency pull requests

## Root cause

Dependabot pull requests #476 and #479 were generated by the `pip` updater and changed only `api/pyproject.toml`. The `uvicorn`, `pytest`, and `docker` backend jobs all install with `--locked`, so each failed because `api/uv.lock` was left stale.

Existing backend dependency pull requests will need to be recreated after this merges so they use the corrected updater.

## Validation

- Dependabot YAML parses and the `api/` updater resolves to `uv`
- `uv lock --check --project api`
- `git diff --check`

## Out of scope

`make deps-check` already fails on `main` because `pytest` and `Pillow` constraints differ between the root, demo, and API manifests. Quality jobs are intentionally unchanged here.

GitHub documents `uv` as a supported Dependabot package ecosystem: https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories
