### PR TITLE
docs: add SVG explainers for core concepts

### DIFF
--- a/docs/docs/getting-started/classification.md
+++ b/docs/docs/getting-started/classification.md
@@ -7,6 +7,8 @@ ImageNet. Many bundled classification checkpoints target Imagenette; selected
 ReXNet checkpoints target ImageNet-1K instead. Always inspect the selected
 checkpoint metadata.
 
+![Six-step transfer-learning workflow: load the checkpoint contract and weights before replacing the head, train the custom head with frozen features, optionally fine-tune the full model, then decode with custom labels.](../img/classification-transfer.svg)
+
 ## Prepare the dataset
 
 [`ImageFolder`][torchvision.datasets.ImageFolder] expects one directory per

--- a/docs/docs/img/box-iou-family.svg
+++ b/docs/docs/img/box-iou-family.svg
@@ -1,0 +1,149 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 800" role="img" aria-labelledby="title desc">
+  <title id="title">Geometry of IoU, GIoU, DIoU, and CIoU</title>
+  <desc id="desc">
+    Four panels reuse the same solid target box A and dashed prediction box B. IoU highlights their
+    intersection, GIoU adds the unused area in the smallest enclosing box, DIoU adds the distance between
+    box centers, and CIoU adds the mismatch between their width-to-height ratios.
+  </desc>
+  <defs>
+    <pattern id="overlap-hatch" width="10" height="10" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line class="overlap-stripe" x1="0" y1="0" x2="0" y2="10"/>
+    </pattern>
+    <pattern id="unused-hatch" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line class="unused-stripe" x1="0" y1="0" x2="0" y2="9"/>
+    </pattern>
+    <marker id="dimension-arrow" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto-start-reverse">
+      <path d="M7 0 0 3.5 7 7z" class="dimension-head"/>
+    </marker>
+    <g id="box-pair">
+      <rect class="target-box" x="0" y="0" width="160" height="100"/>
+      <rect class="prediction-box" x="80" y="50" width="160" height="100"/>
+      <text class="box-label target-label" x="10" y="28">A · target</text>
+      <text class="box-label prediction-label" x="104" y="138">B · prediction</text>
+    </g>
+  </defs>
+  <style>
+    .canvas { fill: #faf8fb; stroke: #d9d1dc; }
+    .panel { fill: #fff; stroke: #d9d1dc; }
+    .title, .panel-title, .formula, .box-label, .geometry-label { fill: #2b2430; }
+    .subtitle, .panel-subtitle, .legend { fill: #675f6a; }
+    .target-box { fill: none; stroke: #a84c7a; stroke-width: 5; }
+    .prediction-box { fill: none; stroke: #0e7490; stroke-width: 5; stroke-dasharray: 12 8; }
+    .target-label { fill: #7f305a; }
+    .prediction-label { fill: #0e6178; }
+    .overlap-area { fill: #b979a0; fill-opacity: .3; }
+    .overlap-stripe { stroke: #7f305a; stroke-width: 3; }
+    .enclosure { fill: none; stroke: #675f6a; stroke-width: 3; stroke-dasharray: 5 6; }
+    .unused-area { fill: #f5c96a; fill-opacity: .25; }
+    .unused-stripe { stroke: #9a6700; stroke-width: 2.5; }
+    .center-line, .diagonal, .dimension {
+      fill: none;
+      stroke: #675f6a;
+      stroke-width: 3;
+      stroke-dasharray: 7 6;
+    }
+    .center-dot { fill: #2b2430; stroke: #fff; stroke-width: 2; }
+    .dimension { marker-start: url(#dimension-arrow); marker-end: url(#dimension-arrow); }
+    .dimension-head { fill: #675f6a; }
+    text {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      text-rendering: geometricPrecision;
+    }
+    .title { font-size: 30px; font-weight: 700; }
+    .subtitle { font-size: 19px; }
+    .legend { font-size: 17px; }
+    .panel-title { font-size: 27px; font-weight: 700; }
+    .panel-subtitle { font-size: 18px; }
+    .formula {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 20px;
+      font-weight: 650;
+    }
+    .box-label { font-size: 17px; font-weight: 700; }
+    .geometry-label { font-size: 18px; font-weight: 700; }
+    @media (max-width: 500px) {
+      .panel-title { font-size: 31px; }
+      .panel-subtitle { font-size: 20px; }
+      .formula { font-size: 22px; }
+      .box-label { font-size: 19px; }
+      .geometry-label { font-size: 20px; }
+    }
+    @media (prefers-color-scheme: dark) {
+      .canvas { fill: #171419; stroke: #4d4552; }
+      .panel { fill: #211d24; stroke: #4d4552; }
+      .title, .panel-title, .formula, .box-label, .geometry-label { fill: #f3edf4; }
+      .subtitle, .panel-subtitle, .legend { fill: #c4bbc7; }
+      .target-box { stroke: #e38ab7; }
+      .prediction-box { stroke: #67e8f9; }
+      .target-label { fill: #f1a5cb; }
+      .prediction-label { fill: #8cecf8; }
+      .overlap-area { fill: #e38ab7; fill-opacity: .22; }
+      .overlap-stripe { stroke: #f1a5cb; }
+      .enclosure, .center-line, .diagonal, .dimension { stroke: #c4bbc7; }
+      .unused-area { fill: #f5c96a; fill-opacity: .16; }
+      .unused-stripe { stroke: #ffd778; }
+      .center-dot { fill: #f3edf4; stroke: #211d24; }
+      .dimension-head { fill: #c4bbc7; }
+    }
+  </style>
+
+  <rect class="canvas" x="1" y="1" width="898" height="798" rx="16"/>
+  <text class="title" x="30" y="43">One box pair, four increasingly strict comparisons</text>
+  <text class="subtitle" x="30" y="71">Each metric keeps overlap, then adds a geometric penalty.</text>
+  <text class="legend" x="552" y="69">A: solid target · B: dashed prediction</text>
+
+  <g>
+    <rect class="panel" x="30" y="100" width="405" height="290" rx="12"/>
+    <text class="panel-title" x="55" y="138">IoU</text>
+    <text class="panel-subtitle" x="55" y="164">Overlap relative to the union</text>
+    <rect class="overlap-area" x="175" y="235" width="80" height="50"/>
+    <rect x="175" y="235" width="80" height="50" fill="url(#overlap-hatch)"/>
+    <use href="#box-pair" x="95" y="185"/>
+    <text class="geometry-label" x="215" y="229" text-anchor="middle">intersection</text>
+    <text class="formula" x="232.5" y="370" text-anchor="middle">IoU = |A ∩ B| / |A ∪ B|</text>
+  </g>
+
+  <g>
+    <rect class="panel" x="465" y="100" width="405" height="290" rx="12"/>
+    <text class="panel-title" x="490" y="138">GIoU</text>
+    <text class="panel-subtitle" x="490" y="164">Adds unused enclosing area</text>
+    <rect class="unused-area" x="690" y="185" width="80" height="50"/>
+    <rect x="690" y="185" width="80" height="50" fill="url(#unused-hatch)"/>
+    <rect class="unused-area" x="530" y="285" width="80" height="50"/>
+    <rect x="530" y="285" width="80" height="50" fill="url(#unused-hatch)"/>
+    <rect class="enclosure" x="530" y="185" width="240" height="150"/>
+    <use href="#box-pair" x="530" y="185"/>
+    <text class="geometry-label" x="746" y="215">C</text>
+    <text class="formula" x="667.5" y="370" text-anchor="middle">GIoU = IoU − unused(C) / |C|</text>
+  </g>
+
+  <g>
+    <rect class="panel" x="30" y="420" width="405" height="340" rx="12"/>
+    <text class="panel-title" x="55" y="458">DIoU</text>
+    <text class="panel-subtitle" x="55" y="484">Adds distance between box centers</text>
+    <use href="#box-pair" x="95" y="505"/>
+    <line class="diagonal" x1="95" y1="505" x2="335" y2="655"/>
+    <line class="center-line" x1="175" y1="555" x2="255" y2="605"/>
+    <circle class="center-dot" cx="175" cy="555" r="6"/>
+    <circle class="center-dot" cx="255" cy="605" r="6"/>
+    <text class="geometry-label" x="203" y="570">ρ²</text>
+    <text class="geometry-label" x="302" y="625">c²</text>
+    <text class="formula" x="232.5" y="740" text-anchor="middle">DIoU = IoU − ρ² / c²</text>
+  </g>
+
+  <g>
+    <rect class="panel" x="465" y="420" width="405" height="340" rx="12"/>
+    <text class="panel-title" x="490" y="458">CIoU</text>
+    <text class="panel-subtitle" x="490" y="484">Adds width-to-height agreement</text>
+    <use href="#box-pair" x="530" y="505"/>
+    <line class="dimension" x1="536" y1="495" x2="684" y2="495"/>
+    <line class="dimension" x1="520" y1="511" x2="520" y2="599"/>
+    <line class="dimension" x1="616" y1="665" x2="764" y2="665"/>
+    <line class="dimension" x1="780" y1="561" x2="780" y2="649"/>
+    <text class="geometry-label" x="610" y="490" text-anchor="middle">w₁</text>
+    <text class="geometry-label" x="511" y="559" text-anchor="end">h₁</text>
+    <text class="geometry-label" x="690" y="688" text-anchor="middle">w₂</text>
+    <text class="geometry-label" x="788" y="609">h₂</text>
+    <text class="formula" x="667.5" y="740" text-anchor="middle">CIoU = DIoU − αv</text>
+  </g>
+</svg>

--- a/docs/docs/img/checkpoint-accuracy-vs-parameters.svg
+++ b/docs/docs/img/checkpoint-accuracy-vs-parameters.svg
@@ -1,0 +1,217 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 690" role="img" aria-labelledby="title desc">
+  <title id="title">Imagenette checkpoint accuracy versus parameter count</title>
+  <desc id="desc">
+    Scatter plot of 27 comparable Imagenette checkpoints. The horizontal axis is parameter count on a
+    logarithmic scale and the vertical axis is top-one accuracy. A connected ring marks the Pareto frontier,
+    and a diamond marks the default ResNet-18 checkpoint.
+  </desc>
+  <style>
+    .canvas { fill: #faf8fb; stroke: #d9d1dc; }
+    .plot { fill: #fff; stroke: #9b919f; }
+    .grid { stroke: #e5dfe7; stroke-width: 1; }
+    .axis { stroke: #675f6a; stroke-width: 2; }
+    .title, .label, .tick, .annotation { fill: #2b2430; }
+    .subtitle { fill: #675f6a; }
+    .point { fill: #817987; stroke: #fff; stroke-width: 2; }
+    .frontier-line { fill: none; stroke: #a84c7a; stroke-width: 4; }
+    .pareto .point { fill: #fff; stroke: #a84c7a; stroke-width: 4; }
+    .legend-pareto { fill: #fff; stroke: #a84c7a; stroke-width: 4; }
+    .default-marker { fill: #0e7490; stroke: #fff; stroke-width: 2.5; }
+    .leader { fill: none; stroke: #675f6a; stroke-width: 1.5; }
+    text {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      text-rendering: geometricPrecision;
+    }
+    .title { font-size: 28px; font-weight: 700; }
+    .subtitle { font-size: 18px; }
+    .label { font-size: 20px; font-weight: 650; }
+    .tick { font-size: 18px; }
+    .annotation { font-size: 18px; font-weight: 650; }
+    @media (max-width: 500px) {
+      .subtitle, .tick { font-size: 21px; }
+      .label { font-size: 23px; }
+      .annotation { font-size: 20px; }
+    }
+    @media (prefers-color-scheme: dark) {
+      .canvas { fill: #171419; stroke: #4d4552; }
+      .plot { fill: #211d24; stroke: #655c69; }
+      .grid { stroke: #39323c; }
+      .axis { stroke: #c4bbc7; }
+      .title, .label, .tick, .annotation { fill: #f3edf4; }
+      .subtitle { fill: #c4bbc7; }
+      .point { fill: #aaa1ad; stroke: #211d24; }
+      .frontier-line { stroke: #e38ab7; }
+      .pareto .point { fill: #211d24; stroke: #e38ab7; }
+      .legend-pareto { fill: #171419; stroke: #e38ab7; }
+      .default-marker { fill: #67e8f9; stroke: #211d24; }
+      .leader { stroke: #c4bbc7; }
+    }
+  </style>
+
+  <rect class="canvas" x="1" y="1" width="898" height="688" rx="16"/>
+  <text class="title" x="65" y="42">Imagenette accuracy vs. model size</text>
+  <text class="subtitle" x="65" y="70">27 published checkpoints · up and left is better</text>
+
+  <circle class="point" cx="553" cy="65" r="6"/>
+  <text class="tick" x="566" y="71">all</text>
+  <line class="frontier-line" x1="620" y1="65" x2="650" y2="65"/>
+  <circle class="legend-pareto" cx="635" cy="65" r="7"/>
+  <text class="tick" x="660" y="71">Pareto</text>
+  <path class="default-marker" d="M769 55 779 65 769 75 759 65z"/>
+  <text class="tick" x="786" y="71">default</text>
+
+  <rect class="plot" x="90" y="100" width="750" height="470"/>
+  <g aria-hidden="true">
+    <line class="grid" x1="90" y1="517.8" x2="840" y2="517.8"/>
+    <line class="grid" x1="90" y1="413.3" x2="840" y2="413.3"/>
+    <line class="grid" x1="90" y1="308.9" x2="840" y2="308.9"/>
+    <line class="grid" x1="90" y1="204.4" x2="840" y2="204.4"/>
+    <line class="grid" x1="90" y1="100" x2="840" y2="100"/>
+    <line class="grid" x1="90" y1="100" x2="90" y2="570"/>
+    <line class="grid" x1="181.2" y1="100" x2="181.2" y2="570"/>
+    <line class="grid" x1="305" y1="100" x2="305" y2="570"/>
+    <line class="grid" x1="428.8" y1="100" x2="428.8" y2="570"/>
+    <line class="grid" x1="592.4" y1="100" x2="592.4" y2="570"/>
+    <line class="grid" x1="716.2" y1="100" x2="716.2" y2="570"/>
+    <line class="grid" x1="840" y1="100" x2="840" y2="570"/>
+  </g>
+
+  <line class="axis" x1="90" y1="570" x2="840" y2="570"/>
+  <line class="axis" x1="90" y1="100" x2="90" y2="570"/>
+  <g aria-hidden="true">
+    <text class="tick" x="75" y="524" text-anchor="end">88</text>
+    <text class="tick" x="75" y="420" text-anchor="end">90</text>
+    <text class="tick" x="75" y="315" text-anchor="end">92</text>
+    <text class="tick" x="75" y="211" text-anchor="end">94</text>
+    <text class="tick" x="75" y="107" text-anchor="end">96</text>
+    <text class="tick" x="90" y="596" text-anchor="middle">3</text>
+    <text class="tick" x="181.2" y="596" text-anchor="middle">5</text>
+    <text class="tick" x="305" y="596" text-anchor="middle">10</text>
+    <text class="tick" x="428.8" y="596" text-anchor="middle">20</text>
+    <text class="tick" x="592.4" y="596" text-anchor="middle">50</text>
+    <text class="tick" x="716.2" y="596" text-anchor="middle">100</text>
+    <text class="tick" x="840" y="596" text-anchor="middle">200</text>
+    <text class="label" x="465" y="632" text-anchor="middle">Parameters (millions, logarithmic scale)</text>
+    <text class="label" x="25" y="335" text-anchor="middle" transform="rotate(-90 25 335)">Imagenette Acc@1 (%)</text>
+  </g>
+
+  <polyline class="frontier-line" points="112.4,539.2 117.5,184.1 210.8,158.5 362.5,139.7 396.6,129.2"/>
+
+  <g class="checkpoint" data-checkpoint="CSPDarknet53_Checkpoint.IMAGENETTE" data-acc1="94.50" data-params="26.6">
+    <title>CSPDarknet53: 94.50% Acc@1, 26.6M parameters</title>
+    <circle class="point" cx="479.7" cy="178.3" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="CSPDarknet53_Mish_Checkpoint.IMAGENETTE" data-acc1="94.65" data-params="26.6">
+    <title>CSPDarknet53 Mish: 94.65% Acc@1, 26.6M parameters</title>
+    <circle class="point" cx="479.7" cy="170.5" r="6"/>
+  </g>
+  <g class="checkpoint pareto" data-checkpoint="ConvNeXt_Atto_Checkpoint.IMAGENETTE" data-acc1="87.59" data-params="3.4" data-pareto="true">
+    <title>ConvNeXt Atto: 87.59% Acc@1, 3.4M parameters; Pareto frontier</title>
+    <circle class="point" cx="112.4" cy="539.2" r="7"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="Darknet19_Checkpoint.IMAGENETTE" data-acc1="93.86" data-params="19.8">
+    <title>Darknet-19: 93.86% Acc@1, 19.8M parameters</title>
+    <circle class="point" cx="427" cy="211.8" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="Darknet53_Checkpoint.IMAGENETTE" data-acc1="94.17" data-params="40.6">
+    <title>Darknet-53: 94.17% Acc@1, 40.6M parameters</title>
+    <circle class="point" cx="555.2" cy="195.6" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="MobileOne_S0_Checkpoint.IMAGENETTE" data-acc1="88.08" data-params="4.3">
+    <title>MobileOne S0: 88.08% Acc@1, 4.3M parameters</title>
+    <circle class="point" cx="154.3" cy="513.6" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="MobileOne_S1_Checkpoint.IMAGENETTE" data-acc1="91.26" data-params="3.6">
+    <title>MobileOne S1: 91.26% Acc@1, 3.6M parameters</title>
+    <circle class="point" cx="122.6" cy="347.5" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="MobileOne_S2_Checkpoint.IMAGENETTE" data-acc1="91.31" data-params="5.9">
+    <title>MobileOne S2: 91.31% Acc@1, 5.9M parameters</title>
+    <circle class="point" cx="210.8" cy="344.9" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="MobileOne_S3_Checkpoint.IMAGENETTE" data-acc1="91.06" data-params="8.1">
+    <title>MobileOne S3: 91.06% Acc@1, 8.1M parameters</title>
+    <circle class="point" cx="267.4" cy="358" r="6"/>
+  </g>
+  <g class="checkpoint pareto" data-checkpoint="ReXNet1_0x_Checkpoint.IMAGENETTE" data-acc1="94.39" data-params="3.5" data-pareto="true">
+    <title>ReXNet 1.0x: 94.39% Acc@1, 3.5M parameters; Pareto frontier</title>
+    <circle class="point" cx="117.5" cy="184.1" r="7"/>
+  </g>
+  <g class="checkpoint pareto" data-checkpoint="ReXNet1_3x_Checkpoint.IMAGENETTE" data-acc1="94.88" data-params="5.9" data-pareto="true">
+    <title>ReXNet 1.3x: 94.88% Acc@1, 5.9M parameters; Pareto frontier</title>
+    <circle class="point" cx="210.8" cy="158.5" r="7"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="ReXNet1_5x_Checkpoint.IMAGENETTE" data-acc1="94.47" data-params="7.8">
+    <title>ReXNet 1.5x: 94.47% Acc@1, 7.8M parameters</title>
+    <circle class="point" cx="260.6" cy="179.9" r="6"/>
+  </g>
+  <g class="checkpoint pareto" data-checkpoint="ReXNet2_0x_Checkpoint.IMAGENETTE" data-acc1="95.24" data-params="13.8" data-pareto="true">
+    <title>ReXNet 2.0x: 95.24% Acc@1, 13.8M parameters; Pareto frontier</title>
+    <circle class="point" cx="362.5" cy="139.7" r="7"/>
+  </g>
+  <g class="checkpoint pareto" data-checkpoint="ReXNet2_2x_Checkpoint.IMAGENETTE" data-acc1="95.44" data-params="16.7" data-pareto="true">
+    <title>ReXNet 2.2x: 95.44% Acc@1, 16.7M parameters; Pareto frontier</title>
+    <circle class="point" cx="396.6" cy="129.2" r="7"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="RepVGG_A0_Checkpoint.IMAGENETTE" data-acc1="92.92" data-params="24.7">
+    <title>RepVGG A0: 92.92% Acc@1, 24.7M parameters</title>
+    <circle class="point" cx="466.5" cy="260.8" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="RepVGG_A1_Checkpoint.IMAGENETTE" data-acc1="93.78" data-params="30.1">
+    <title>RepVGG A1: 93.78% Acc@1, 30.1M parameters</title>
+    <circle class="point" cx="501.8" cy="215.9" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="RepVGG_A2_Checkpoint.IMAGENETTE" data-acc1="93.63" data-params="48.6">
+    <title>RepVGG A2: 93.63% Acc@1, 48.6M parameters</title>
+    <circle class="point" cx="587.4" cy="223.8" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="RepVGG_B0_Checkpoint.IMAGENETTE" data-acc1="92.69" data-params="31.8">
+    <title>RepVGG B0: 92.69% Acc@1, 31.8M parameters</title>
+    <circle class="point" cx="511.6" cy="272.9" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="RepVGG_B1_Checkpoint.IMAGENETTE" data-acc1="93.96" data-params="100.8">
+    <title>RepVGG B1: 93.96% Acc@1, 100.8M parameters</title>
+    <circle class="point" cx="717.6" cy="206.5" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="RepVGG_B2_Checkpoint.IMAGENETTE" data-acc1="94.14" data-params="157.5">
+    <title>RepVGG B2: 94.14% Acc@1, 157.5M parameters</title>
+    <circle class="point" cx="797.3" cy="197.1" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="Res2Net50_26w_4s_Checkpoint.IMAGENETTE" data-acc1="93.94" data-params="23.7">
+    <title>Res2Net-50 26w 4s: 93.94% Acc@1, 23.7M parameters</title>
+    <circle class="point" cx="459.1" cy="207.6" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="ResNeXt50_32x4d_Checkpoint.IMAGENETTE" data-acc1="94.55" data-params="23.0">
+    <title>ResNeXt-50 32x4d: 94.55% Acc@1, 23.0M parameters</title>
+    <circle class="point" cx="453.8" cy="175.7" r="6"/>
+  </g>
+  <g class="checkpoint default" data-checkpoint="ResNet18_Checkpoint.IMAGENETTE" data-acc1="93.61" data-params="11.2" data-default="true">
+    <title>Default ResNet-18: 93.61% Acc@1, 11.2M parameters</title>
+    <path class="default-marker" d="M325.2 214.8 335.2 224.8 325.2 234.8 315.2 224.8z"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="ResNet34_Checkpoint.IMAGENETTE" data-acc1="93.81" data-params="21.3">
+    <title>ResNet-34: 93.81% Acc@1, 21.3M parameters</title>
+    <circle class="point" cx="440" cy="214.4" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="ResNet50D_Checkpoint.IMAGENETTE" data-acc1="94.65" data-params="23.5">
+    <title>ResNet-50D: 94.65% Acc@1, 23.5M parameters</title>
+    <circle class="point" cx="457.6" cy="170.5" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="ResNet50_Checkpoint.IMAGENETTE" data-acc1="93.78" data-params="23.5">
+    <title>ResNet-50: 93.78% Acc@1, 23.5M parameters</title>
+    <circle class="point" cx="457.6" cy="215.9" r="6"/>
+  </g>
+  <g class="checkpoint" data-checkpoint="SKNet50_Checkpoint.IMAGENETTE" data-acc1="94.37" data-params="35.2">
+    <title>SKNet-50: 94.37% Acc@1, 35.2M parameters</title>
+    <circle class="point" cx="529.8" cy="185.1" r="6"/>
+  </g>
+
+  <path class="leader" d="M119 187 151 208"/>
+  <text class="annotation" x="156" y="215">Pareto · ReXNet 1.0×</text>
+  <path class="leader" d="M398 129 430 112"/>
+  <text class="annotation" x="436" y="116">ReXNet 2.2×</text>
+  <path class="leader" d="M324 229 348 251"/>
+  <text class="annotation" x="353" y="258">Default · ResNet-18</text>
+  <path class="leader" d="M115 538 143 521"/>
+  <text class="annotation" x="148" y="525">ConvNeXt Atto</text>
+</svg>

--- a/docs/docs/img/classification-transfer.svg
+++ b/docs/docs/img/classification-transfer.svg
@@ -1,0 +1,160 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 700" role="img" aria-labelledby="title desc">
+  <title id="title">Transfer-learning workflow for a custom Holocron classifier</title>
+  <desc id="desc">
+    Six numbered steps show checkpoint metadata, loading pretrained weights, replacing the classification
+    head, training with frozen features, optional full-model fine-tuning, and inference with custom labels.
+    Warnings explain that the head must be replaced after loading weights and that original checkpoint
+    categories must not be used for custom outputs. A final note lists trainer checkpoint contents.
+  </desc>
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <path d="M0 0 9 4.5 0 9z" class="arrow-head"/>
+    </marker>
+  </defs>
+  <style>
+    .canvas { fill: #faf8fb; stroke: #d9d1dc; }
+    .card { fill: #fff; stroke: #d9d1dc; }
+    .card-key { fill: #f5edf2; stroke: #a84c7a; }
+    .card-optional { fill: #eef8fa; stroke: #0e7490; }
+    .title, .step-title, .body, .code, .note-title, .note-text { fill: #2b2430; }
+    .subtitle, .muted { fill: #675f6a; }
+    .step-number { fill: #a84c7a; }
+    .step-number-text { fill: #fff; }
+    .arrow { fill: none; stroke: #675f6a; stroke-width: 3; marker-end: url(#arrow); }
+    .arrow-head { fill: #675f6a; }
+    .warning { fill: #fff2f0; stroke: #b42318; }
+    .warning-icon, .warning-text { fill: #b42318; }
+    .checkpoint-note { fill: #f2eef4; stroke: #9b919f; }
+    .saved { fill: #176b45; }
+    .omitted { fill: #9b2c22; }
+    text {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      text-rendering: geometricPrecision;
+    }
+    .title { font-size: 30px; font-weight: 700; }
+    .subtitle { font-size: 20px; }
+    .step-title { font-size: 25px; font-weight: 700; }
+    .body { font-size: 21px; }
+    .code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 18px;
+    }
+    .step-number-text { font-size: 20px; font-weight: 700; text-anchor: middle; }
+    .warning-text { font-size: 20px; font-weight: 650; }
+    .warning-icon { font-size: 25px; font-weight: 800; text-anchor: middle; }
+    .note-title { font-size: 20px; font-weight: 700; }
+    .note-text { font-size: 18px; }
+    @media (max-width: 500px) {
+      .body { font-size: 23px; }
+      .code { font-size: 20px; }
+      .warning-text { font-size: 21px; }
+      .note-text { font-size: 19px; }
+    }
+    @media (prefers-color-scheme: dark) {
+      .canvas { fill: #171419; stroke: #4d4552; }
+      .card { fill: #211d24; stroke: #4d4552; }
+      .card-key { fill: #2c2028; stroke: #e38ab7; }
+      .card-optional { fill: #17272b; stroke: #67e8f9; }
+      .title, .step-title, .body, .code, .note-title, .note-text { fill: #f3edf4; }
+      .subtitle, .muted { fill: #c4bbc7; }
+      .step-number { fill: #d978aa; }
+      .arrow { stroke: #c4bbc7; }
+      .arrow-head { fill: #c4bbc7; }
+      .warning { fill: #351c1d; stroke: #ff8a80; }
+      .warning-icon, .warning-text { fill: #ff8a80; }
+      .checkpoint-note { fill: #28232b; stroke: #655c69; }
+      .saved { fill: #7ee2b8; }
+      .omitted { fill: #ffaaa3; }
+    }
+  </style>
+
+  <rect class="canvas" x="1" y="1" width="838" height="698" rx="16"/>
+  <text class="title" x="30" y="42">From published checkpoint to custom classifier</text>
+  <text class="subtitle" x="30" y="70">Load the original contract first; customize only after the weights are in place.</text>
+
+  <path class="arrow" d="M250 185H300"/>
+  <path class="arrow" d="M530 185H580"/>
+  <path class="arrow" d="M700 270V375"/>
+  <path class="arrow" d="M590 475H540"/>
+  <path class="arrow" d="M310 475H260"/>
+
+  <g>
+    <rect class="card-key" x="30" y="100" width="220" height="170" rx="12"/>
+    <circle class="step-number" cx="55" cy="126" r="17"/>
+    <text class="step-number-text" x="55" y="133">1</text>
+    <text class="step-title" x="78" y="134">Checkpoint data</text>
+    <text class="body" x="50" y="174">Weights</text>
+    <text class="body" x="50" y="205">Input transform</text>
+    <text class="body" x="50" y="236">Original labels</text>
+  </g>
+
+  <g>
+    <rect class="card" x="310" y="100" width="220" height="170" rx="12"/>
+    <circle class="step-number" cx="335" cy="126" r="17"/>
+    <text class="step-number-text" x="335" y="133">2</text>
+    <text class="step-title" x="358" y="134">Load weights</text>
+    <text class="body" x="330" y="177">Keep the original head</text>
+    <text class="code" x="330" y="209">resnet18(</text>
+    <text class="code" x="330" y="235"> checkpoint=…)</text>
+  </g>
+
+  <g>
+    <rect class="card-key" x="590" y="100" width="220" height="170" rx="12"/>
+    <circle class="step-number" cx="615" cy="126" r="17"/>
+    <text class="step-number-text" x="615" y="133">3</text>
+    <text class="step-title" x="638" y="134">Replace head</text>
+    <text class="code" x="610" y="181">model.head = …</text>
+    <text class="body" x="610" y="216">10 → N outputs</text>
+    <text class="body" x="610" y="246">after loading</text>
+  </g>
+
+  <g>
+    <rect class="warning" x="245" y="300" width="350" height="54" rx="10"/>
+    <text class="warning-icon" x="273" y="335">×</text>
+    <text class="warning-text" x="295" y="334">Replacing the head first breaks loading</text>
+  </g>
+
+  <g>
+    <rect class="card" x="590" y="390" width="220" height="170" rx="12"/>
+    <circle class="step-number" cx="615" cy="416" r="17"/>
+    <text class="step-number-text" x="615" y="423">4</text>
+    <text class="step-title" x="638" y="424">Train new head</text>
+    <text class="code" x="610" y="470">freeze_until=</text>
+    <text class="code" x="610" y="496">"features"</text>
+    <text class="body" x="610" y="532">features stay frozen</text>
+  </g>
+
+  <g>
+    <rect class="card-optional" x="310" y="390" width="230" height="170" rx="12"/>
+    <circle class="step-number" cx="335" cy="416" r="17"/>
+    <text class="step-number-text" x="335" y="423">5</text>
+    <text class="step-title" x="358" y="424">Optional unfreeze</text>
+    <text class="body" x="330" y="473">Fine-tune the full model</text>
+    <text class="code" x="330" y="508">fit_n_epochs(...)</text>
+    <text class="body" x="330" y="538">all parameters update</text>
+  </g>
+
+  <g>
+    <rect class="card-key" x="30" y="390" width="230" height="170" rx="12"/>
+    <circle class="step-number" cx="55" cy="416" r="17"/>
+    <text class="step-number-text" x="55" y="423">6</text>
+    <text class="step-title" x="78" y="424">Save, then infer</text>
+    <text class="body" x="50" y="471">Decode outputs with</text>
+    <text class="code" x="50" y="505">train_set.classes</text>
+    <text class="body" x="50" y="536">your custom labels</text>
+  </g>
+
+  <g>
+    <rect class="warning" x="30" y="585" width="330" height="85" rx="10"/>
+    <text class="warning-icon" x="57" y="620">×</text>
+    <text class="warning-text" x="80" y="618">Do not reuse the original</text>
+    <text class="warning-text" x="80" y="647">checkpoint categories</text>
+  </g>
+
+  <g>
+    <rect class="checkpoint-note" x="380" y="585" width="430" height="85" rx="10"/>
+    <text class="note-title" x="400" y="614">Trainer checkpoint</text>
+    <text class="note-text saved" x="400" y="641">✓ model · epoch · step · best loss</text>
+    <text class="note-text omitted" x="400" y="663">× optimizer · scheduler · class names</text>
+  </g>
+</svg>

--- a/docs/docs/img/classification-transfer.svg
+++ b/docs/docs/img/classification-transfer.svg
@@ -45,9 +45,8 @@
     .note-title { font-size: 20px; font-weight: 700; }
     .note-text { font-size: 18px; }
     @media (max-width: 500px) {
-      .body { font-size: 23px; }
+      .step-title, .body { font-size: 22px; }
       .code { font-size: 20px; }
-      .warning-text { font-size: 21px; }
       .note-text { font-size: 19px; }
     }
     @media (prefers-color-scheme: dark) {
@@ -93,7 +92,7 @@
     <circle class="step-number" cx="335" cy="126" r="17"/>
     <text class="step-number-text" x="335" y="133">2</text>
     <text class="step-title" x="358" y="134">Load weights</text>
-    <text class="body" x="330" y="177">Keep the original head</text>
+    <text class="body" x="330" y="177">Keep original head</text>
     <text class="code" x="330" y="209">resnet18(</text>
     <text class="code" x="330" y="235"> checkpoint=…)</text>
   </g>
@@ -111,7 +110,8 @@
   <g>
     <rect class="warning" x="245" y="300" width="350" height="54" rx="10"/>
     <text class="warning-icon" x="273" y="335">×</text>
-    <text class="warning-text" x="295" y="334">Replacing the head first breaks loading</text>
+    <text class="warning-text" x="295" y="323">Load weights before</text>
+    <text class="warning-text" x="295" y="345">replacing the head</text>
   </g>
 
   <g>
@@ -128,10 +128,10 @@
     <rect class="card-optional" x="310" y="390" width="230" height="170" rx="12"/>
     <circle class="step-number" cx="335" cy="416" r="17"/>
     <text class="step-number-text" x="335" y="423">5</text>
-    <text class="step-title" x="358" y="424">Optional unfreeze</text>
-    <text class="body" x="330" y="473">Fine-tune the full model</text>
+    <text class="step-title" x="357" y="424">Optional unfreeze</text>
+    <text class="body" x="330" y="473">Fine-tune full model</text>
     <text class="code" x="330" y="508">fit_n_epochs(...)</text>
-    <text class="body" x="330" y="538">all parameters update</text>
+    <text class="body" x="330" y="538">all weights update</text>
   </g>
 
   <g>

--- a/docs/docs/reference/models/models.md
+++ b/docs/docs/reference/models/models.md
@@ -43,6 +43,11 @@ The output represents the classification scores for each output classes.
 
 Here is the list of available checkpoints:
 
+The chart compares only the 27 Imagenette checkpoints. ImageNet-1K rows remain
+in the table for reference but use a different evaluation dataset.
+
+![Scatter plot of Imagenette top-one accuracy against parameter count, with the Pareto frontier and default ResNet-18 checkpoint highlighted.](../../img/checkpoint-accuracy-vs-parameters.svg)
+
 | **Checkpoint** | **Acc@1** | **Acc@5** | **Params** | **Size (MB)** |
 |---|---|---|---|---|
 | [`CSPDarknet53_Checkpoint.IMAGENETTE`][holocron.models.classification.CSPDarknet53_Checkpoint.IMAGENETTE] | 94.50% | 99.64% | 26.6M | 101.8 |

--- a/docs/docs/reference/ops.md
+++ b/docs/docs/reference/ops.md
@@ -7,6 +7,8 @@
 
 ## Boxes
 
+![Four-panel comparison of IoU overlap, GIoU enclosing area, DIoU center distance, and CIoU aspect-ratio geometry using the same target and prediction boxes.](../img/box-iou-family.svg)
+
 ::: holocron.ops
     options:
         heading_level: 3

--- a/holocron/ops/boxes.py
+++ b/holocron/ops/boxes.py
@@ -121,8 +121,6 @@ def diou_loss(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     $c$ c is the diagonal length of the smallest enclosing box covering the two boxes,
     and $\rho(.)$ is the Euclidean distance.
 
-    ![Distance-IoU loss](https://github.com/frgfm/Holocron/releases/download/v0.1.3/diou_loss.png)
-
     Args:
         boxes1: bounding boxes of shape [M, 4]
         boxes2: bounding boxes of shape [N, 4]

--- a/holocron/ops/boxes.py
+++ b/holocron/ops/boxes.py
@@ -116,6 +116,10 @@ def diou_loss(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     \mathcal{L}_{DIoU} = 1 - IoU + \frac{\rho^2(b, b^{GT})}{c^2}
     $$
 
+    Illustration from the original paper:
+
+    ![Distance-IoU loss](https://github.com/frgfm/Holocron/releases/download/v0.1.3/diou_loss.png)
+
     where $\IoU$ is the Intersection over Union,
     $b$ and $b^{GT}$ are the centers of the box and the ground truth box respectively,
     $c$ c is the diagonal length of the smallest enclosing box covering the two boxes,

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -32,3 +32,53 @@ def test_homepage_quickstart(monkeypatch, tmp_path):
     assert probabilities.shape == (len(checkpoint.meta.categories),)
     assert namespace["label"] in checkpoint.meta.categories
     assert 0 <= namespace["confidence"] <= 1
+
+
+def test_checkpoint_chart_matches_table():
+    repo_root = Path(__file__).parents[1]
+    models_page = (repo_root / "docs" / "docs" / "reference" / "models" / "models.md").read_text()
+    documented = {
+        match["checkpoint"]: (float(match["acc1"]), float(match["params"]))
+        for match in re.finditer(
+            r"^\| \[`(?P<checkpoint>[^`]+\.IMAGENETTE)`\]\[[^\]]+\] \| "
+            r"(?P<acc1>\d+\.\d+)% \| [^|]+ \| (?P<params>\d+(?:\.\d+)?)M \|",
+            models_page,
+            re.MULTILINE,
+        )
+    }
+
+    chart = (repo_root / "docs" / "docs" / "img" / "checkpoint-accuracy-vs-parameters.svg").read_text()
+    points = [
+        match.groupdict()
+        for match in re.finditer(
+            r'<g class="checkpoint[^"]*" data-checkpoint="(?P<checkpoint>[^"]+)" '
+            r'data-acc1="(?P<acc1>[\d.]+)" data-params="(?P<params>[\d.]+)"(?P<flags>[^>]*)>',
+            chart,
+        )
+    ]
+    plotted = {
+        point["checkpoint"]: (float(point["acc1"]), float(point["params"]))
+        for point in points
+    }
+
+    assert len(points) == len(plotted) == len(documented) == 27
+    assert plotted == documented
+    assert [point["checkpoint"] for point in points if 'data-default="true"' in point["flags"]] == [
+        "ResNet18_Checkpoint.IMAGENETTE"
+    ]
+
+    expected_pareto = {
+        checkpoint
+        for checkpoint, (acc1, params) in documented.items()
+        if not any(
+            other_checkpoint != checkpoint
+            and other_params <= params
+            and other_acc1 >= acc1
+            and (other_params < params or other_acc1 > acc1)
+            for other_checkpoint, (other_acc1, other_params) in documented.items()
+        )
+    }
+    plotted_pareto = {
+        point["checkpoint"] for point in points if 'data-pareto="true"' in point["flags"]
+    }
+    assert plotted_pareto == expected_pareto

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,3 +1,4 @@
+import math
 import re
 from pathlib import Path
 
@@ -52,8 +53,10 @@ def test_checkpoint_chart_matches_table():
         match.groupdict()
         for match in re.finditer(
             r'<g class="checkpoint[^"]*" data-checkpoint="(?P<checkpoint>[^"]+)" '
-            r'data-acc1="(?P<acc1>[\d.]+)" data-params="(?P<params>[\d.]+)"(?P<flags>[^>]*)>',
+            r'data-acc1="(?P<acc1>[\d.]+)" data-params="(?P<params>[\d.]+)"(?P<flags>[^>]*)>'
+            r"(?P<body>.*?)</g>",
             chart,
+            re.DOTALL,
         )
     ]
     plotted = {point["checkpoint"]: (float(point["acc1"]), float(point["params"])) for point in points}
@@ -63,6 +66,25 @@ def test_checkpoint_chart_matches_table():
     assert [point["checkpoint"] for point in points if 'data-default="true"' in point["flags"]] == [
         "ResNet18_Checkpoint.IMAGENETTE"
     ]
+
+    positions = {}
+    for point in points:
+        circle = re.search(r'<circle class="point" cx="([\d.]+)" cy="([\d.]+)"', point["body"])
+        if circle is not None:
+            x, y = map(float, circle.groups())
+        else:
+            diamond = re.search(r'<path class="default-marker" d="([^"]+)"', point["body"])
+            assert diamond is not None
+            coordinates = [float(value) for value in re.findall(r"[\d.]+", diamond[1])]
+            x = sum(coordinates[::2]) / (len(coordinates) / 2)
+            y = sum(coordinates[1::2]) / (len(coordinates) / 2)
+
+        positions[point["checkpoint"]] = (x, y)
+        acc1, params = plotted[point["checkpoint"]]
+        expected_x = 90 + (math.log10(params) - math.log10(3)) / (math.log10(200) - math.log10(3)) * 750
+        expected_y = 570 - (acc1 - 87) / (96 - 87) * 470
+        assert math.isclose(x, expected_x, abs_tol=0.11)
+        assert math.isclose(y, expected_y, abs_tol=0.11)
 
     expected_pareto = {
         checkpoint
@@ -77,3 +99,11 @@ def test_checkpoint_chart_matches_table():
     }
     plotted_pareto = {point["checkpoint"] for point in points if 'data-pareto="true"' in point["flags"]}
     assert plotted_pareto == expected_pareto
+
+    frontier = re.search(r'<polyline class="frontier-line" points="([^"]+)"', chart)
+    assert frontier is not None
+    frontier_points = [tuple(map(float, point.split(","))) for point in frontier[1].split()]
+    expected_frontier = [
+        positions[checkpoint] for checkpoint in sorted(expected_pareto, key=lambda name: documented[name][1])
+    ]
+    assert frontier_points == expected_frontier

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -56,10 +56,7 @@ def test_checkpoint_chart_matches_table():
             chart,
         )
     ]
-    plotted = {
-        point["checkpoint"]: (float(point["acc1"]), float(point["params"]))
-        for point in points
-    }
+    plotted = {point["checkpoint"]: (float(point["acc1"]), float(point["params"])) for point in points}
 
     assert len(points) == len(plotted) == len(documented) == 27
     assert plotted == documented
@@ -78,7 +75,5 @@ def test_checkpoint_chart_matches_table():
             for other_checkpoint, (other_acc1, other_params) in documented.items()
         )
     }
-    plotted_pareto = {
-        point["checkpoint"] for point in points if 'data-pareto="true"' in point["flags"]
-    }
+    plotted_pareto = {point["checkpoint"] for point in points if 'data-pareto="true"' in point["flags"]}
     assert plotted_pareto == expected_pareto


### PR DESCRIPTION
## Summary

- add a transfer-learning workflow to the classification guide
- chart the 27 comparable Imagenette checkpoints and guard its data against table drift
- replace the remote DIoU image with a local IoU-family geometry explainer

## Verification

- uv run --with pytest pytest -o addopts= tests/test_docs.py -q
- uv run ruff check tests/test_docs.py
- make build-docs
- desktop and 390 px render checks in light and dark themes