### PR TITLE
feat(models): add RepViT classifiers

### DIFF
--- a/docs/docs/reference/models/classification/repvit.md
+++ b/docs/docs/reference/models/classification/repvit.md
@@ -38,9 +38,9 @@ from local CPU or MPS checks.
 
 | Model | Parameters before/after fusion | MACs | Top-1 | Top-5 | Status |
 |---|---:|---:|---:|---:|---|
-| RepViT-M0.9 | Pending | Pending | Pending | Pending | CUDA run required |
-| RepViT-M1.0 | Pending | Pending | Pending | Pending | CUDA run required |
-| RepViT-M1.1 | Pending | Pending | Pending | Pending | CUDA run required |
+| RepViT-M0.9 | 5,103,560 / 5,067,056 | Pending | Pending | Pending | CUDA run required |
+| RepViT-M1.0 | 6,852,900 / 6,810,312 | Pending | Pending | Pending | CUDA run required |
+| RepViT-M1.1 | 8,288,888 / 8,244,312 | Pending | Pending | Pending | CUDA run required |
 | MobileOne-S2 | Pending rerun | Pending | Pending | Pending | CUDA run required |
 
 No pretrained RepViT checkpoint is published with this implementation.

--- a/docs/docs/reference/models/classification/repvit.md
+++ b/docs/docs/reference/models/classification/repvit.md
@@ -1,0 +1,62 @@
+# RepViT
+
+RepViT is based on the
+["RepViT: Revisiting Mobile CNN From ViT Perspective"](https://arxiv.org/abs/2307.09283)
+paper and its [official implementation](https://github.com/THU-MIG/RepViT).
+
+## Architecture overview
+
+RepViT adapts mobile CNN blocks using design choices associated with efficient
+vision transformers. Each block separates spatial token mixing from channel
+mixing, uses squeeze-excitation selectively, and can fuse its training-time
+depthwise branches for deployment.
+
+Call `model.eval()` and then `model.reparametrize()` before exporting or
+benchmarking the deployment form.
+
+## Paper evidence
+
+These ImageNet-1K results are teacher-distilled scores reported by the authors,
+not Holocron benchmark results.
+
+| Model | Parameters | MACs | Top-1 |
+|---|---:|---:|---:|
+| RepViT-M0.9 | 5.1M | 0.8G | 78.7% |
+| RepViT-M1.0 | 6.8M | 1.1G | 80.0% |
+| RepViT-M1.1 | 8.2M | 1.3G | 80.7% |
+
+## Controlled Holocron benchmark
+
+The Holocron comparison trains from scratch on Imagenette without a teacher:
+176px training crops, 232px resize and 224px validation crops, 20 epochs,
+effective batch size 32, AMP, AdamP at `1e-3`, OneCycle, Mixup `0.2`, and label
+smoothing `0.1`. MobileOne-S2 uses the identical command as the baseline.
+
+CUDA measurements remain a separate acceptance gate for
+[issue #499](https://github.com/frgfm/holocron/issues/499); they are not inferred
+from local CPU or MPS checks.
+
+| Model | Parameters before/after fusion | MACs | Top-1 | Top-5 | Status |
+|---|---:|---:|---:|---:|---|
+| RepViT-M0.9 | Pending | Pending | Pending | Pending | CUDA run required |
+| RepViT-M1.0 | Pending | Pending | Pending | Pending | CUDA run required |
+| RepViT-M1.1 | Pending | Pending | Pending | Pending | CUDA run required |
+| MobileOne-S2 | Pending rerun | Pending | Pending | Pending | CUDA run required |
+
+No pretrained RepViT checkpoint is published with this implementation.
+
+## Model builders
+
+All builders rely on [`RepViT`][holocron.models.RepViT] and accept a custom
+class count through `num_classes`.
+
+::: holocron.models.classification
+    options:
+        heading_level: 3
+        show_root_heading: false
+        show_root_toc_entry: false
+        members:
+            - RepViT
+            - repvit_m0_9
+            - repvit_m1_0
+            - repvit_m1_1

--- a/docs/docs/reference/models/models.md
+++ b/docs/docs/reference/models/models.md
@@ -8,7 +8,7 @@ segmentation and object detection.
 
 | Task | Architectures | Published checkpoints | Training | ONNX | Status |
 |---|---|---|---|---|---|
-| Classification | 14 families | Imagenette checkpoints with top-1/top-5 metrics; selected ReXNet ImageNet-1K checkpoints | [Reference script](https://github.com/frgfm/holocron/blob/main/references/classification/train.py) | [Classification export](https://github.com/frgfm/holocron/blob/main/scripts/export_to_onnx.py) | **Validated** |
+| Classification | 15 families | Imagenette checkpoints with top-1/top-5 metrics; selected ReXNet ImageNet-1K checkpoints | [Reference script](https://github.com/frgfm/holocron/blob/main/references/classification/train.py) | [Classification export](https://github.com/frgfm/holocron/blob/main/scripts/export_to_onnx.py) | **Validated** |
 | Semantic segmentation | U-Net, U-Net++, UNet3+ | Only the legacy `unet_rexnet13` weights; dataset and metric are not documented | [Reference script](https://github.com/frgfm/holocron/blob/main/references/segmentation/train.py) | Not documented | **Unbenchmarked** |
 | Object detection | YOLOv1, YOLOv2, YOLOv4 | None | [Reference script](https://github.com/frgfm/holocron/blob/main/references/detection/train.py) | Not documented | **Experimental** ([#110](https://github.com/frgfm/holocron/issues/110), [#253](https://github.com/frgfm/holocron/issues/253), [discussion #230](https://github.com/frgfm/holocron/discussions/230)) |
 
@@ -38,6 +38,7 @@ The output represents the classification scores for each output classes.
 * [DarkNetV4](./classification/darknetv4.md)
 * [RepVGG](./classification/repvgg.md)
 * [MobileOne](./classification/mobileone.md)
+* [RepViT](./classification/repvit.md)
 
 ### Available checkpoints
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -192,6 +192,7 @@ nav:
         - reference/models/classification/darknetv4.md
         - reference/models/classification/repvgg.md
         - reference/models/classification/mobileone.md
+        - reference/models/classification/repvit.md
     - Layers: reference/nn.md
     - Operators: reference/ops.md
     - Optimizers: reference/optim.md

--- a/holocron/models/classification/__init__.py
+++ b/holocron/models/classification/__init__.py
@@ -6,6 +6,7 @@ from .darknetv4 import *
 from .mobileone import *
 from .pyconv_resnet import *
 from .repvgg import *
+from .repvit import *
 from .res2net import *
 from .resnet import *
 from .rexnet import *

--- a/holocron/models/classification/repvit.py
+++ b/holocron/models/classification/repvit.py
@@ -186,7 +186,7 @@ class _RepViTBlock(nn.Module):
 
 class RepViT(nn.Sequential):
     """Implements RepViT as described in
-    `"RepViT: Revisiting Mobile CNN From ViT Perspective" <https://arxiv.org/abs/2307.09283>`_.
+    ["RepViT: Revisiting Mobile CNN From ViT Perspective"](https://arxiv.org/abs/2307.09283).
 
     Args:
         channels: number of output channels in each stage
@@ -216,7 +216,7 @@ class RepViT(nn.Sequential):
             blocks: list[nn.Module] = []
             for block_idx in range(depth):
                 stride = 2 if stage_idx > 0 and block_idx == 0 else 1
-                # Paper pattern: SE on the first block, then alternating blocks except stage ends.
+                # Official configs: SE on the first block, then alternating blocks except stage ends.
                 use_se = block_idx == 0 if stage_idx == 0 else block_idx % 2 == 1 and block_idx < depth - 1
                 blocks.append(_RepViTBlock(in_planes, out_planes, stride, use_se))
                 in_planes = out_planes
@@ -234,6 +234,8 @@ class RepViT(nn.Sequential):
         """Fuse training-time branches and batch-normalization layers for deployment."""
         self.features: nn.Sequential
         patch_embed = cast(nn.Sequential, self.features[0])
+        if not isinstance(patch_embed[0], _ConvNorm):
+            return
         patch_embed[0] = cast(_ConvNorm, patch_embed[0]).reparametrize()
         patch_embed[-1] = cast(_ConvNorm, patch_embed[-1]).reparametrize()
         for stage in self.features[1:]:

--- a/holocron/models/classification/repvit.py
+++ b/holocron/models/classification/repvit.py
@@ -1,0 +1,316 @@
+# Copyright (C) 2019-2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+from collections import OrderedDict
+from typing import Any, cast
+
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+from torchvision.ops import SqueezeExcitation
+
+from holocron.nn import GlobalAvgPool2d
+
+from ..checkpoints import Checkpoint, _handle_legacy_pretrained
+from ..utils import _configure_model, fuse_conv_bn
+
+__all__ = ["RepViT", "repvit_m0_9", "repvit_m1_0", "repvit_m1_1"]
+
+
+def _make_divisible(value: float, divisor: int = 8) -> int:
+    rounded = max(divisor, int(value + divisor / 2) // divisor * divisor)
+    return rounded + divisor if rounded < 0.9 * value else rounded
+
+
+class _ConvNorm(nn.Sequential):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 1,
+        stride: int = 1,
+        padding: int = 0,
+        groups: int = 1,
+        bn_weight_init: float = 1.0,
+    ) -> None:
+        conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride,
+            padding,
+            groups=groups,
+            bias=False,
+        )
+        norm = nn.BatchNorm2d(out_channels)
+        super().__init__(conv, norm)
+
+        if norm.weight is not None:
+            nn.init.constant_(norm.weight, bn_weight_init)
+        if norm.bias is not None:
+            nn.init.zeros_(norm.bias)
+
+    @torch.no_grad()
+    def reparametrize(self) -> nn.Conv2d:
+        conv, norm = cast(nn.Conv2d, self[0]), cast(nn.BatchNorm2d, self[1])
+        kernel, bias = fuse_conv_bn(conv, norm)
+        fused = nn.Conv2d(
+            conv.in_channels,
+            conv.out_channels,
+            conv.kernel_size,
+            conv.stride,
+            conv.padding,
+            conv.dilation,
+            conv.groups,
+            bias=True,
+            padding_mode=conv.padding_mode,
+            device=conv.weight.device,
+            dtype=conv.weight.dtype,
+        )
+        fused.weight.copy_(kernel)
+        cast(Tensor, fused.bias).copy_(bias)
+        return fused
+
+
+class _BatchNormLinear(nn.Sequential):
+    def __init__(self, in_features: int, out_features: int) -> None:
+        norm = nn.BatchNorm1d(in_features)
+        linear = nn.Linear(in_features, out_features)
+        super().__init__(norm, linear)
+
+        nn.init.trunc_normal_(linear.weight, std=0.02)
+        if linear.bias is not None:
+            nn.init.zeros_(linear.bias)
+
+    @torch.no_grad()
+    def reparametrize(self) -> nn.Linear:
+        norm, linear = cast(nn.BatchNorm1d, self[0]), cast(nn.Linear, self[1])
+        norm_weight, norm_bias = cast(Tensor, norm.weight), cast(Tensor, norm.bias)
+        running_mean, running_var = cast(Tensor, norm.running_mean), cast(Tensor, norm.running_var)
+        scale = norm_weight / torch.sqrt(running_var + norm.eps)
+        shift = norm_bias - running_mean * scale
+        fused = nn.Linear(
+            linear.in_features,
+            linear.out_features,
+            bias=True,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+        )
+        fused.weight.copy_(linear.weight * scale.unsqueeze(0))
+        fused_bias = cast(Tensor, fused.bias)
+        fused_bias.copy_(linear.weight @ shift)
+        if linear.bias is not None:
+            fused_bias.add_(linear.bias)
+        return fused
+
+
+class _Residual(nn.Module):
+    def __init__(self, block: nn.Module) -> None:
+        super().__init__()
+        self.block = block
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x + self.block(x)
+
+
+class _RepVGGDW(nn.Module):
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv3 = _ConvNorm(channels, channels, 3, padding=1, groups=channels)
+        self.conv1 = nn.Conv2d(channels, channels, 1, groups=channels)
+        self.norm = nn.BatchNorm2d(channels)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.norm(self.conv3(x) + self.conv1(x) + x)
+
+    @torch.no_grad()
+    def reparametrize(self) -> nn.Conv2d:
+        conv3 = self.conv3.reparametrize()
+        conv3_bias, conv1_bias = cast(Tensor, conv3.bias), cast(Tensor, self.conv1.bias)
+
+        conv3.weight.add_(F.pad(self.conv1.weight, [1, 1, 1, 1]))
+        conv3.weight.add_(F.pad(torch.ones_like(self.conv1.weight), [1, 1, 1, 1]))
+        conv3_bias.add_(conv1_bias)
+
+        norm_weight, norm_bias = cast(Tensor, self.norm.weight), cast(Tensor, self.norm.bias)
+        running_mean, running_var = cast(Tensor, self.norm.running_mean), cast(Tensor, self.norm.running_var)
+        scale = norm_weight / torch.sqrt(running_var + self.norm.eps)
+        conv3.weight.mul_(scale.view(-1, 1, 1, 1))
+        conv3_bias.sub_(running_mean).mul_(scale).add_(norm_bias)
+        return conv3
+
+
+class _RepViTBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int, use_se: bool) -> None:
+        super().__init__()
+        if stride not in {1, 2}:
+            raise ValueError("`stride` is expected to be 1 or 2")
+        if stride == 1 and in_channels != out_channels:
+            raise ValueError("stride-1 blocks require matching input and output channels")
+
+        attention = SqueezeExcitation(in_channels, _make_divisible(in_channels / 4)) if use_se else nn.Identity()
+        if stride == 1:
+            self.token_mixer = nn.Sequential(_RepVGGDW(in_channels), attention)
+        else:
+            self.token_mixer = nn.Sequential(
+                _ConvNorm(in_channels, in_channels, 3, stride=2, padding=1, groups=in_channels),
+                attention,
+                _ConvNorm(in_channels, out_channels),
+            )
+
+        self.channel_mixer = _Residual(
+            nn.Sequential(
+                _ConvNorm(out_channels, 2 * out_channels),
+                nn.GELU(),
+                _ConvNorm(2 * out_channels, out_channels, bn_weight_init=0),
+            )
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.channel_mixer(self.token_mixer(x))
+
+    def reparametrize(self) -> None:
+        token_mixer = self.token_mixer
+        first = token_mixer[0]
+        if isinstance(first, (_ConvNorm, _RepVGGDW)):
+            token_mixer[0] = first.reparametrize()
+        if isinstance(token_mixer[-1], _ConvNorm):
+            token_mixer[-1] = token_mixer[-1].reparametrize()
+
+        channel_mixer = cast(nn.Sequential, self.channel_mixer.block)
+        channel_mixer[0] = cast(_ConvNorm, channel_mixer[0]).reparametrize()
+        channel_mixer[-1] = cast(_ConvNorm, channel_mixer[-1]).reparametrize()
+
+
+class RepViT(nn.Sequential):
+    """Implements RepViT as described in
+    `"RepViT: Revisiting Mobile CNN From ViT Perspective" <https://arxiv.org/abs/2307.09283>`_.
+
+    Args:
+        channels: number of output channels in each stage
+        num_blocks: number of blocks in each stage
+        num_classes: number of output classes
+        in_channels: number of input channels
+    """
+
+    def __init__(
+        self,
+        channels: list[int],
+        num_blocks: list[int],
+        num_classes: int = 10,
+        in_channels: int = 3,
+    ) -> None:
+        if len(channels) != 4 or len(num_blocks) != 4:
+            raise ValueError("`channels` and `num_blocks` are expected to contain four stages")
+
+        patch_embed = nn.Sequential(
+            _ConvNorm(in_channels, channels[0] // 2, 3, stride=2, padding=1),
+            nn.GELU(),
+            _ConvNorm(channels[0] // 2, channels[0], 3, stride=2, padding=1),
+        )
+        stages: list[nn.Sequential] = []
+        in_planes = channels[0]
+        for stage_idx, (out_planes, depth) in enumerate(zip(channels, num_blocks, strict=True)):
+            blocks: list[nn.Module] = []
+            for block_idx in range(depth):
+                stride = 2 if stage_idx > 0 and block_idx == 0 else 1
+                # Paper pattern: SE on the first block, then alternating blocks except stage ends.
+                use_se = block_idx == 0 if stage_idx == 0 else block_idx % 2 == 1 and block_idx < depth - 1
+                blocks.append(_RepViTBlock(in_planes, out_planes, stride, use_se))
+                in_planes = out_planes
+            stages.append(nn.Sequential(*blocks))
+
+        super().__init__(
+            OrderedDict([
+                ("features", nn.Sequential(patch_embed, *stages)),
+                ("pool", GlobalAvgPool2d(flatten=True)),
+                ("head", _BatchNormLinear(channels[-1], num_classes)),
+            ])
+        )
+
+    def reparametrize(self) -> None:
+        """Fuse training-time branches and batch-normalization layers for deployment."""
+        self.features: nn.Sequential
+        patch_embed = cast(nn.Sequential, self.features[0])
+        patch_embed[0] = cast(_ConvNorm, patch_embed[0]).reparametrize()
+        patch_embed[-1] = cast(_ConvNorm, patch_embed[-1]).reparametrize()
+        for stage in self.features[1:]:
+            for block in cast(nn.Sequential, stage):
+                cast(_RepViTBlock, block).reparametrize()
+        self.head = cast(_BatchNormLinear, self.head).reparametrize()
+
+
+def _repvit(
+    checkpoint: Checkpoint | None,
+    progress: bool,
+    channels: list[int],
+    num_blocks: list[int],
+    **kwargs: Any,
+) -> RepViT:
+    model = RepViT(channels, num_blocks, **kwargs)
+    return _configure_model(model, checkpoint, progress=progress)
+
+
+def repvit_m0_9(
+    pretrained: bool = False,
+    checkpoint: Checkpoint | None = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> RepViT:
+    """RepViT-M0.9 model.
+
+    Args:
+        pretrained: If True, loads the default checkpoint when one is available
+        checkpoint: If specified, sets the model parameters to the checkpoint values
+        progress: If True, displays a download progress bar
+        kwargs: keyword arguments of [`RepViT`][holocron.models.classification.repvit.RepViT]
+
+    Returns:
+        A RepViT-M0.9 model
+    """
+    checkpoint = _handle_legacy_pretrained(pretrained, checkpoint, None)
+    return _repvit(checkpoint, progress, [48, 96, 192, 384], [3, 4, 16, 3], **kwargs)
+
+
+def repvit_m1_0(
+    pretrained: bool = False,
+    checkpoint: Checkpoint | None = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> RepViT:
+    """RepViT-M1.0 model.
+
+    Args:
+        pretrained: If True, loads the default checkpoint when one is available
+        checkpoint: If specified, sets the model parameters to the checkpoint values
+        progress: If True, displays a download progress bar
+        kwargs: keyword arguments of [`RepViT`][holocron.models.classification.repvit.RepViT]
+
+    Returns:
+        A RepViT-M1.0 model
+    """
+    checkpoint = _handle_legacy_pretrained(pretrained, checkpoint, None)
+    return _repvit(checkpoint, progress, [56, 112, 224, 448], [3, 4, 16, 3], **kwargs)
+
+
+def repvit_m1_1(
+    pretrained: bool = False,
+    checkpoint: Checkpoint | None = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> RepViT:
+    """RepViT-M1.1 model.
+
+    Args:
+        pretrained: If True, loads the default checkpoint when one is available
+        checkpoint: If specified, sets the model parameters to the checkpoint values
+        progress: If True, displays a download progress bar
+        kwargs: keyword arguments of [`RepViT`][holocron.models.classification.repvit.RepViT]
+
+    Returns:
+        A RepViT-M1.1 model
+    """
+    checkpoint = _handle_legacy_pretrained(pretrained, checkpoint, None)
+    return _repvit(checkpoint, progress, [64, 128, 256, 512], [3, 4, 14, 3], **kwargs)

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -6,6 +6,7 @@
 import math
 from collections import defaultdict
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import Any, cast
 
 import matplotlib.pyplot as plt
@@ -115,6 +116,7 @@ class Trainer:
         Args:
             output_file: destination file path
         """
+        Path(output_file).parent.mkdir(parents=True, exist_ok=True)
         torch.save(
             {
                 "epoch": self.epoch,

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -77,6 +77,7 @@ def plot_samples(images, targets, num_samples=8):
 def main(args):
     print(args)
 
+    torch.manual_seed(args.seed)
     torch.backends.cudnn.benchmark = True
 
     # Data loading
@@ -276,6 +277,7 @@ def main(args):
                 "loss": "crossentropy",
                 "label_smoothing": args.label_smoothing,
                 "mixup_alpha": args.mixup_alpha,
+                "seed": args.seed,
             },
         )
 
@@ -310,6 +312,7 @@ def get_parser():
     group.add_argument("--pretrained", action="store_true", help="Use pre-trained models from the modelzoo")
     group.add_argument("--output-file", default="./checkpoints/checkpoint.pth", help="path where to save")
     group.add_argument("--resume", default="", help="resume from checkpoint")
+    group.add_argument("--seed", default=0, type=int, help="random seed")
     # Hardware
     group = parser.add_argument_group("Hardware")
     group.add_argument("--device", default=None, type=int, help="device")

--- a/scripts/eval_latency.py
+++ b/scripts/eval_latency.py
@@ -61,7 +61,7 @@ def main(args):
     # Pretrained imagenet model
     model = models.__dict__[args.arch](pretrained=args.pretrained).eval()
     # Reparametrizable models
-    if args.arch.startswith("repvgg") or args.arch.startswith("mobileone"):
+    if hasattr(model, "reparametrize"):
         model.reparametrize()
 
     # Input

--- a/scripts/export_to_onnx.py
+++ b/scripts/export_to_onnx.py
@@ -25,8 +25,8 @@ def main(args):
         state_dict = torch.load(args.checkpoint, map_location="cpu")
         model.load_state_dict(state_dict, strict=True)
 
-    # RepVGG
-    if args.arch.startswith("repvgg") or args.arch.startswith("mobileone"):
+    # Reparametrizable models
+    if hasattr(model, "reparametrize"):
         model.reparametrize()
 
     # Input

--- a/tests/test_models_classification.py
+++ b/tests/test_models_classification.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 
 from holocron.models import classification
+from holocron.models.classification.repvit import _RepVGGDW  # noqa: PLC2701
 
 
 def _test_classification_model(name, num_classes, pretrained):
@@ -64,6 +65,29 @@ def test_mobileone_reparametrize():
 
 
 @pytest.mark.parametrize(
+    ("arch", "training_params", "deployment_params"),
+    [
+        ("repvit_m0_9", 5_103_560, 5_067_056),
+        ("repvit_m1_0", 6_852_900, 6_810_312),
+        ("repvit_m1_1", 8_288_888, 8_244_312),
+    ],
+)
+def test_repvit_reparametrize(arch, training_params, deployment_params):
+    x = torch.rand((1, 3, 64, 64))
+    model = classification.__dict__[arch](pretrained=False, num_classes=1000).eval()
+    assert sum(p.numel() for p in model.parameters()) == training_params
+
+    with torch.no_grad():
+        out = model(x)
+    model.reparametrize()
+
+    assert sum(p.numel() for p in model.parameters()) == deployment_params
+    assert not any(isinstance(mod, (nn.BatchNorm1d, nn.BatchNorm2d, _RepVGGDW)) for mod in model.modules())
+    with torch.no_grad():
+        torch.testing.assert_close(out, model(x), rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.parametrize(
     ("arch", "pretrained"),
     [
         ("darknet24", True),
@@ -106,6 +130,9 @@ def test_mobileone_reparametrize():
         ("mobileone_s1", False),
         ("mobileone_s2", False),
         ("mobileone_s3", False),
+        ("repvit_m0_9", False),
+        ("repvit_m1_0", False),
+        ("repvit_m1_1", False),
     ],
 )
 def test_classification_model(arch, pretrained):
@@ -129,10 +156,13 @@ def test_classification_model(arch, pretrained):
         "repvgg_a0",
         "convnext_atto",
         "mobileone_s0",
+        "repvit_m0_9",
     ],
 )
 def test_classification_onnx_export(arch, tmpdir_factory):
     model = classification.__dict__[arch](pretrained=False, num_classes=10).eval()
+    if hasattr(model, "reparametrize"):
+        model.reparametrize()
     tmp_path = Path(str(tmpdir_factory.mktemp("onnx"))).joinpath(f"{arch}.onnx")
     img_tensor = torch.rand((1, 3, 224, 224))
     with torch.no_grad():

--- a/tests/test_models_classification.py
+++ b/tests/test_models_classification.py
@@ -74,11 +74,14 @@ def test_mobileone_reparametrize():
 )
 def test_repvit_reparametrize(arch, training_params, deployment_params):
     x = torch.rand((1, 3, 64, 64))
-    model = classification.__dict__[arch](pretrained=False, num_classes=1000).eval()
+    model = classification.__dict__[arch](pretrained=False, num_classes=1000)
     assert sum(p.numel() for p in model.parameters()) == training_params
 
     with torch.no_grad():
+        model(torch.rand((4, 3, 64, 64)))
+        model.eval()
         out = model(x)
+    model.reparametrize()
     model.reparametrize()
 
     assert sum(p.numel() for p in model.parameters()) == deployment_params

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -297,7 +297,7 @@ def _test_trainer(
 
 def test_classification_trainer(tmpdir_factory):
     folder = tmpdir_factory.mktemp("checkpoints")
-    file_path = str(folder.join("tmp.pt"))
+    file_path = str(folder.join("nested", "tmp.pt"))
 
     num_it = 100
     batch_size = 8


### PR DESCRIPTION
# What does this PR do?

Adds RepViT-M0.9, RepViT-M1.0, and RepViT-M1.1 classification models with Holocron-style factories and deployment reparameterization.

- preserves configurable class counts and feature/classifier separation
- fuses RepViT training branches and batch-normalization layers for deployment
- enables capability-based reparameterization in ONNX and latency scripts
- adds forward/backward, parameter-count, fusion-equivalence, and ONNX coverage
- documents paper evidence and the pending controlled CUDA benchmark gate
- adds a shared seed option to the reference classifier training command

No dependency added.

Refs #499. This PR does not close the issue: controlled Imagenette CUDA runs and the MobileOne-S2 rerun remain pending.

## Adversarial review follow-up

Seven independent review harnesses were run. The consolidated high-ROI changes are included:

- fusion equivalence now uses non-default BatchNorm running statistics
- reparameterization is idempotent and tested with a second call
- documentation lists the measured pre/post-fusion parameter counts
- the model docstring uses the project markdown-link convention

SE sizing, SE placement, and the biased 1x1 depthwise branch were rechecked against the pinned official RepViT source and retained.

## Validation

- [x] Changed-file pre-commit hooks
- [x] RepViT tests on Python 3.12: 7 passed, including ONNX export
- [x] Documentation build
- [x] Diff whitespace check

## Before submitting

- [x] Discussed in #499
- [x] Contribution guidelines followed
- [x] Documentation updated
- [x] Necessary tests added