### PR TITLE
ci(dependabot): consolidate root dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,13 +21,13 @@ updates:
       actions:
         patterns:
           - "*"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     labels:
       - "dependencies"
       - "type: misc"
     commit-message:
-      prefix: "build(deps-dev)"
+      prefix: "build(deps)"
     schedule:
       interval: "daily"
       time: "08:00"
@@ -36,64 +36,32 @@ updates:
       - dependency-name: "ruff"
       - dependency-name: "ty"
       - dependency-name: "prek"
+      - dependency-name: "mkdocs"
+      - dependency-name: "mkdocs-material"
+      - dependency-name: "mkdocstrings"
+      - dependency-name: "griffe-typingdoc"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-cov"
+      - dependency-name: "pytest-pretty"
+      - dependency-name: "torch"
+      - dependency-name: "torchvision"
     groups:
       quality:
         patterns:
           - "ruff"
           - "ty"
           - "prek"
-  - package-ecosystem: "pip"
-    directory: "/"
-    labels:
-      - "dependencies"
-      - "type: misc"
-    commit-message:
-      prefix: "build(deps-docs)"
-    schedule:
-      interval: "daily"
-      time: "08:00"
-    allow:
-      # Safe updates
-      - dependency-name: "mkdocs"
-      - dependency-name: "mkdocs-material"
-      - dependency-name: "mkdocstrings"
-      - dependency-name: "griffe-typingdoc"
-    groups:
-      quality:
+      docs:
         patterns:
           - "mkdocs"
           - "mkdocs-material"
           - "mkdocstrings"
           - "griffe-typingdoc"
-  - package-ecosystem: "pip"
-    directory: "/"
-    labels:
-      - "dependencies"
-      - "type: misc"
-    commit-message:
-      prefix: "build(deps-test)"
-    schedule:
-      interval: "daily"
-      time: "08:00"
-    allow:
-      # Safe updates
-      - dependency-name: "pytest"
-      - dependency-name: "pytest-cov"
-      - dependency-name: "pytest-pretty"
-    groups:
-      quality:
+      tests:
         patterns:
           - "pytest"
           - "pytest-cov"
           - "pytest-pretty"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "08:00"
-    allow:
-      - dependency-name: "torch"
-      - dependency-name: "torchvision"
   - package-ecosystem: "uv"
     directory: "api/"
     schedule:


### PR DESCRIPTION
## Summary
- consolidate four overlapping root Python update jobs into one uv updater
- preserve the existing allowlist and group quality, docs, and test dependencies separately
- keep torch and torchvision as individual updates while allowing Dependabot to maintain uv.lock

## Why
All four pip jobs targeted the same root directory, which GitHub documents as an unsupported overlap. The docs rules were therefore not applied reliably, and #485, #486, and #487 opened as separate PRs that changed only pyproject.toml.

## Validation
- uv run prek run --files .github/dependabot.yml
- YAML structure check: one root Python updater, uv ecosystem, expected groups, and allowed group patterns
- git diff --check