### PR TITLE
fix: align LR finder with optimizer steps

### DIFF
--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -161,16 +161,17 @@ class Trainer:
             # Backprop
             if not self.skip_nan_loss or torch.isfinite(batch_loss):
                 nan_cnt = 0
-                self._backprop_step(batch_loss)
+                if self._backprop_step(batch_loss):
+                    self.scheduler.step()
             else:
                 nan_cnt += 1
                 if nan_cnt > self.nan_tolerance:
                     raise ValueError(f"loss value has been NaN or inf for more than {self.nan_tolerance} steps.")
-            # Update LR
-            self.scheduler.step()
             pb.comment = f"Training loss: {batch_loss.item():.4}"
 
             self.step += 1
+        if self._optimizer_step():
+            self.scheduler.step()
         self.epoch += 1
 
     def to_cuda(
@@ -200,31 +201,39 @@ class Trainer:
         target = target.cuda(non_blocking=True)
         return x, target
 
-    def _backprop_step(self, loss: Tensor) -> None:
-        # Backpropate the loss
+    def _backprop_step(self, loss: Tensor, force: bool = False) -> bool:
         self._grad_count += 1
         if self.amp:
-            # Backprop
             self.scaler.scale(loss).backward()
-            if self._grad_count == self.gradient_acc:
-                # Safeguard for Gradient explosion
-                if isinstance(self.grad_clip, float):
-                    self.scaler.unscale_(self.optimizer)
-                    nn.utils.clip_grad_norm_(self.model.parameters(), self.grad_clip)
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
-                self.optimizer.zero_grad()
-                self._grad_count = 0
         else:
-            # Backprop
             loss.backward()
-            if self._grad_count == self.gradient_acc:
-                # Safeguard for Gradient explosion
-                if isinstance(self.grad_clip, float):
-                    nn.utils.clip_grad_norm_(self.model.parameters(), self.grad_clip)
-                self.optimizer.step()
-                self.optimizer.zero_grad()
-                self._grad_count = 0
+        if self._grad_count < self.gradient_acc and not force:
+            return False
+        return self._optimizer_step()
+
+    def _optimizer_step(self) -> bool:
+        if self._grad_count == 0:
+            return False
+
+        if self.amp:
+            self.scaler.unscale_(self.optimizer)
+        for param in self.model.parameters():
+            if param.grad is not None:
+                param.grad.div_(self._grad_count)
+        if isinstance(self.grad_clip, float):
+            nn.utils.clip_grad_norm_(self.model.parameters(), self.grad_clip)
+
+        if self.amp:
+            scale = self.scaler.get_scale()
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+            stepped = self.scaler.get_scale() >= scale
+        else:
+            self.optimizer.step()
+            stepped = True
+        self.optimizer.zero_grad()
+        self._grad_count = 0
+        return stepped
 
     def _get_loss(self, x: Tensor, target: Tensor, return_logits: bool = False) -> Tensor | tuple[Tensor, Tensor]:
         # AMP
@@ -269,6 +278,7 @@ class Trainer:
                 if len(params) > 0:
                     self.optimizer.add_param_group({"params": params, "weight_decay": wd})
         self.optimizer.zero_grad()
+        self._grad_count = 0
 
     @torch.inference_mode()
     def evaluate(self):  # type: ignore[no-untyped-def]  # noqa: D102, ANN201
@@ -280,10 +290,11 @@ class Trainer:
 
     def _reset_scheduler(self, lr: float, num_epochs: int, sched_type: str = "onecycle", **kwargs: Any) -> None:
         self.scheduler: LRScheduler
+        num_steps = num_epochs * math.ceil(len(self.train_loader) / self.gradient_acc)
         if sched_type == "onecycle":
-            self.scheduler = OneCycleLR(self.optimizer, lr, num_epochs * len(self.train_loader), **kwargs)
+            self.scheduler = OneCycleLR(self.optimizer, lr, num_steps, **kwargs)
         elif sched_type == "cosine":
-            self.scheduler = CosineAnnealingLR(self.optimizer, num_epochs * len(self.train_loader), **kwargs)
+            self.scheduler = CosineAnnealingLR(self.optimizer, num_steps, **kwargs)
         else:
             raise ValueError(f"The following scheduler type is not supported: {sched_type}")
 
@@ -350,7 +361,7 @@ class Trainer:
            start_lr: initial learning rate
            end_lr: final learning rate
            norm_weight_decay: weight decay to apply to normalization parameters
-           num_it: number of iterations to perform
+           num_it: maximum number of microbatches to consume
 
         Raises:
             ValueError: if the number of iterations is greater than the number of available batches
@@ -361,11 +372,14 @@ class Trainer:
         freeze_model(self.model.train(), freeze_until)
         # Update param groups & LR
         self._reset_opt(start_lr, norm_weight_decay)
-        gamma = (end_lr / start_lr) ** (1 / (num_it - 1))
+        num_steps = math.ceil(num_it / self.gradient_acc)
+        gamma = (end_lr / start_lr) ** (1 / (num_steps - 1)) if num_steps > 1 else 1
         scheduler = MultiplicativeLR(self.optimizer, lambda step: gamma)
 
-        self.lr_recorder = [start_lr * gamma**idx for idx in range(num_it)]
+        self.lr_recorder = []
         self.loss_recorder = []
+        accumulated_loss = 0.0
+        accumulated_batches = 0
 
         if self.amp:
             self.scaler = GradScaler("cuda")
@@ -375,21 +389,25 @@ class Trainer:
 
             # Forward
             batch_loss: Tensor = self._get_loss(x, target)  # type: ignore[assignment]
-            self._backprop_step(batch_loss)
-            # Update LR
-            scheduler.step()
-
-            # Record
             if torch.isnan(batch_loss) or torch.isinf(batch_loss):
                 if batch_idx == 0:
                     raise ValueError("loss value is NaN or inf.")
                 break
-            self.loss_recorder.append(batch_loss.item())
-            # Stop after the number of iterations
-            if batch_idx + 1 == num_it:
-                break
 
-        self.lr_recorder = self.lr_recorder[: len(self.loss_recorder)]
+            accumulated_loss += batch_loss.item()
+            accumulated_batches += 1
+            is_last_batch = batch_idx + 1 == num_it
+            stepped = self._backprop_step(batch_loss, force=is_last_batch)
+            if self._grad_count == 0:
+                if stepped:
+                    self.lr_recorder.append(float(self.optimizer.param_groups[0]["lr"]))
+                    self.loss_recorder.append(accumulated_loss / accumulated_batches)
+                    scheduler.step()
+                accumulated_loss = 0.0
+                accumulated_batches = 0
+
+            if is_last_batch:
+                break
 
     def plot_recorder(self, beta: float = 0.95, **kwargs: Any) -> None:
         """Display the results of the LR grid search

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,7 +1,10 @@
+import math
+import warnings
+
 import pytest
 import torch
 from torch import nn
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader, Dataset, TensorDataset
 from torchvision.models import get_model, get_model_weights
 
 from holocron import trainer
@@ -75,6 +78,153 @@ class MockDetDataset(Dataset):
 def collate_fn(batch):
     imgs, target = zip(*batch, strict=False)
     return imgs, target
+
+
+class _CountingSGD(torch.optim.SGD):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.used_lrs = []
+
+    def step(self, *args, **kwargs):
+        self.used_lrs.append(float(self.param_groups[0]["lr"]))
+        return super().step(*args, **kwargs)
+
+
+class _CountingScheduler(torch.optim.lr_scheduler.MultiplicativeLR):
+    instance = None
+
+    def __init__(self, *args, **kwargs):
+        self.steps = -1
+        super().__init__(*args, **kwargs)
+        type(self).instance = self
+
+    def step(self, *args, **kwargs):
+        self.steps += 1
+        return super().step(*args, **kwargs)
+
+
+def _linear_trainer(x, target, gradient_acc, optimizer_cls=torch.optim.SGD):
+    dataset = TensorDataset(x, target)
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+    model = nn.Linear(1, 1, bias=False)
+    optimizer = optimizer_cls(model.parameters(), lr=0.1)
+    return trainer.Trainer(model, loader, loader, nn.MSELoss(), optimizer, gradient_acc=gradient_acc)
+
+
+def test_gradient_accumulation_matches_large_batch():
+    x = torch.tensor([[1.0], [3.0]])
+    target = torch.tensor([[2.0], [0.0]])
+    accumulated = _linear_trainer(x, target, gradient_acc=2)
+    large_batch = _linear_trainer(x, target, gradient_acc=1)
+    large_batch.model.load_state_dict(accumulated.model.state_dict())
+
+    for batch in accumulated.train_loader:
+        accumulated._backprop_step(accumulated._get_loss(*batch))
+    large_batch._backprop_step(large_batch._get_loss(x, target))
+
+    torch.testing.assert_close(accumulated.model.weight, large_batch.model.weight)
+
+
+def test_gradient_accumulation_flushes_partial_batch(monkeypatch):
+    x = torch.arange(1, 6, dtype=torch.float32).unsqueeze(1)
+    target = torch.zeros_like(x)
+    learner = _linear_trainer(x, target, gradient_acc=2, optimizer_cls=_CountingSGD)
+    learner.model.weight.data.fill_(1)
+    initial_weight = learner.model.weight.detach().clone()
+
+    learner._reset_scheduler(0.1, 2, sched_type="cosine")
+    assert learner.scheduler.T_max == 2 * math.ceil(len(learner.train_loader) / learner.gradient_acc)
+
+    class Scheduler:
+        steps = 0
+
+        def step(self):
+            self.steps += 1
+
+    monkeypatch.setattr("holocron.trainer.core.progress_bar", lambda data, **_kwargs: data)
+    learner.scheduler = Scheduler()
+    learner._fit_epoch(None)
+
+    assert (
+        len(learner.optimizer.used_lrs)
+        == learner.scheduler.steps
+        == math.ceil(len(learner.train_loader) / learner.gradient_acc)
+    )
+    assert learner._grad_count == 0
+    assert not torch.equal(learner.model.weight, initial_weight)
+
+
+@pytest.mark.parametrize(
+    ("gradient_acc", "num_it", "expected_steps"),
+    [(1, 5, 5), (2, 5, 3), (8, 100, 13), (8, 3, 1)],
+)
+def test_find_lr_gradient_accumulation(monkeypatch, gradient_acc, num_it, expected_steps):
+    x = torch.arange(1, num_it + 1, dtype=torch.float32).unsqueeze(1)
+    learner = _linear_trainer(x, torch.zeros_like(x), gradient_acc, optimizer_cls=_CountingSGD)
+    losses = list(range(num_it, 0, -1))
+    loss_iter = iter(losses)
+    learner._get_loss = lambda *_args: learner.model.weight.sum() * 0 + next(loss_iter)
+    monkeypatch.setattr("holocron.trainer.core.MultiplicativeLR", _CountingScheduler)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        learner.find_lr(start_lr=1e-3, end_lr=1e-1, num_it=num_it)
+
+    expected_losses = []
+    for idx in range(0, num_it, gradient_acc):
+        window = losses[idx : idx + gradient_acc]
+        expected_losses.append(sum(window) / len(window))
+    assert len(learner.optimizer.used_lrs) == _CountingScheduler.instance.steps == expected_steps
+    assert learner.lr_recorder == pytest.approx(learner.optimizer.used_lrs)
+    assert learner.loss_recorder == pytest.approx(expected_losses)
+    assert learner.lr_recorder[0] == pytest.approx(1e-3)
+    assert learner.lr_recorder[-1] == pytest.approx(1e-1 if expected_steps > 1 else 1e-3)
+    assert learner._grad_count == 0
+    assert not any("lr_scheduler.step() before optimizer.step()" in str(warning.message) for warning in caught)
+    if expected_steps > 1:
+        learner.plot_recorder(block=False)
+
+
+def test_find_lr_ignores_amp_overflow(monkeypatch):
+    class SkipFirstGradScaler:
+        def __init__(self, *_args, **_kwargs):
+            self.current_scale = 2.0
+            self.skip = True
+
+        @staticmethod
+        def scale(loss):
+            return loss
+
+        def unscale_(self, _optimizer):
+            pass
+
+        def step(self, optimizer):
+            if not self.skip:
+                optimizer.step()
+
+        def update(self):
+            if self.skip:
+                self.current_scale /= 2
+                self.skip = False
+
+        def get_scale(self):
+            return self.current_scale
+
+    x = torch.tensor([[1.0], [2.0]])
+    learner = _linear_trainer(x, torch.zeros_like(x), gradient_acc=1, optimizer_cls=_CountingSGD)
+    losses = iter([1.0, 2.0])
+    learner._get_loss = lambda *_args: learner.model.weight.sum() * 0 + next(losses)
+    learner.amp = True
+    monkeypatch.setattr("holocron.trainer.core.GradScaler", SkipFirstGradScaler)
+    monkeypatch.setattr("holocron.trainer.core.MultiplicativeLR", _CountingScheduler)
+
+    learner.find_lr(start_lr=1e-3, end_lr=1e-1, num_it=2)
+
+    assert learner.optimizer.used_lrs == pytest.approx([1e-3])
+    assert _CountingScheduler.instance.steps == 1
+    assert learner.lr_recorder == pytest.approx([1e-3])
+    assert learner.loss_recorder == pytest.approx([2.0])
+    assert learner._grad_count == 0
 
 
 def _test_trainer(


### PR DESCRIPTION
## Summary

- advance learning-rate schedulers only after successful optimizer updates
- normalize and flush gradient-accumulation windows, including partial final windows
- apply the same update-level scheduling and averaged-gradient semantics to regular epoch training
- record the actual update LR and mean window loss during LR finder runs
- ignore AMP-overflow skips without advancing the sweep or adding misleading points

Closes #504

## Validation

- `uv run --frozen --extra test pytest tests/test_trainer.py -k 'gradient_accumulation or find_lr_ignores_amp_overflow' --no-cov -q` — 7 passed
- `uv run --frozen --extra test pytest tests/test_trainer.py --no-cov -q` — 12 passed
- `make lint-check`
- `make typing-check`
- `make test` — 122 passed; 21 unrelated ONNX failures from the installed `ml_dtypes` API and one existing exact-float box assertion
