### PR TITLE
feat(utils): add synthetic text rendering

### DIFF
--- a/docs/docs/reference/utils.md
+++ b/docs/docs/reference/utils.md
@@ -2,6 +2,56 @@
 
 `holocron.utils` provides some utilities for general usage.
 
+## Synthetic text rendering
+
+Load fonts once, then render tight grayscale masks for characters or complete
+sequences. Font discovery and the optional download happen before the sampling
+loop; resizing and stochastic effects remain regular TorchVision transforms.
+
+```python
+from itertools import cycle
+
+import matplotlib.pyplot as plt
+from PIL import ImageFont
+from torchvision.transforms import v2
+
+from holocron.utils import find_fonts, render_text
+
+font_paths = find_fonts("OCR-42é")[:3]
+# For a reproducible five-family OFL pack instead:
+# from holocron.utils import download_fonts
+# font_paths = download_fonts()
+fonts = [ImageFont.truetype(path, 48) for path in font_paths]
+
+augment = v2.Compose([
+    v2.Pad(4, fill=0),
+    v2.Resize(48),
+    v2.RandomAffine(degrees=8, translate=(0.05, 0.05), scale=(0.9, 1.1), fill=0),
+    v2.GaussianBlur(kernel_size=3, sigma=(0.1, 1.0)),
+    v2.RandomInvert(p=0.2),
+])
+
+fig, axes = plt.subplots(2, 3, constrained_layout=True)
+for ax, text, font in zip(axes.flat, ["A", "OCR-42"] * 3, cycle(fonts)):
+    ax.imshow(augment(render_text(text, font)), cmap="gray", vmin=0, vmax=255)
+    ax.axis("off")
+plt.show()
+```
+
+The downloadable fonts come from the
+[Google Fonts repository](https://github.com/google/fonts) under the SIL Open
+Font License.
+
+::: holocron.utils
+    options:
+        heading_level: 3
+        show_root_heading: false
+        show_root_toc_entry: false
+        members:
+            - render_text
+            - find_fonts
+            - download_fonts
+
 ## Miscellaneous
 
 ::: holocron.utils

--- a/docs/docs/reference/utils.md
+++ b/docs/docs/reference/utils.md
@@ -5,22 +5,29 @@
 ## Synthetic text rendering
 
 Load fonts once, then render tight grayscale masks for characters or complete
-sequences. Font discovery and the optional download happen before the sampling
+sequences. Font discovery and corpus preparation happen before the sampling
 loop; resizing and stochastic effects remain regular TorchVision transforms.
+
+The library performs no network access. To prepare the pinned starter manifest
+from the repository, run:
+
+```console
+uv run --python 3.12 scripts/prepare_fonts.py --output /tmp/holocron-fonts
+```
+
+Use `find_fonts(text)` instead when only installed system fonts are needed.
 
 ```python
 from itertools import cycle
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 from PIL import ImageFont
 from torchvision.transforms import v2
 
-from holocron.utils import find_fonts, render_text
+from holocron.utils import render_text
 
-font_paths = find_fonts("OCR-42é")[:3]
-# For a reproducible five-family OFL pack instead:
-# from holocron.utils import download_fonts
-# font_paths = download_fonts()
+font_paths = tuple(str(path) for path in sorted(Path("/tmp/holocron-fonts").glob("*.ttf")))[:3]
 fonts = [ImageFont.truetype(path, 48) for path in font_paths]
 
 augment = v2.Compose([
@@ -50,7 +57,6 @@ Font License.
         members:
             - render_text
             - find_fonts
-            - download_fonts
 
 ## Miscellaneous
 

--- a/holocron/utils/__init__.py
+++ b/holocron/utils/__init__.py
@@ -1,3 +1,3 @@
-from . import data, fonts
+from . import data
 from .fonts import *
 from .misc import *

--- a/holocron/utils/__init__.py
+++ b/holocron/utils/__init__.py
@@ -1,2 +1,3 @@
-from . import data
+from . import data, fonts
+from .fonts import *
 from .misc import *

--- a/holocron/utils/fonts.py
+++ b/holocron/utils/fonts.py
@@ -3,49 +3,14 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-import hashlib
 from functools import lru_cache
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from urllib.parse import quote
 
 from matplotlib import font_manager
 from matplotlib.ft2font import FT2Font
 from PIL import Image, ImageFont
-from torch.hub import download_url_to_file, get_dir
 
-__all__ = ["download_fonts", "find_fonts", "render_text"]
-
-
-_GOOGLE_FONTS_REVISION = "038b637da7b3fd956a4ed93ffc607c3d5e4ce172"
-_GOOGLE_FONTS_URL = f"https://raw.githubusercontent.com/google/fonts/{_GOOGLE_FONTS_REVISION}"
-_FONT_MANIFEST = (
-    (
-        "Montserrat.ttf",
-        "ofl/montserrat/Montserrat[wght].ttf",
-        "0f7b311b2f3279e4eef9b2f968bcdbab6e28f4daeb1f049f4f278a902bcd82f7",
-    ),
-    (
-        "Lora.ttf",
-        "ofl/lora/Lora[wght].ttf",
-        "822a6621ccbe8d97d20ac88c1c41f5615c9c2c202eaa75f272cd452aac6475a7",
-    ),
-    (
-        "RobotoMono.ttf",
-        "ofl/robotomono/RobotoMono[wght].ttf",
-        "66a80e79d17e4c7cabd162e2916578a4cc08fd19eef6e2a643305eae9c567b2b",
-    ),
-    (
-        "Caveat.ttf",
-        "ofl/caveat/Caveat[wght].ttf",
-        "0bdb6b660482d31531b3945849fba5916b3ef8695da7024a9e6b9ee3c4157988",
-    ),
-    (
-        "BebasNeue.ttf",
-        "ofl/bebasneue/BebasNeue-Regular.ttf",
-        "08e4623805102d819f58601e46e345648846075e363b2ceb23313c2d1c83ec73",
-    ),
-)
+__all__ = ["find_fonts", "render_text"]
 
 
 def _validate_color(name: str, color: int) -> None:
@@ -143,44 +108,3 @@ def find_fonts(text: str | None = None) -> tuple[str, ...]:
             continue
         available.append(font_path)
     return tuple(available)
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as file:
-        while chunk := file.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def download_fonts(cache_dir: str | Path | None = None, *, progress: bool = True) -> tuple[str, ...]:
-    """Download a small SHA-256-verified Latin OCR font collection.
-
-    Args:
-        cache_dir: destination directory, or the Holocron Torch Hub cache by default
-        progress: whether to display download progress
-
-    Returns:
-        downloaded font paths in deterministic manifest order
-    """
-    root = Path(cache_dir) if cache_dir is not None else Path(get_dir()) / "holocron" / "fonts"
-    root.mkdir(parents=True, exist_ok=True)
-
-    font_paths = []
-    for filename, source_path, expected_sha256 in _FONT_MANIFEST:
-        destination = root / filename
-        if destination.is_file() and _sha256(destination) == expected_sha256:
-            font_paths.append(str(destination))
-            continue
-
-        url = f"{_GOOGLE_FONTS_URL}/{quote(source_path, safe='/')}"
-        with NamedTemporaryFile(dir=root, prefix=f".{filename}.", delete=False) as file:
-            temporary = Path(file.name)
-        try:
-            download_url_to_file(url, str(temporary), hash_prefix=expected_sha256, progress=progress)
-            temporary.replace(destination)
-        finally:
-            temporary.unlink(missing_ok=True)
-        font_paths.append(str(destination))
-
-    return tuple(font_paths)

--- a/holocron/utils/fonts.py
+++ b/holocron/utils/fonts.py
@@ -49,7 +49,9 @@ _FONT_MANIFEST = (
 
 
 def _validate_color(name: str, color: int) -> None:
-    if isinstance(color, bool) or not isinstance(color, int) or not 0 <= color <= 255:
+    if isinstance(color, bool) or not isinstance(color, int):
+        raise TypeError(f"{name} must be an integer")
+    if not 0 <= color <= 255:
         raise ValueError(f"{name} must be an integer between 0 and 255")
 
 
@@ -160,9 +162,6 @@ def download_fonts(cache_dir: str | Path | None = None, *, progress: bool = True
 
     Returns:
         downloaded font paths in deterministic manifest order
-
-    Raises:
-        RuntimeError: if a downloaded file fails SHA-256 verification
     """
     root = Path(cache_dir) if cache_dir is not None else Path(get_dir()) / "holocron" / "fonts"
     root.mkdir(parents=True, exist_ok=True)
@@ -179,8 +178,6 @@ def download_fonts(cache_dir: str | Path | None = None, *, progress: bool = True
             temporary = Path(file.name)
         try:
             download_url_to_file(url, str(temporary), hash_prefix=expected_sha256, progress=progress)
-            if _sha256(temporary) != expected_sha256:
-                raise RuntimeError(f"invalid SHA-256 for downloaded font: {filename}")
             temporary.replace(destination)
         finally:
             temporary.unlink(missing_ok=True)

--- a/holocron/utils/fonts.py
+++ b/holocron/utils/fonts.py
@@ -1,0 +1,189 @@
+# Copyright (C) 2019-2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+import hashlib
+from functools import lru_cache
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from urllib.parse import quote
+
+from matplotlib import font_manager
+from matplotlib.ft2font import FT2Font
+from PIL import Image, ImageFont
+from torch.hub import download_url_to_file, get_dir
+
+__all__ = ["download_fonts", "find_fonts", "render_text"]
+
+
+_GOOGLE_FONTS_REVISION = "038b637da7b3fd956a4ed93ffc607c3d5e4ce172"
+_GOOGLE_FONTS_URL = f"https://raw.githubusercontent.com/google/fonts/{_GOOGLE_FONTS_REVISION}"
+_FONT_MANIFEST = (
+    (
+        "Montserrat.ttf",
+        "ofl/montserrat/Montserrat[wght].ttf",
+        "0f7b311b2f3279e4eef9b2f968bcdbab6e28f4daeb1f049f4f278a902bcd82f7",
+    ),
+    (
+        "Lora.ttf",
+        "ofl/lora/Lora[wght].ttf",
+        "822a6621ccbe8d97d20ac88c1c41f5615c9c2c202eaa75f272cd452aac6475a7",
+    ),
+    (
+        "RobotoMono.ttf",
+        "ofl/robotomono/RobotoMono[wght].ttf",
+        "66a80e79d17e4c7cabd162e2916578a4cc08fd19eef6e2a643305eae9c567b2b",
+    ),
+    (
+        "Caveat.ttf",
+        "ofl/caveat/Caveat[wght].ttf",
+        "0bdb6b660482d31531b3945849fba5916b3ef8695da7024a9e6b9ee3c4157988",
+    ),
+    (
+        "BebasNeue.ttf",
+        "ofl/bebasneue/BebasNeue-Regular.ttf",
+        "08e4623805102d819f58601e46e345648846075e363b2ceb23313c2d1c83ec73",
+    ),
+)
+
+
+def _validate_color(name: str, color: int) -> None:
+    if isinstance(color, bool) or not isinstance(color, int) or not 0 <= color <= 255:
+        raise ValueError(f"{name} must be an integer between 0 and 255")
+
+
+def render_text(
+    text: str,
+    font: ImageFont.FreeTypeFont,
+    *,
+    padding: int = 0,
+    background_color: int = 0,
+    text_color: int = 255,
+) -> Image.Image:
+    """Render text as a tight grayscale image.
+
+    Args:
+        text: non-empty Unicode text to render
+        font: preloaded font used for rasterization
+        padding: number of background pixels added on every side
+        background_color: grayscale background value
+        text_color: grayscale text value
+
+    Returns:
+        rendered grayscale image
+
+    Raises:
+        TypeError: if `text`, `font`, or `padding` has an invalid type
+        ValueError: if the arguments cannot produce a visible image
+    """
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    if not text:
+        raise ValueError("text must not be empty")
+    if not isinstance(font, ImageFont.FreeTypeFont):
+        raise TypeError("font must be a PIL.ImageFont.FreeTypeFont")
+    if isinstance(padding, bool) or not isinstance(padding, int):
+        raise TypeError("padding must be an integer")
+    if padding < 0:
+        raise ValueError("padding must be non-negative")
+    _validate_color("background_color", background_color)
+    _validate_color("text_color", text_color)
+    if background_color == text_color:
+        raise ValueError("background_color and text_color must differ")
+
+    mask, _ = font.getmask2(text, mode="L")
+    # Pillow has no public zero-copy wrapper for its rasterized ImagingCore mask.
+    image = Image.Image()._new(mask)  # noqa: SLF001
+    if image.getbbox() is None:
+        raise ValueError("text does not contain a visible glyph")
+
+    if padding == 0 and background_color == 0 and text_color == 255:
+        return image
+
+    output = Image.new("L", (image.width + 2 * padding, image.height + 2 * padding), background_color)
+    output.paste(text_color, (padding, padding), image)
+    return output
+
+
+@lru_cache(maxsize=128)
+def find_fonts(text: str | None = None) -> tuple[str, ...]:
+    """Find loadable system fonts that cover the requested text.
+
+    Matplotlib-bundled fonts are included so discovery does not depend on the
+    host having user-installed fonts.
+
+    Args:
+        text: optional text whose non-whitespace code points must be supported
+
+    Returns:
+        sorted, deduplicated font paths
+
+    Raises:
+        TypeError: if `text` is neither a string nor `None`
+    """
+    if text is not None and not isinstance(text, str):
+        raise TypeError("text must be a string or None")
+
+    required_codepoints = {ord(char) for char in text or "" if not char.isspace()}
+    font_paths = {str(entry.fname) for entry in font_manager.fontManager.ttflist}
+    font_paths.update(font_manager.findSystemFonts())
+
+    available = []
+    for font_path in sorted(font_paths):
+        if not Path(font_path).is_file():
+            continue
+        try:
+            ImageFont.truetype(font_path, 10)
+            if required_codepoints and not required_codepoints.issubset(FT2Font(font_path).get_charmap()):
+                continue
+        except (OSError, RuntimeError, ValueError):
+            continue
+        available.append(font_path)
+    return tuple(available)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_fonts(cache_dir: str | Path | None = None, *, progress: bool = True) -> tuple[str, ...]:
+    """Download a small SHA-256-verified Latin OCR font collection.
+
+    Args:
+        cache_dir: destination directory, or the Holocron Torch Hub cache by default
+        progress: whether to display download progress
+
+    Returns:
+        downloaded font paths in deterministic manifest order
+
+    Raises:
+        RuntimeError: if a downloaded file fails SHA-256 verification
+    """
+    root = Path(cache_dir) if cache_dir is not None else Path(get_dir()) / "holocron" / "fonts"
+    root.mkdir(parents=True, exist_ok=True)
+
+    font_paths = []
+    for filename, source_path, expected_sha256 in _FONT_MANIFEST:
+        destination = root / filename
+        if destination.is_file() and _sha256(destination) == expected_sha256:
+            font_paths.append(str(destination))
+            continue
+
+        url = f"{_GOOGLE_FONTS_URL}/{quote(source_path, safe='/')}"
+        with NamedTemporaryFile(dir=root, prefix=f".{filename}.", delete=False) as file:
+            temporary = Path(file.name)
+        try:
+            download_url_to_file(url, str(temporary), hash_prefix=expected_sha256, progress=progress)
+            if _sha256(temporary) != expected_sha256:
+                raise RuntimeError(f"invalid SHA-256 for downloaded font: {filename}")
+            temporary.replace(destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+        font_paths.append(str(destination))
+
+    return tuple(font_paths)

--- a/references/fonts/latin-starter.json
+++ b/references/fonts/latin-starter.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "sources": {
+    "google-fonts": {
+      "base_url": "https://raw.githubusercontent.com/google/fonts",
+      "revision": "038b637da7b3fd956a4ed93ffc607c3d5e4ce172"
+    }
+  },
+  "fonts": [
+    {
+      "family": "Montserrat",
+      "style": "Variable",
+      "source": "google-fonts",
+      "path": "ofl/montserrat/Montserrat[wght].ttf",
+      "filename": "Montserrat.ttf",
+      "sha256": "0f7b311b2f3279e4eef9b2f968bcdbab6e28f4daeb1f049f4f278a902bcd82f7",
+      "license": "OFL-1.1"
+    },
+    {
+      "family": "Lora",
+      "style": "Variable",
+      "source": "google-fonts",
+      "path": "ofl/lora/Lora[wght].ttf",
+      "filename": "Lora.ttf",
+      "sha256": "822a6621ccbe8d97d20ac88c1c41f5615c9c2c202eaa75f272cd452aac6475a7",
+      "license": "OFL-1.1"
+    },
+    {
+      "family": "Roboto Mono",
+      "style": "Variable",
+      "source": "google-fonts",
+      "path": "ofl/robotomono/RobotoMono[wght].ttf",
+      "filename": "RobotoMono.ttf",
+      "sha256": "66a80e79d17e4c7cabd162e2916578a4cc08fd19eef6e2a643305eae9c567b2b",
+      "license": "OFL-1.1"
+    },
+    {
+      "family": "Caveat",
+      "style": "Variable",
+      "source": "google-fonts",
+      "path": "ofl/caveat/Caveat[wght].ttf",
+      "filename": "Caveat.ttf",
+      "sha256": "0bdb6b660482d31531b3945849fba5916b3ef8695da7024a9e6b9ee3c4157988",
+      "license": "OFL-1.1"
+    },
+    {
+      "family": "Bebas Neue",
+      "style": "Regular",
+      "source": "google-fonts",
+      "path": "ofl/bebasneue/BebasNeue-Regular.ttf",
+      "filename": "BebasNeue.ttf",
+      "sha256": "08e4623805102d819f58601e46e345648846075e363b2ceb23313c2d1c83ec73",
+      "license": "OFL-1.1"
+    }
+  ]
+}

--- a/scripts/prepare_fonts.py
+++ b/scripts/prepare_fonts.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2019-2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+"""Prepare a verified local font directory from a manifest."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from urllib.parse import quote
+
+from torch.hub import download_url_to_file
+
+_DEFAULT_MANIFEST = Path(__file__).resolve().parents[1] / "references" / "fonts" / "latin-starter.json"
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def prepare_fonts(manifest_path, output_dir, progress=True):
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("version") != 1:
+        raise ValueError("unsupported font manifest version")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    font_paths = []
+
+    for font in manifest["fonts"]:
+        source = manifest["sources"][font["source"]]
+        filename = font["filename"]
+        checksum = font["sha256"].lower()
+        if Path(filename).name != filename:
+            raise ValueError(f"invalid font filename: {filename}")
+        try:
+            valid_checksum = len(bytes.fromhex(checksum)) == 32
+        except ValueError:
+            valid_checksum = False
+        if not valid_checksum:
+            raise ValueError(f"invalid SHA-256 for {filename}")
+
+        destination = output_dir / filename
+        if destination.is_file() and _sha256(destination) == checksum:
+            font_paths.append(destination)
+            continue
+
+        url = "/".join((source["base_url"].rstrip("/"), source["revision"], quote(font["path"], safe="/")))
+        with NamedTemporaryFile(dir=output_dir, prefix=f".{filename}.", delete=False) as file:
+            temporary = Path(file.name)
+        try:
+            download_url_to_file(url, str(temporary), hash_prefix=checksum, progress=progress)
+            temporary.replace(destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+        font_paths.append(destination)
+
+    return tuple(font_paths)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--manifest", type=Path, default=_DEFAULT_MANIFEST, help="Font manifest to prepare")
+    parser.add_argument("--output", type=Path, required=True, help="Destination font directory")
+    parser.add_argument("--quiet", action="store_true", help="Disable download progress")
+    args = parser.parse_args()
+
+    for font_path in prepare_fonts(args.manifest, args.output, progress=not args.quiet):
+        print(font_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,6 +125,8 @@ def test_render_text_invalid_options(dejavu_sans):
         utils.render_text("A", dejavu_sans, padding=-1)
     with pytest.raises(ValueError, match="between 0 and 255"):
         utils.render_text("A", dejavu_sans, text_color=256)
+    with pytest.raises(TypeError, match="must be an integer"):
+        utils.render_text("A", dejavu_sans, text_color=True)
     with pytest.raises(ValueError, match="must differ"):
         utils.render_text("A", dejavu_sans, background_color=0, text_color=0)
     with pytest.raises(TypeError, match="FreeTypeFont"):
@@ -171,10 +173,10 @@ def test_download_fonts_rejects_bad_checksum(monkeypatch, tmp_path):
     monkeypatch.setattr(font_utils, "_FONT_MANIFEST", (("Test.ttf", "ofl/test/Test.ttf", checksum),))
 
     def _download(url, destination, hash_prefix, progress):
-        del url, hash_prefix, progress
-        Path(destination).write_bytes(b"unexpected")
+        del url, destination, hash_prefix, progress
+        raise RuntimeError("invalid hash value")
 
     monkeypatch.setattr(font_utils, "download_url_to_file", _download)
-    with pytest.raises(RuntimeError, match="invalid SHA-256"):
+    with pytest.raises(RuntimeError, match="invalid hash value"):
         font_utils.download_fonts(tmp_path)
     assert not (tmp_path / "Test.ttf").exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -10,6 +11,7 @@ from PIL import Image, ImageFont
 
 from holocron import utils
 from holocron.utils import fonts as font_utils
+from scripts import prepare_fonts as font_prep
 
 
 @pytest.fixture(scope="module")
@@ -144,39 +146,72 @@ def test_find_fonts_uses_bundled_fonts(monkeypatch):
     font_utils.find_fonts.cache_clear()
 
 
-def test_download_fonts_cache(monkeypatch, tmp_path):
+@pytest.fixture
+def font_manifest(tmp_path):
     payload = b"font payload"
     checksum = hashlib.sha256(payload).hexdigest()
-    monkeypatch.setattr(font_utils, "_FONT_MANIFEST", (("Test.ttf", "ofl/test/Test.ttf", checksum),))
+    manifest = {
+        "version": 1,
+        "sources": {"test": {"base_url": "https://example.com/fonts", "revision": "abc123"}},
+        "fonts": [
+            {
+                "family": "Test",
+                "style": "Regular",
+                "source": "test",
+                "path": "Test.ttf",
+                "filename": "Test.ttf",
+                "sha256": checksum,
+                "license": "OFL-1.1",
+            }
+        ],
+    }
+    manifest_path = tmp_path / "fonts.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest_path, payload
+
+
+def test_prepare_fonts_cache(font_manifest, monkeypatch, tmp_path):
+    manifest_path, payload = font_manifest
     calls = []
 
     def _download(url, destination, hash_prefix, progress):
         calls.append((url, Path(destination), hash_prefix, progress))
         Path(destination).write_bytes(payload)
 
-    monkeypatch.setattr(font_utils, "download_url_to_file", _download)
-    expected = (str(tmp_path / "Test.ttf"),)
+    monkeypatch.setattr(font_prep, "download_url_to_file", _download)
+    output_dir = tmp_path / "output"
+    expected = (output_dir / "Test.ttf",)
 
-    assert font_utils.download_fonts(tmp_path, progress=False) == expected
-    assert font_utils.download_fonts(tmp_path, progress=False) == expected
+    assert font_prep.prepare_fonts(manifest_path, output_dir, progress=False) == expected
+    assert font_prep.prepare_fonts(manifest_path, output_dir, progress=False) == expected
     assert len(calls) == 1
     assert calls[0][1].name.startswith(".Test.ttf.")
 
-    (tmp_path / "Test.ttf").write_bytes(b"corrupt")
-    assert font_utils.download_fonts(tmp_path, progress=False) == expected
+    expected[0].write_bytes(b"corrupt")
+    assert font_prep.prepare_fonts(manifest_path, output_dir, progress=False) == expected
     assert len(calls) == 2
-    assert (tmp_path / "Test.ttf").read_bytes() == payload
+    assert expected[0].read_bytes() == payload
 
 
-def test_download_fonts_rejects_bad_checksum(monkeypatch, tmp_path):
-    checksum = hashlib.sha256(b"expected").hexdigest()
-    monkeypatch.setattr(font_utils, "_FONT_MANIFEST", (("Test.ttf", "ofl/test/Test.ttf", checksum),))
+def test_prepare_fonts_rejects_bad_checksum(font_manifest, monkeypatch, tmp_path):
+    manifest_path, _ = font_manifest
 
     def _download(url, destination, hash_prefix, progress):
         del url, destination, hash_prefix, progress
         raise RuntimeError("invalid hash value")
 
-    monkeypatch.setattr(font_utils, "download_url_to_file", _download)
+    monkeypatch.setattr(font_prep, "download_url_to_file", _download)
+    output_dir = tmp_path / "output"
     with pytest.raises(RuntimeError, match="invalid hash value"):
-        font_utils.download_fonts(tmp_path)
-    assert not (tmp_path / "Test.ttf").exists()
+        font_prep.prepare_fonts(manifest_path, output_dir)
+    assert not (output_dir / "Test.ttf").exists()
+
+
+def test_prepare_fonts_rejects_unknown_version(font_manifest, tmp_path):
+    manifest_path, _ = font_manifest
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["version"] = 2
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported font manifest version"):
+        font_prep.prepare_fonts(manifest_path, tmp_path / "output")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,20 @@
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
-from PIL import Image
+from matplotlib import font_manager
+from PIL import Image, ImageFont
 
 from holocron import utils
+from holocron.utils import fonts as font_utils
+
+
+@pytest.fixture(scope="module")
+def dejavu_sans():
+    return ImageFont.truetype(font_manager.findfont("DejaVu Sans"), 32)
 
 
 def test_mixup():
@@ -69,3 +80,101 @@ def test_parallel(arr, fn, expected, progress, num_threads):
 def test_find_image_size():
     ds = [(Image.fromarray(np.full((16, 16, 3), 255, dtype=np.uint8)), 0) for _ in range(100)]
     utils.find_image_size(ds, block=False)
+
+
+@pytest.mark.parametrize("text", ["A", "é", "OCR-42", " A ", "A A"])
+def test_render_text(dejavu_sans, text):
+    image = utils.render_text(text, dejavu_sans)
+    assert image.mode == "L"
+    assert image.width > 0
+    assert image.height > 0
+    assert image.getbbox() is not None
+    assert image.tobytes() == utils.render_text(text, dejavu_sans).tobytes()
+
+
+def test_render_text_layout(dejavu_sans):
+    character = utils.render_text("A", dejavu_sans)
+    sequence = utils.render_text("OCR-42", dejavu_sans)
+    padded = utils.render_text("A", dejavu_sans, padding=3)
+    inverted = utils.render_text("é", dejavu_sans, padding=1, background_color=255, text_color=0)
+
+    assert sequence.width > character.width
+    assert padded.size == (character.width + 6, character.height + 6)
+    assert padded.crop((3, 3, padded.width - 3, padded.height - 3)).tobytes() == character.tobytes()
+    assert inverted.getpixel((0, 0)) == 255
+    assert inverted.getextrema()[0] < 255
+
+
+@pytest.mark.parametrize(
+    ("args", "error", "match"),
+    [
+        (("",), ValueError, "must not be empty"),
+        (("   ",), ValueError, "visible glyph"),
+        ((123,), TypeError, "must be a string"),
+    ],
+)
+def test_render_text_invalid_text(dejavu_sans, args, error, match):
+    with pytest.raises(error, match=match):
+        utils.render_text(*args, dejavu_sans)
+
+
+def test_render_text_invalid_options(dejavu_sans):
+    with pytest.raises(TypeError, match="padding must be an integer"):
+        utils.render_text("A", dejavu_sans, padding=1.5)
+    with pytest.raises(ValueError, match="padding must be non-negative"):
+        utils.render_text("A", dejavu_sans, padding=-1)
+    with pytest.raises(ValueError, match="between 0 and 255"):
+        utils.render_text("A", dejavu_sans, text_color=256)
+    with pytest.raises(ValueError, match="must differ"):
+        utils.render_text("A", dejavu_sans, background_color=0, text_color=0)
+    with pytest.raises(TypeError, match="FreeTypeFont"):
+        utils.render_text("A", ImageFont.load_default_imagefont())
+
+
+def test_find_fonts_uses_bundled_fonts(monkeypatch):
+    bundled_font = font_manager.findfont("DejaVu Sans")
+    monkeypatch.setattr(font_manager, "findSystemFonts", list)
+    monkeypatch.setattr(font_manager.fontManager, "ttflist", [SimpleNamespace(fname=bundled_font)])
+    font_utils.find_fonts.cache_clear()
+
+    assert font_utils.find_fonts("é") == (bundled_font,)
+    assert font_utils.find_fonts(chr(0x10FFFF)) == ()
+    font_utils.find_fonts.cache_clear()
+
+
+def test_download_fonts_cache(monkeypatch, tmp_path):
+    payload = b"font payload"
+    checksum = hashlib.sha256(payload).hexdigest()
+    monkeypatch.setattr(font_utils, "_FONT_MANIFEST", (("Test.ttf", "ofl/test/Test.ttf", checksum),))
+    calls = []
+
+    def _download(url, destination, hash_prefix, progress):
+        calls.append((url, Path(destination), hash_prefix, progress))
+        Path(destination).write_bytes(payload)
+
+    monkeypatch.setattr(font_utils, "download_url_to_file", _download)
+    expected = (str(tmp_path / "Test.ttf"),)
+
+    assert font_utils.download_fonts(tmp_path, progress=False) == expected
+    assert font_utils.download_fonts(tmp_path, progress=False) == expected
+    assert len(calls) == 1
+    assert calls[0][1].name.startswith(".Test.ttf.")
+
+    (tmp_path / "Test.ttf").write_bytes(b"corrupt")
+    assert font_utils.download_fonts(tmp_path, progress=False) == expected
+    assert len(calls) == 2
+    assert (tmp_path / "Test.ttf").read_bytes() == payload
+
+
+def test_download_fonts_rejects_bad_checksum(monkeypatch, tmp_path):
+    checksum = hashlib.sha256(b"expected").hexdigest()
+    monkeypatch.setattr(font_utils, "_FONT_MANIFEST", (("Test.ttf", "ofl/test/Test.ttf", checksum),))
+
+    def _download(url, destination, hash_prefix, progress):
+        del url, hash_prefix, progress
+        Path(destination).write_bytes(b"unexpected")
+
+    monkeypatch.setattr(font_utils, "download_url_to_file", _download)
+    with pytest.raises(RuntimeError, match="invalid SHA-256"):
+        font_utils.download_fonts(tmp_path)
+    assert not (tmp_path / "Test.ttf").exists()


### PR DESCRIPTION
## Summary

- add a generic zero-copy render_text primitive for characters and complete sequences
- discover loadable system fonts with optional Unicode coverage filtering
- keep the library network-free; pinned URLs, revisions, checksums, styles, and licenses live in references/fonts/latin-starter.json, consumed by an offline preparation CLI
- document preloaded-font rendering followed by composable TorchVision transforms

## Prepare and smoke-test the font corpus

Prepare the versioned starter manifest from the repository:

```console
uv run --python 3.12 scripts/prepare_fonts.py --output /tmp/holocron-fonts --quiet
```

Then preload the resulting paths and measure only the rendering hot path:

```console
uv run --python 3.12 python - <<'PY'
from pathlib import Path
from time import perf_counter

from PIL import ImageFont

from holocron.utils import render_text

paths = sorted(Path('/tmp/holocron-fonts').glob('*.ttf'))
fonts = [(path.stem, ImageFont.truetype(path, 64)) for path in paths]
for font_name, font in fonts:
    image = render_text('OCR-42é', font, padding=6)
    output = Path('/tmp') / f'{font_name}-OCR-42e.png'
    image.save(output)
    print(font_name, image.mode, image.size, output)

font = fonts[0][1]
for text, iterations in (('A', 20_000), ('OCR-42é', 10_000)):
    start = perf_counter()
    for _ in range(iterations):
        render_text(text, font)
    print(f'{text!r}: {iterations / (perf_counter() - start):,.0f} renders/s')
PY
```

Observed in a local macOS run: all five sequence outputs were grayscale L images with distinct family shapes and rectangular geometry; A reached 55,257 renders/s and OCR-42é reached 8,121 renders/s. These are repeatable local measurements, not CI thresholds.

## Validation

- uv run --python 3.12 --extra test pytest -q --no-cov tests/test_utils.py (20 passed)
- uv run --python 3.12 --extra quality make quality
- uv run --python 3.12 --extra docs make build-docs
- real manifest preparation: five verified files downloaded, preloaded, and rendered

## Adversarial review

Five independent review harnesses completed. Their main consensus was to remove redundant checksum work while preserving atomic replacement and the zero-copy Pillow mask wrapper. Follow-up design review moved all font provisioning and provenance metadata out of holocron.utils and into the reference manifest plus preparation CLI.