### PR TITLE
docs: clarify development status and model maturity

### DIFF
--- a/docs/docs/getting-started/classification.md
+++ b/docs/docs/getting-started/classification.md
@@ -138,7 +138,9 @@ trainer.load(state)
 
 Current trainer checkpoints contain the model, epoch, step and best loss. They
 do **not** contain optimizer or scheduler state, so loading resumes model and
-counter state rather than the exact optimization trajectory.
+counter state rather than the exact optimization trajectory. Persist
+`train_set.classes` with your deployment artifacts because trainer checkpoints
+do not store class names.
 
 ## Run inference with custom labels
 

--- a/docs/docs/getting-started/classification.md
+++ b/docs/docs/getting-started/classification.md
@@ -1,0 +1,170 @@
+# Fine-tune a classifier
+
+This guide adapts the default pretrained ResNet-18 to a folder of custom
+classes. `ResNet18_Checkpoint.DEFAULT.value` was trained on
+[Imagenette](https://github.com/fastai/imagenette), a ten-class subset of
+ImageNet. Many bundled classification checkpoints target Imagenette; selected
+ReXNet checkpoints target ImageNet-1K instead. Always inspect the selected
+checkpoint metadata.
+
+## Prepare the dataset
+
+[`ImageFolder`][torchvision.datasets.ImageFolder] expects one directory per
+class, with matching class directories under `train` and `val`:
+
+```text
+dataset/
+├── train/
+│   ├── class_a/
+│   │   ├── image_001.jpg
+│   │   └── image_002.jpg
+│   └── class_b/
+│       └── image_003.jpg
+└── val/
+    ├── class_a/
+    │   └── image_004.jpg
+    └── class_b/
+        └── image_005.jpg
+```
+
+Load the checkpoint metadata first. It defines the input size, interpolation,
+normalization and original labels used by the published weights:
+
+```python
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision.datasets import ImageFolder
+from torchvision.transforms.v2 import (
+    Compose,
+    ConvertImageDtype,
+    Normalize,
+    PILToTensor,
+    RandomHorizontalFlip,
+    RandomResizedCrop,
+    Resize,
+)
+
+from holocron.models.classification import ResNet18_Checkpoint, resnet18
+from holocron.trainer import ClassificationTrainer
+
+checkpoint = ResNet18_Checkpoint.DEFAULT.value
+preprocessing = checkpoint.pre_processing
+original_labels = checkpoint.meta.categories
+
+train_transform = Compose([
+    RandomResizedCrop(
+        preprocessing.input_shape[1:],
+        interpolation=preprocessing.interpolation,
+    ),
+    RandomHorizontalFlip(),
+    PILToTensor(),
+    ConvertImageDtype(torch.float32),
+    Normalize(preprocessing.mean, preprocessing.std),
+])
+val_transform = Compose([
+    Resize(
+        preprocessing.input_shape[1:],
+        interpolation=preprocessing.interpolation,
+    ),
+    PILToTensor(),
+    ConvertImageDtype(torch.float32),
+    Normalize(preprocessing.mean, preprocessing.std),
+])
+
+train_set = ImageFolder("dataset/train", transform=train_transform)
+val_set = ImageFolder("dataset/val", transform=val_transform)
+if train_set.classes != val_set.classes:
+    raise ValueError("train and val must contain the same class directories")
+
+train_loader = DataLoader(train_set, batch_size=32, shuffle=True, num_workers=4)
+val_loader = DataLoader(val_set, batch_size=32, num_workers=4)
+```
+
+`original_labels` describes the checkpoint's Imagenette outputs before the
+head is replaced. `train_set.classes` describes your custom outputs.
+
+## Load the weights, then replace the head
+
+The checkpoint must load while the model still has its original ten-output
+head. Replace `model.head` only afterwards:
+
+```python
+model = resnet18(checkpoint=checkpoint)
+model.head = nn.Linear(model.head.in_features, len(train_set.classes))
+```
+
+Replacing the head before loading the checkpoint would create a state-dict
+shape mismatch.
+
+## Train the custom head
+
+Start by freezing `features`, which leaves the new head trainable:
+
+```python
+criterion = nn.CrossEntropyLoss()
+optimizer = torch.optim.AdamW(model.parameters(), lr=3e-4)
+trainer = ClassificationTrainer(
+    model,
+    train_loader,
+    val_loader,
+    criterion,
+    optimizer,
+    gpu=0 if torch.cuda.is_available() else None,
+    output_file="resnet18-custom.pth",
+)
+trainer.fit_n_epochs(5, lr=3e-4, freeze_until="features")
+```
+
+Optionally unfreeze the full model and continue at a lower learning rate:
+
+```python
+trainer.fit_n_epochs(5, lr=1e-4)
+```
+
+Calling `fit_n_epochs` without `freeze_until` makes every model parameter
+trainable again.
+
+## Save and resume
+
+The trainer automatically saves its best validation state to `output_file`.
+You can also save and load explicitly:
+
+```python
+trainer.save("resnet18-custom.pth")
+state = torch.load("resnet18-custom.pth", map_location="cpu", weights_only=True)
+trainer.load(state)
+```
+
+Current trainer checkpoints contain the model, epoch, step and best loss. They
+do **not** contain optimizer or scheduler state, so loading resumes model and
+counter state rather than the exact optimization trajectory.
+
+## Run inference with custom labels
+
+After fine-tuning, use `ImageFolder.classes`, not
+`checkpoint.meta.categories`, to decode the new head:
+
+```python
+from PIL import Image
+
+image = Image.open("image.jpg").convert("RGB")
+device = next(model.parameters()).device
+
+model.eval()
+with torch.inference_mode():
+    probabilities = model(val_transform(image).unsqueeze(0).to(device)).squeeze(0).softmax(dim=0)
+
+class_idx = probabilities.argmax().item()
+label = train_set.classes[class_idx]
+confidence = probabilities[class_idx].item()
+print(label, confidence)
+```
+
+## Target constraints
+
+For the `CrossEntropyLoss` setup above, hard targets are `torch.int64` class
+indices in `[0, number_of_classes)`. A configured `ignore_index` may appear
+outside that range and excludes those hard targets from the loss. Soft targets
+are also supported as floating-point class probabilities with the same shape
+as the logits; `ignore_index` applies only to hard class-index targets.

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -1,54 +1,57 @@
 # Installation
 
+!!! warning "Choose the matching version"
+    Development commands match these pages. PyPI `0.2.1` predates them, so
+    some APIs differ.
+
 ## Virtual environment
 
 !!! tip
     You will need an environment manager, and I cannot recommend enough [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
-Create a virtual environment with your prefered Python version (3.11 or higher is required to use Holocron):
+Create a virtual environment with your preferred Python version (3.11 or higher is required to use Holocron):
 ```bash
 $ uv venv --python 3.11
 ```
 
-=== "Stable"
+=== "Development (this documentation)"
+
+    ```bash
+    $ uv pip install "pylocron @ git+https://github.com/frgfm/holocron.git"
+    ```
+
+=== "Stable v0.2.1"
 
     ```bash
     $ uv pip install pylocron
     ```
 
-=== "Latest"
-
-    ```bash
-    $ uv pip install pylocron @ git+https://github.com/frgfm/holocron.git
-    ```
-
-
 ## System installation
 
 You'll need [Python](https://www.python.org/downloads/) 3.11 or higher, and a package installer like [uv](https://docs.astral.sh/uv/getting-started/installation/) or [pip](https://packaging.python.org/en/latest/tutorials/installing-packages/).
 
-=== "Stable"
+=== "Development (uv)"
+
+    ```bash
+    $ uv pip install --system "pylocron @ git+https://github.com/frgfm/holocron.git"
+    ```
+
+=== "Stable v0.2.1 (uv)"
 
     ```bash
     $ uv pip install --system pylocron
     ```
 
-=== "Latest"
+=== "Development (pip)"
 
     ```bash
-    $ uv pip install --system pylocron @ git+https://github.com/frgfm/holocron.git
+    $ pip install "pylocron @ git+https://github.com/frgfm/holocron.git"
     ```
 
-=== "Stable (pip)"
+=== "Stable v0.2.1 (pip)"
 
     ```bash
     $ pip install pylocron
-    ```
-
-=== "Latest (pip)"
-
-    ```bash
-    $ pip install pylocron @ git+https://github.com/frgfm/holocron.git
     ```
 
 !!! info

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,6 +6,11 @@
 
 Holocron is meant to bridge the gap between [PyTorch](https://pytorch.org/) and latest research papers. It brings training components that are not available yet in PyTorch with a similar interface.
 
+!!! warning "Development documentation"
+    These pages follow the `main` branch and Holocron `0.2.2.dev0`. The stable
+    PyPI release is `0.2.1`, and some APIs differ. See the
+    [installation options](getting-started/installation.md).
+
 This project is meant for:
 
 * :zap: **speed**: architectures in this repo are picked for both pure performances and minimal latency
@@ -16,47 +21,59 @@ This project is meant for:
 Create and activate a virtual environment and then install Holocron:
 
 ```shell
-pip install pylocron
+uv pip install "pylocron @ git+https://github.com/frgfm/holocron.git"
 ```
 
-Check out the [installation guide](getting-started/installation.md) for more options
+For stable `0.2.1` and system-wide options, see the
+[installation guide](getting-started/installation.md).
 
 ## Quick start
 
-Load a model and use it just like any PyTorch model:
+Load a checkpoint and use its preprocessing and category metadata:
 
-```python hl_lines="4 7"
+<!-- quickstart-example-start -->
+```python
+import torch
 from PIL import Image
 from torchvision.transforms.v2 import Compose, ConvertImageDtype, Normalize, PILToTensor, Resize
-from torchvision.transforms.v2.functional import InterpolationMode
-from holocron.models.classification import repvgg_a0
+from holocron.models.classification import ResNet18_Checkpoint, resnet18
 
-# Load your model
-model = repvgg_a0(pretrained=True).eval()
+checkpoint = ResNet18_Checkpoint.DEFAULT.value
+model = resnet18(checkpoint=checkpoint).eval()
 
-# Read your image
-img = Image.open(path_to_an_image).convert("RGB")
+image = Image.open(path_to_an_image).convert("RGB")
+preprocessing = checkpoint.pre_processing
 
-# Preprocessing
-config = model.default_cfg
 transform = Compose([
-    Resize(config["input_shape"][1:], interpolation=InterpolationMode.BILINEAR),
+    Resize(preprocessing.input_shape[1:], interpolation=preprocessing.interpolation),
     PILToTensor(),
     ConvertImageDtype(torch.float32),
-    Normalize(config["mean"], config["std"]),
+    Normalize(preprocessing.mean, preprocessing.std),
 ])
 
-input_tensor = transform(img).unsqueeze(0)
+input_tensor = transform(image).unsqueeze(0)
 
-# Inference
 with torch.inference_mode():
-    output = model(input_tensor)
-print(config["classes"][output.squeeze(0).argmax().item()], output.squeeze(0).softmax(dim=0).max())
+    probabilities = model(input_tensor).squeeze(0).softmax(dim=0)
+
+class_idx = probabilities.argmax().item()
+label = checkpoint.meta.categories[class_idx]
+confidence = probabilities[class_idx].item()
+print(label, confidence)
 ```
+<!-- quickstart-example-end -->
+
+To adapt this checkpoint to your own classes, follow the
+[classification and transfer-learning guide](getting-started/classification.md).
 
 ## Model zoo
 
-### Image classification
+Holocron implements all three tasks below, but they do not have the same level
+of checkpoint and benchmark coverage. See the
+[capability and maturity matrix](reference/models/models.md#support-status)
+before choosing a model.
+
+### Image classification — validated
 
 * TridentNet from ["Scale-Aware Trident Networks for Object Detection"](https://arxiv.org/pdf/1901.01892.pdf)
 * SKNet from ["Selective Kernel Networks"](https://arxiv.org/pdf/1903.06586.pdf)
@@ -64,12 +81,14 @@ print(config["classes"][output.squeeze(0).argmax().item()], output.squeeze(0).so
 * ReXNet from ["ReXNet: Diminishing Representational Bottleneck on Convolutional Neural Network"](https://arxiv.org/pdf/2007.00992.pdf)
 * RepVGG from ["RepVGG: Making VGG-style ConvNets Great Again"](https://arxiv.org/pdf/2101.03697.pdf)
 
-### Semantic segmentation
+### Semantic segmentation — unbenchmarked
+
 * U-Net from ["U-Net: Convolutional Networks for Biomedical Image Segmentation"](https://arxiv.org/pdf/1505.04597.pdf)
 * U-Net++ from ["UNet++: Redesigning Skip Connections to Exploit Multiscale Features in Image Segmentation"](https://arxiv.org/pdf/1912.05074.pdf)
 * UNet3+ from ["UNet 3+: A Full-Scale Connected UNet For Medical Image Segmentation"](https://arxiv.org/pdf/2004.08790.pdf)
 
-### Object detection
+### Object detection — experimental
+
 * YOLO from ["You Only Look Once: Unified, Real-Time Object Detection"](https://pjreddie.com/media/files/papers/yolo_1.pdf)
 * YOLOv2 from ["YOLO9000: Better, Faster, Stronger"](https://pjreddie.com/media/files/papers/YOLO9000.pdf)
 * YOLOv4 from ["YOLOv4: Optimal Speed and Accuracy of Object Detection"](https://arxiv.org/pdf/2004.10934.pdf)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -73,7 +73,10 @@ of checkpoint and benchmark coverage. See the
 [capability and maturity matrix](reference/models/models.md#support-status)
 before choosing a model.
 
-### Image classification — validated
+### Image classification — validated checkpoints
+
+Published checkpoints and metrics cover Imagenette, plus selected ReXNet
+ImageNet-1K variants.
 
 * TridentNet from ["Scale-Aware Trident Networks for Object Detection"](https://arxiv.org/pdf/1901.01892.pdf)
 * SKNet from ["Selective Kernel Networks"](https://arxiv.org/pdf/1903.06586.pdf)

--- a/docs/docs/reference/models/models.md
+++ b/docs/docs/reference/models/models.md
@@ -2,8 +2,20 @@
 
 The models subpackage contains definitions of models for addressing
 different tasks, including: image classification, pixelwise semantic
-segmentation, object detection, instance segmentation, person
-keypoint detection and video classification.
+segmentation and object detection.
+
+## Support status
+
+| Task | Architectures | Published checkpoints | Training | ONNX | Status |
+|---|---|---|---|---|---|
+| Classification | 14 families | Imagenette checkpoints with top-1/top-5 metrics; selected ReXNet ImageNet-1K checkpoints | [Reference script](https://github.com/frgfm/holocron/blob/main/references/classification/train.py) | [Classification export](https://github.com/frgfm/holocron/blob/main/scripts/export_to_onnx.py) | **Validated** |
+| Semantic segmentation | U-Net, U-Net++, UNet3+ | Only the legacy `unet_rexnet13` weights; dataset and metric are not documented | [Reference script](https://github.com/frgfm/holocron/blob/main/references/segmentation/train.py) | Not documented | **Unbenchmarked** |
+| Object detection | YOLOv1, YOLOv2, YOLOv4 | None | [Reference script](https://github.com/frgfm/holocron/blob/main/references/detection/train.py) | Not documented | **Experimental** ([#110](https://github.com/frgfm/holocron/issues/110), [#253](https://github.com/frgfm/holocron/issues/253), [discussion #230](https://github.com/frgfm/holocron/discussions/230)) |
+
+**Validated** means published task checkpoints and metrics are available.
+**Unbenchmarked** means an implementation or legacy weight exists without a
+documented evaluation dataset and metric. **Experimental** means the API is
+available, but published task weights and a confirmed benchmark are not.
 
 
 ## Classification
@@ -70,6 +82,13 @@ Here is the list of available checkpoints:
 
 ## Object Detection
 
+!!! warning "Experimental"
+    YOLOv1, YOLOv2 and YOLOv4 have a reference training script but no
+    published detection weights. Known training and benchmark gaps are tracked
+    in [#110](https://github.com/frgfm/holocron/issues/110),
+    [#253](https://github.com/frgfm/holocron/issues/253) and
+    [discussion #230](https://github.com/frgfm/holocron/discussions/230).
+
 Object detection models expect a 4D image tensor as an input (N x C x H x W) and returns a list of dictionaries.
 Each dictionary has 3 keys: box coordinates, classification probability, classification label.
 
@@ -113,6 +132,11 @@ yolov2 = models.yolov2(num_classes=10)
 
 
 ## Semantic Segmentation
+
+!!! note "Unbenchmarked"
+    `unet_rexnet13` is the only segmentation model with a legacy checkpoint.
+    Its training dataset and evaluation metric are not documented. Other
+    segmentation architectures have no published weights.
 
 Semantic segmentation models expect a 4D image tensor as an input (N x C x H x W) and returns a classification score
 tensor of size (N x K x Ho x Wo).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: Holocron
+site_name: Holocron — development documentation
 site_url: https://frgfm.github.io/holocron
 site_description: PyTorch implementations of recent Computer Vision tricks (ReXNet, RepVGG, Unet3p, YOLOv4, CIoU loss, AdaBelief, PolyLoss, MobileOne).
 site_author: François-Guillaume Fernandez
@@ -74,6 +74,7 @@ plugins:
     sections:
       Getting started:
         - getting-started/installation.md
+        - getting-started/classification.md
         - getting-started/notebooks.md
       Package Reference:
         - reference/models/models.md
@@ -171,6 +172,7 @@ nav:
   - Home: index.md
   - Getting started:
     - getting-started/installation.md
+    - getting-started/classification.md
     - getting-started/notebooks.md
   - Package Reference:
     - Models:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,10 +82,10 @@ docs = [
 
 
 [project.urls]
-documentation = "https://frgfm.github.io/Holocron"
+documentation = "https://frgfm.github.io/holocron/"
 repository = "https://github.com/frgfm/Holocron"
 tracker = "https://github.com/frgfm/Holocron/issues"
-changelog = "https://frgfm.github.io/Holocron/latest/changelog.html"
+changelog = "https://frgfm.github.io/holocron/notes/changelog/"
 
 [tool.uv.build-backend]
 module-name = "holocron"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,34 @@
+import re
+from pathlib import Path
+
+from PIL import Image
+
+
+def test_homepage_quickstart(monkeypatch, tmp_path):
+    homepage = (Path(__file__).parents[1] / "docs" / "docs" / "index.md").read_text()
+    match = re.search(
+        r"<!-- quickstart-example-start -->\s*```python\n(?P<code>.*?)\n```\s*<!-- quickstart-example-end -->",
+        homepage,
+        re.DOTALL,
+    )
+    assert match is not None
+
+    image_path = tmp_path / "image.png"
+    Image.new("RGB", (320, 240)).save(image_path)
+
+    monkeypatch.setattr("holocron.models.utils.load_pretrained_params", lambda *_args, **_kwargs: None)
+    namespace = {"path_to_an_image": image_path}
+    exec(compile(match["code"], "docs/docs/index.md", "exec"), namespace)  # noqa: S102
+
+    checkpoint = namespace["checkpoint"]
+    probabilities = namespace["probabilities"]
+    resize, _, _, normalize = namespace["transform"].transforms
+    assert namespace["preprocessing"] is checkpoint.pre_processing
+    assert tuple(resize.size) == checkpoint.pre_processing.input_shape[1:]
+    assert resize.interpolation == checkpoint.pre_processing.interpolation
+    assert tuple(normalize.mean) == checkpoint.pre_processing.mean
+    assert tuple(normalize.std) == checkpoint.pre_processing.std
+    assert namespace["input_tensor"].shape == (1, *checkpoint.pre_processing.input_shape)
+    assert probabilities.shape == (len(checkpoint.meta.categories),)
+    assert namespace["label"] in checkpoint.meta.categories
+    assert 0 <= namespace["confidence"] <= 1


### PR DESCRIPTION
## Summary
- mark the site as development documentation and repair the checkpoint quick start
- add a task maturity matrix with checkpoint, training, and ONNX coverage
- add a complete classification transfer-learning guide and executable homepage example test

## Verification
- `uv run --with pytest pytest -o addopts="" tests/test_docs.py -q`
- `uvx ruff==0.16.0 check tests/test_docs.py`
- `make build-docs`
- local desktop and mobile render checks for the homepage, installation guide, classification guide, and model matrix

## Full-suite note
The full suite reached all 136 tests: 114 passed. Twenty-one ONNX cases fail because the locked `onnx==1.19.0` loads with incompatible `ml-dtypes==0.4.1`; `test_aspect_ratio` also fails an exact floating-point equality assertion. These failures are outside this documentation-only diff.