### PR TITLE
feat(references): add synthetic character training

### DIFF
--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -24,6 +24,49 @@ From there, you can run your training with the following command
 python train.py imagenette2-320/ --arch darknet53 --lr 5e-3 -b 32 -j 16 --epochs 40 --opt adamp --sched onecycle
 ```
 
+## Synthetic character classification
+
+Prepare the checksum-verified starter fonts once:
+
+```shell
+uv run --python 3.12 scripts/prepare_fonts.py \
+  --output /tmp/holocron-fonts --quiet
+```
+
+Generate and inspect fresh augmented samples without starting training:
+
+```shell
+uv run --python 3.12 --extra training \
+  references/classification/train_characters.py \
+  --font-dir /tmp/holocron-fonts \
+  --manifest references/fonts/latin-starter.json \
+  --show-samples /tmp/character-samples.png
+```
+
+Run a small CPU smoke training job:
+
+```shell
+uv run --python 3.12 --extra training \
+  references/classification/train_characters.py \
+  --font-dir /tmp/holocron-fonts \
+  --manifest references/fonts/latin-starter.json \
+  --device cpu --workers 0 --epochs 1 \
+  --image-size 32 --render-size 64 \
+  --samples-per-epoch 256 --batch-size 32
+```
+
+Measure live-image DataLoader throughput after worker warm-up:
+
+```shell
+uv run --python 3.12 --extra training \
+  references/classification/train_characters.py \
+  --font-dir /tmp/holocron-fonts \
+  --manifest references/fonts/latin-starter.json \
+  --benchmark-loader
+```
+
+`--render-size` controls glyph rasterization resolution; `--image-size` controls the final model input resolution. To expand the corpus, prepare another local manifest and directory and pass those paths to the same script—no Python changes are needed. Training itself never downloads data or fonts.
+
 
 
 ## Personal leaderboard

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -67,8 +67,6 @@ uv run --python 3.12 --extra training \
 
 `--render-size` controls glyph rasterization resolution; `--image-size` controls the final model input resolution. To expand the corpus, prepare another local manifest and directory and pass those paths to the same script—no Python changes are needed. Training itself never downloads data or fonts.
 
-
-
 ## Personal leaderboard
 
 The updated list of available checkpoints can be found in the [documentation](https://frgfm.github.io/Holocron/latest/models.html#classification).

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -67,6 +67,8 @@ uv run --python 3.12 --extra training \
 
 `--render-size` controls glyph rasterization resolution; `--image-size` controls the final model input resolution. To expand the corpus, prepare another local manifest and directory and pass those paths to the same script—no Python changes are needed. Training itself never downloads data or fonts.
 
+`--arch alexnet` reuses TorchVision's AlexNet feature stack with a compact task head; use image size 64 or larger.
+
 ## Personal leaderboard
 
 The updated list of available checkpoints can be found in the [documentation](https://frgfm.github.io/Holocron/latest/models.html#classification).

--- a/references/classification/train_characters.py
+++ b/references/classification/train_characters.py
@@ -25,6 +25,7 @@ from matplotlib.ft2font import FT2Font
 from PIL import Image, ImageFont
 from torch import Tensor, nn
 from torch.utils.data import DataLoader, Dataset, RandomSampler, Sampler, SequentialSampler
+from torchvision.models import alexnet
 from torchvision.transforms import v2 as T
 from torchvision.transforms.v2 import functional as F
 from torchvision.transforms.v2.functional import InterpolationMode, to_pil_image
@@ -35,12 +36,13 @@ from holocron.utils import find_fonts, render_text
 
 DEFAULT_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 FONT_EXTENSIONS = {".otf", ".ttc", ".ttf"}
-MODEL_NAMES = tuple(
-    sorted(
+MODEL_NAMES = (
+    "alexnet",
+    *sorted(
         name
         for name, value in vars(classification).items()
         if name.islower() and not name.startswith("_") and callable(value)
-    )
+    ),
 )
 
 
@@ -420,6 +422,15 @@ def resolve_device(device: str) -> int | None:
     return index
 
 
+def build_model(name: str, num_classes: int) -> nn.Module:
+    if name == "alexnet":
+        model = alexnet(weights=None, num_classes=num_classes)
+        model.avgpool = nn.AdaptiveAvgPool2d(1)
+        model.classifier = nn.Linear(256, num_classes)
+        return model
+    return getattr(classification, name)(False, num_classes=num_classes)
+
+
 def _json_value(value: Any) -> Any:
     return str(value) if isinstance(value, Path) else value
 
@@ -566,6 +577,8 @@ def get_parser() -> argparse.ArgumentParser:
 def main(args: argparse.Namespace) -> None:
     if args.render_size < args.image_size:
         raise ValueError("--render-size must be at least --image-size")
+    if args.arch == "alexnet" and args.image_size < 63:
+        raise ValueError("AlexNet requires --image-size of at least 63")
     torch.manual_seed(args.seed)
     gpu = resolve_device(args.device)
     if args.amp and gpu is None:
@@ -609,7 +622,7 @@ def main(args: argparse.Namespace) -> None:
         pin_memory=gpu is not None,
     )
 
-    model = getattr(classification, args.arch)(False, num_classes=len(alphabet))
+    model = build_model(args.arch, len(alphabet))
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
     checkpoint_path = args.output_dir / "checkpoint.pth"

--- a/references/classification/train_characters.py
+++ b/references/classification/train_characters.py
@@ -1,0 +1,619 @@
+# Copyright (C) 2019-2026, François-Guillaume Fernandez.
+#
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+"""Train a character classifier from live synthetic images."""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import time
+import warnings
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import torch
+from matplotlib.ft2font import FT2Font
+from PIL import Image, ImageFont
+from torch import Tensor, nn
+from torch.utils.data import DataLoader, Dataset, RandomSampler, Sampler, SequentialSampler
+from torchvision.transforms import v2 as T
+from torchvision.transforms.v2 import functional as F
+from torchvision.transforms.v2.functional import InterpolationMode, to_pil_image
+
+from holocron.models import classification
+from holocron.trainer import ClassificationTrainer
+from holocron.utils import find_fonts, render_text
+
+DEFAULT_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+FONT_EXTENSIONS = {".otf", ".ttc", ".ttf"}
+MODEL_NAMES = tuple(
+    sorted(
+        name
+        for name, value in vars(classification).items()
+        if name.islower() and not name.startswith("_") and callable(value)
+    )
+)
+
+
+@dataclass(frozen=True)
+class FontRecord:
+    """Resolved local font and its optional manifest metadata."""
+
+    path: Path
+    family: str
+    style: str | None = None
+    sha256: str | None = None
+    source: str | None = None
+
+
+class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
+    """Map-style dataset that renders one live character image per sample."""
+
+    def __init__(
+        self,
+        alphabet: Sequence[str],
+        fonts: Sequence[FontRecord | str | Path],
+        render_size: int,
+        samples_per_epoch: int,
+        transform: Callable[[Image.Image], Tensor],
+        *,
+        deterministic: bool = False,
+    ) -> None:
+        self.classes = tuple(alphabet)
+        if not self.classes:
+            raise ValueError("alphabet must not be empty")
+        if any(not isinstance(character, str) or len(character) != 1 for character in self.classes):
+            raise ValueError("alphabet entries must each be one Unicode code point")
+        if len(set(self.classes)) != len(self.classes):
+            raise ValueError("alphabet must not contain duplicate characters")
+        if any(not character.isprintable() or character.isspace() for character in self.classes):
+            raise ValueError("alphabet must contain visible characters only")
+        if isinstance(render_size, bool) or not isinstance(render_size, int) or render_size <= 0:
+            raise ValueError("render_size must be a positive integer")
+        if isinstance(samples_per_epoch, bool) or not isinstance(samples_per_epoch, int) or samples_per_epoch <= 0:
+            raise ValueError("samples_per_epoch must be a positive integer")
+        if not callable(transform):
+            raise TypeError("transform must be callable")
+
+        records = tuple(
+            record
+            if isinstance(record, FontRecord)
+            else FontRecord(Path(record).expanduser().resolve(), str(Path(record).expanduser().resolve()))
+            for record in fonts
+        )
+        if not records:
+            raise ValueError("fonts must not be empty")
+        if len({record.path for record in records}) != len(records):
+            raise ValueError("fonts must not contain duplicate paths")
+
+        compatible: list[list[FontRecord]] = [[] for _ in self.classes]
+        for record in records:
+            if not record.path.is_file():
+                raise FileNotFoundError(f"font file does not exist: {record.path}")
+            try:
+                codepoints = FT2Font(str(record.path)).get_charmap()
+                font = ImageFont.truetype(str(record.path), render_size)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise ValueError(f"unable to load font: {record.path}") from exc
+
+            for class_index, character in enumerate(self.classes):
+                if ord(character) not in codepoints:
+                    continue
+                try:
+                    render_text(character, font)
+                except ValueError:
+                    continue
+                compatible[class_index].append(record)
+
+        self._font_groups: list[tuple[tuple[FontRecord, ...], ...]] = []
+        self._font_choices: list[tuple[FontRecord, ...]] = []
+        for character, choices in zip(self.classes, compatible, strict=True):
+            if not choices:
+                raise ValueError(f"no visible font supports character {character!r}")
+            families: dict[str, list[FontRecord]] = {}
+            for record in choices:
+                families.setdefault(record.family, []).append(record)
+            groups = tuple(tuple(styles) for styles in families.values())
+            self._font_groups.append(groups)
+            self._font_choices.append(tuple(record for group in groups for record in group))
+
+        self.class_to_idx = {character: index for index, character in enumerate(self.classes)}
+        self.render_size = render_size
+        self.samples_per_epoch = samples_per_epoch
+        self.transform = transform
+        self.deterministic = deterministic
+        self._font_cache: dict[Path, ImageFont.FreeTypeFont] = {}
+        self._font_cache_pid: int | None = os.getpid()
+
+    def __len__(self) -> int:
+        return self.samples_per_epoch
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = vars(self).copy()
+        state["_font_cache"] = {}
+        state["_font_cache_pid"] = None
+        return state
+
+    def _select_font(self, index: int, class_index: int) -> FontRecord:
+        if self.deterministic:
+            choices = self._font_choices[class_index]
+            return choices[(index // len(self.classes)) % len(choices)]
+
+        families = self._font_groups[class_index]
+        family = families[torch.randint(len(families), ()).item()]
+        return family[torch.randint(len(family), ()).item()]
+
+    def _get_font(self, path: Path) -> ImageFont.FreeTypeFont:
+        process_id = os.getpid()
+        if process_id != self._font_cache_pid:
+            self._font_cache.clear()
+            self._font_cache_pid = process_id
+        font = self._font_cache.get(path)
+        if font is None:
+            font = ImageFont.truetype(str(path), self.render_size)
+            self._font_cache[path] = font
+        return font
+
+    def __getitem__(self, index: int) -> tuple[Tensor, int]:
+        class_index = index % len(self.classes)
+        record = self._select_font(index, class_index)
+        image = render_text(self.classes[class_index], self._get_font(record.path))
+        return self.transform(image), class_index
+
+
+def _sha256(path: Path) -> str:
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def resolve_font_records(
+    alphabet: Sequence[str], font_dir: Path | None, manifest_path: Path | None
+) -> tuple[tuple[FontRecord, ...], dict[str, Any] | None]:
+    """Resolve local font files and optional manifest provenance.
+
+    Returns:
+        font records and optional manifest metadata
+
+    Raises:
+        FileNotFoundError: if a manifest font is missing
+        NotADirectoryError: if the requested font directory does not exist
+        TypeError: if a manifest source has an invalid type
+        ValueError: if the inputs, manifest, checksums, or discovered corpus are invalid
+    """
+    if manifest_path is not None and font_dir is None:
+        raise ValueError("--manifest requires --font-dir")
+
+    if manifest_path is not None:
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if manifest.get("version") != 1:
+                raise ValueError("unsupported font manifest version")
+            sources = manifest["sources"]
+            font_entries = manifest["fonts"]
+        except (KeyError, TypeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"invalid font manifest: {manifest_path}") from exc
+        if not isinstance(sources, dict) or not isinstance(font_entries, list):
+            raise TypeError(f"invalid font manifest structure: {manifest_path}")
+        if any(not isinstance(source, dict) for source in sources.values()):
+            raise TypeError(f"invalid font source in manifest: {manifest_path}")
+
+        records = []
+        for entry in font_entries:
+            try:
+                filename = entry["filename"]
+                family = entry["family"]
+                expected_hash = entry["sha256"].lower()
+                source = entry["source"]
+            except (AttributeError, KeyError, TypeError) as exc:
+                raise ValueError(f"invalid font entry in manifest: {manifest_path}") from exc
+            if not all(isinstance(value, str) for value in (filename, family, expected_hash, source)):
+                raise ValueError(f"invalid font entry in manifest: {manifest_path}")
+            if source not in sources:
+                raise ValueError(f"unknown font source in manifest: {source}")
+            try:
+                valid_checksum = len(bytes.fromhex(expected_hash)) == 32
+            except ValueError:
+                valid_checksum = False
+            if not valid_checksum:
+                raise ValueError(f"invalid font checksum: {filename}")
+            if Path(filename).name != filename:
+                raise ValueError(f"invalid font filename: {filename}")
+            path = (font_dir / filename).resolve()  # type: ignore[operator]
+            if not path.is_file():
+                raise FileNotFoundError(f"font file does not exist: {path}")
+            actual_hash = _sha256(path)
+            if actual_hash != expected_hash:
+                raise ValueError(f"font checksum mismatch: {path}")
+            records.append(FontRecord(path, family, entry.get("style"), actual_hash, source))
+
+        manifest_info = {
+            "path": str(manifest_path.resolve()),
+            "version": manifest["version"],
+            "source_revisions": {name: source.get("revision") for name, source in sources.items()},
+        }
+        return tuple(records), manifest_info
+
+    if font_dir is not None:
+        if not font_dir.is_dir():
+            raise NotADirectoryError(f"font directory does not exist: {font_dir}")
+        paths = sorted(
+            path.resolve() for path in font_dir.rglob("*") if path.is_file() and path.suffix.lower() in FONT_EXTENSIONS
+        )
+    else:
+        paths = [Path(path).resolve() for path in find_fonts("".join(alphabet))]
+
+    if not paths:
+        raise ValueError("no local font files found")
+    return tuple(FontRecord(path, str(path), sha256=_sha256(path)) for path in paths), None
+
+
+def square_pad(image: Image.Image, margin: int) -> Image.Image:
+    """Add a margin and center a tight glyph in a square without resizing it.
+
+    Returns:
+        square grayscale image
+    """
+    image = F.pad(image, [margin, margin, margin, margin], fill=0)
+    width, height = image.size
+    delta = abs(width - height)
+    padding = [0, delta // 2, 0, delta - delta // 2] if width > height else [delta // 2, 0, delta - delta // 2, 0]
+    return F.pad(image, padding, fill=0)
+
+
+def build_transforms(args: argparse.Namespace) -> tuple[T.Compose, T.Compose]:
+    finalize = [
+        T.Resize((args.image_size, args.image_size), interpolation=InterpolationMode.LANCZOS, antialias=True),
+        T.Grayscale(num_output_channels=3),
+        T.ToImage(),
+        T.ToDtype(torch.float32, scale=True),
+        T.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+    ]
+    pad = partial(square_pad, margin=args.margin)
+    train_transform = T.Compose([
+        pad,
+        T.RandomAffine(
+            args.rotation,
+            translate=(args.translate, args.translate),
+            scale=(1 - args.scale_jitter, 1 + args.scale_jitter),
+            shear=args.shear,
+            interpolation=InterpolationMode.BILINEAR,
+            fill=0,
+        ),
+        T.RandomApply([T.GaussianBlur(3, sigma=(0.1, 1.0))], p=args.blur_prob),
+        T.RandomInvert(p=args.invert_prob),
+        *finalize,
+    ])
+    return train_transform, T.Compose([pad, *finalize])
+
+
+def _generator(seed: int) -> torch.Generator:
+    return torch.Generator().manual_seed(seed)
+
+
+def build_loader(
+    dataset: SyntheticCharacterDataset,
+    batch_size: int,
+    workers: int,
+    sampler: Sampler[int],
+    seed: int,
+    *,
+    pin_memory: bool,
+) -> DataLoader:
+    kwargs: dict[str, Any] = {
+        "batch_size": batch_size,
+        "drop_last": False,
+        "sampler": sampler,
+        "num_workers": workers,
+        "pin_memory": pin_memory,
+        "generator": _generator(seed),
+    }
+    if workers > 0:
+        kwargs.update(persistent_workers=True, prefetch_factor=2)
+    return DataLoader(dataset, **kwargs)
+
+
+def save_sample_grid(loader: DataLoader, classes: Sequence[str], output_path: Path) -> None:
+    images, targets = next(iter(loader))
+    count = min(32, len(targets))
+    columns = min(8, count)
+    rows = math.ceil(count / columns)
+    figure, axes = plt.subplots(rows, columns, figsize=(2 * columns, 2 * rows), squeeze=False)
+    for index, axis in enumerate(axes.flat):
+        axis.axis("off")
+        if index >= count:
+            continue
+        image = (images[index] * 0.5 + 0.5).clamp(0, 1)
+        axis.imshow(to_pil_image(image))
+        axis.set_title(classes[targets[index].item()])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)
+    print(f"Saved {count} samples to {output_path}")
+
+
+def benchmark_loader(loader: DataLoader, warmup_batches: int, measured_batches: int) -> None:
+    required_batches = warmup_batches + measured_batches
+    if required_batches > len(loader):
+        raise ValueError(
+            f"benchmark needs {required_batches} batches, but the loader only has {len(loader)}; "
+            "increase --samples-per-epoch"
+        )
+
+    iterator = iter(loader)
+    for _ in range(warmup_batches):
+        next(iterator)
+    start = time.perf_counter()
+    sample_count = 0
+    image_size = None
+    for _ in range(measured_batches):
+        images, targets = next(iterator)
+        sample_count += len(targets)
+        image_size = images.shape[-1]
+    elapsed = time.perf_counter() - start
+    dataset = loader.dataset
+    print(f"Hardware: {platform.processor() or platform.machine()} ({platform.platform()})")
+    print(
+        f"Loader: workers={loader.num_workers}, batch_size={loader.batch_size}, "
+        f"render_size={dataset.render_size}, image_size={image_size}, base_mask_cache=disabled"
+    )
+    print(
+        f"Measured {sample_count} samples after {warmup_batches} warm-up batches and "
+        f"{measured_batches} measured batches: {sample_count / elapsed:.1f} samples/s"
+    )
+
+
+def resolve_device(device: str) -> int | None:
+    if device == "auto":
+        return 0 if torch.cuda.is_available() else None
+    if device == "cpu":
+        return None
+    if device == "cuda":
+        index = 0
+    elif device.startswith("cuda:") and device[5:].isdigit():
+        index = int(device[5:])
+    else:
+        raise ValueError("--device must be 'auto', 'cpu', 'cuda', or 'cuda:N'")
+    if not torch.cuda.is_available():
+        raise ValueError("CUDA was requested but is not available")
+    if index >= torch.cuda.device_count():
+        raise ValueError(f"CUDA device index is out of range: {index}")
+    return index
+
+
+def _json_value(value: Any) -> Any:
+    return str(value) if isinstance(value, Path) else value
+
+
+def write_provenance(
+    output_path: Path,
+    args: argparse.Namespace,
+    dataset: SyntheticCharacterDataset,
+    records: Sequence[FontRecord],
+    manifest_info: dict[str, Any] | None,
+) -> None:
+    font_root = args.font_dir.resolve() if args.font_dir is not None else None
+    fonts = []
+    for record in records:
+        try:
+            path = record.path.relative_to(font_root) if font_root is not None else record.path
+        except ValueError:
+            path = record.path
+        fonts.append({
+            "path": str(path),
+            "family": record.family,
+            "style": record.style,
+            "sha256": record.sha256,
+            "source": record.source,
+        })
+    payload = {
+        "version": 1,
+        "alphabet": list(dataset.classes),
+        "class_to_index": dataset.class_to_idx,
+        "seed": args.seed,
+        "image_size": args.image_size,
+        "render_size": args.render_size,
+        "architecture": args.arch,
+        "configuration": {key: _json_value(value) for key, value in vars(args).items()},
+        "fonts": fonts,
+        "manifest": manifest_info,
+        "base_mask_cache": False,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def validate_resume_metadata(resume_path: Path, architecture: str, classes: Sequence[str]) -> None:
+    metadata_path = resume_path.with_suffix(".json")
+    if not metadata_path.is_file():
+        warnings.warn(
+            f"resume metadata not found at {metadata_path}; architecture and alphabet cannot be verified",
+            stacklevel=2,
+        )
+        return
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if metadata.get("architecture") != architecture:
+        raise ValueError("resume checkpoint architecture does not match --arch")
+    if metadata.get("alphabet") != list(classes):
+        raise ValueError("resume checkpoint alphabet does not match --alphabet")
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer")
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative number")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive number")
+    return parsed
+
+
+def _probability(value: str) -> float:
+    parsed = float(value)
+    if not 0 <= parsed <= 1:
+        raise argparse.ArgumentTypeError("expected a probability between 0 and 1")
+    return parsed
+
+
+def _scale_jitter(value: str) -> float:
+    parsed = float(value)
+    if not 0 <= parsed < 1:
+        raise argparse.ArgumentTypeError("expected a scale jitter between 0 and 1")
+    return parsed
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    data = parser.add_argument_group("Data and model")
+    data.add_argument("--font-dir", type=Path, help="local font directory; system fonts are used when omitted")
+    data.add_argument("--manifest", type=Path, help="optional version-1 font manifest")
+    data.add_argument("--alphabet", default=DEFAULT_ALPHABET, help="ordered character classes")
+    data.add_argument("--arch", choices=MODEL_NAMES, default="convnext_atto", help="classifier architecture")
+    data.add_argument("--image-size", type=_positive_int, default=64, help="square model input size")
+    data.add_argument("--render-size", type=_positive_int, default=128, help="font rasterization size")
+    data.add_argument("--samples-per-epoch", type=_positive_int, default=62_000)
+    data.add_argument("--validation-fonts-per-class", type=_positive_int, default=5)
+
+    loading = parser.add_argument_group("Data loading")
+    loading.add_argument("--batch-size", type=_positive_int, default=256)
+    loading.add_argument("--workers", type=_nonnegative_int, default=min(os.cpu_count() or 1, 8))
+    loading.add_argument("--seed", type=int, default=0)
+
+    augmentation = parser.add_argument_group("Augmentation")
+    augmentation.add_argument("--margin", type=_nonnegative_int, default=8)
+    augmentation.add_argument("--rotation", type=_nonnegative_float, default=8.0)
+    augmentation.add_argument("--translate", type=_probability, default=0.08)
+    augmentation.add_argument("--scale-jitter", type=_scale_jitter, default=0.1)
+    augmentation.add_argument("--shear", type=_nonnegative_float, default=5.0)
+    augmentation.add_argument("--blur-prob", type=_probability, default=0.1)
+    augmentation.add_argument("--invert-prob", type=_probability, default=0.5)
+
+    optimization = parser.add_argument_group("Optimization")
+    optimization.add_argument("--epochs", type=_positive_int, default=10)
+    optimization.add_argument("--lr", type=_positive_float, default=1e-3)
+    optimization.add_argument("--weight-decay", type=_nonnegative_float, default=1e-4)
+    optimization.add_argument("--device", default="auto", help="auto, cpu, cuda, or cuda:N")
+    optimization.add_argument("--amp", action="store_true", help="use CUDA automatic mixed precision")
+    optimization.add_argument("--output-dir", type=Path, default=Path("checkpoints/characters"))
+    optimization.add_argument("--resume", type=Path, help="checkpoint to resume")
+
+    actions = parser.add_argument_group("Actions")
+    action = actions.add_mutually_exclusive_group()
+    action.add_argument("--show-samples", type=Path, metavar="PATH", help="save an augmented grid and exit")
+    action.add_argument("--benchmark-loader", action="store_true", help="benchmark live image loading and exit")
+    action.add_argument("--check-setup", action="store_true", help="run the trainer's one-batch overfit check")
+    actions.add_argument("--benchmark-warmup-batches", type=_nonnegative_int, default=10)
+    actions.add_argument("--benchmark-batches", type=_positive_int, default=100)
+    return parser
+
+
+def main(args: argparse.Namespace) -> None:
+    if args.render_size < args.image_size:
+        raise ValueError("--render-size must be at least --image-size")
+    torch.manual_seed(args.seed)
+    gpu = resolve_device(args.device)
+    if args.amp and gpu is None:
+        raise ValueError("--amp requires a CUDA device")
+
+    alphabet = tuple(args.alphabet)
+    records, manifest_info = resolve_font_records(alphabet, args.font_dir, args.manifest)
+    train_transform, val_transform = build_transforms(args)
+    train_set = SyntheticCharacterDataset(alphabet, records, args.render_size, args.samples_per_epoch, train_transform)
+    train_sampler = RandomSampler(train_set, generator=_generator(args.seed))
+    train_loader = build_loader(
+        train_set,
+        min(args.batch_size, 32) if args.show_samples is not None else args.batch_size,
+        args.workers,
+        train_sampler,
+        args.seed + 1,
+        pin_memory=gpu is not None,
+    )
+
+    if args.show_samples is not None:
+        save_sample_grid(train_loader, train_set.classes, args.show_samples)
+        return
+    if args.benchmark_loader:
+        benchmark_loader(train_loader, args.benchmark_warmup_batches, args.benchmark_batches)
+        return
+
+    val_set = SyntheticCharacterDataset(
+        alphabet,
+        records,
+        args.render_size,
+        len(alphabet) * args.validation_fonts_per_class,
+        val_transform,
+        deterministic=True,
+    )
+    val_loader = build_loader(
+        val_set,
+        args.batch_size,
+        args.workers,
+        SequentialSampler(val_set),
+        args.seed + 2,
+        pin_memory=gpu is not None,
+    )
+
+    model = getattr(classification, args.arch)(False, num_classes=len(alphabet))
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    checkpoint_path = args.output_dir / "checkpoint.pth"
+    checkpoint_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
+
+    def save_metadata(_metrics: dict[str, float]) -> None:
+        nonlocal checkpoint_mtime
+        current_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
+        if current_mtime != checkpoint_mtime:
+            write_provenance(args.output_dir / "checkpoint.json", args, train_set, records, manifest_info)
+            checkpoint_mtime = current_mtime
+
+    trainer = ClassificationTrainer(
+        model,
+        train_loader,
+        val_loader,
+        criterion,
+        optimizer,
+        gpu,
+        str(checkpoint_path),
+        amp=args.amp,
+        on_epoch_end=save_metadata,
+    )
+
+    if args.resume is not None:
+        validate_resume_metadata(args.resume, args.arch, train_set.classes)
+        trainer.load(torch.load(args.resume, map_location="cpu"))
+    if args.check_setup:
+        trainer.check_setup(lr=args.lr, num_it=100)
+        return
+
+    trainer.fit_n_epochs(args.epochs, args.lr, sched_type="onecycle")
+
+
+if __name__ == "__main__":
+    main(get_parser().parse_args())

--- a/references/classification/train_characters.py
+++ b/references/classification/train_characters.py
@@ -1,5 +1,5 @@
-# Copyright (C) 2019-2026, François-Guillaume Fernandez.
-#
+# Copyright (C) 2026, François-Guillaume Fernandez.
+
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
@@ -14,7 +14,7 @@ import platform
 import time
 import warnings
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -55,6 +55,80 @@ class FontRecord:
     source: str | None = None
 
 
+def _validate_alphabet(alphabet: Sequence[str]) -> tuple[str, ...]:
+    classes = tuple(alphabet)
+    if not classes:
+        raise ValueError("alphabet must not be empty")
+    if any(not isinstance(character, str) or len(character) != 1 for character in classes):
+        raise ValueError("alphabet entries must each be one Unicode code point")
+    if len(set(classes)) != len(classes):
+        raise ValueError("alphabet must not contain duplicate characters")
+    if any(not character.isprintable() or character.isspace() for character in classes):
+        raise ValueError("alphabet must contain visible characters only")
+    return classes
+
+
+def _as_font_record(record: FontRecord | str | Path) -> FontRecord:
+    if isinstance(record, FontRecord):
+        return record
+    path = Path(record).expanduser().resolve()
+    return FontRecord(path, str(path))
+
+
+def _inspect_fonts(
+    classes: Sequence[str], fonts: Sequence[FontRecord | str | Path], render_size: int
+) -> tuple[tuple[FontRecord, ...], list[list[FontRecord]]]:
+    records = tuple(_as_font_record(record) for record in fonts)
+    if not records:
+        raise ValueError("fonts must not be empty")
+    if len({record.path for record in records}) != len(records):
+        raise ValueError("fonts must not contain duplicate paths")
+
+    compatible: list[list[FontRecord]] = [[] for _ in classes]
+    validated_records = []
+    for record in records:
+        if not record.path.is_file():
+            raise FileNotFoundError(f"font file does not exist: {record.path}")
+        try:
+            font_info = FT2Font(str(record.path))
+            codepoints = font_info.get_charmap()
+            font = ImageFont.truetype(str(record.path), render_size)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ValueError(f"unable to load font: {record.path}") from exc
+
+        resolved_record = replace(record, family=font_info.family_name, style=font_info.style_name)
+        validated_records.append(resolved_record)
+        for class_index, character in enumerate(classes):
+            if ord(character) not in codepoints:
+                continue
+            try:
+                render_text(character, font)
+            except ValueError:
+                continue
+            compatible[class_index].append(resolved_record)
+    return tuple(validated_records), compatible
+
+
+def _group_fonts(
+    classes: Sequence[str], records: Sequence[FontRecord], compatible: Sequence[Sequence[FontRecord]]
+) -> tuple[list[tuple[tuple[FontRecord, ...], ...]], list[tuple[FontRecord, ...]], tuple[FontRecord, ...]]:
+    font_groups = []
+    font_choices = []
+    for character, choices in zip(classes, compatible, strict=True):
+        if not choices:
+            raise ValueError(f"no visible font supports character {character!r}")
+        families: dict[str, list[FontRecord]] = {}
+        for record in choices:
+            families.setdefault(record.family, []).append(record)
+        groups = tuple(tuple(styles) for styles in families.values())
+        font_groups.append(groups)
+        font_choices.append(tuple(record for group in groups for record in group))
+
+    selected_paths = {record.path for choices in compatible for record in choices}
+    selected_records = tuple(record for record in records if record.path in selected_paths)
+    return font_groups, font_choices, selected_records
+
+
 class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
     """Map-style dataset that renders one live character image per sample."""
 
@@ -68,15 +142,7 @@ class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
         *,
         deterministic: bool = False,
     ) -> None:
-        self.classes = tuple(alphabet)
-        if not self.classes:
-            raise ValueError("alphabet must not be empty")
-        if any(not isinstance(character, str) or len(character) != 1 for character in self.classes):
-            raise ValueError("alphabet entries must each be one Unicode code point")
-        if len(set(self.classes)) != len(self.classes):
-            raise ValueError("alphabet must not contain duplicate characters")
-        if any(not character.isprintable() or character.isspace() for character in self.classes):
-            raise ValueError("alphabet must contain visible characters only")
+        self.classes = _validate_alphabet(alphabet)
         if isinstance(render_size, bool) or not isinstance(render_size, int) or render_size <= 0:
             raise ValueError("render_size must be a positive integer")
         if isinstance(samples_per_epoch, bool) or not isinstance(samples_per_epoch, int) or samples_per_epoch <= 0:
@@ -84,48 +150,8 @@ class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
         if not callable(transform):
             raise TypeError("transform must be callable")
 
-        records = tuple(
-            record
-            if isinstance(record, FontRecord)
-            else FontRecord(Path(record).expanduser().resolve(), str(Path(record).expanduser().resolve()))
-            for record in fonts
-        )
-        if not records:
-            raise ValueError("fonts must not be empty")
-        if len({record.path for record in records}) != len(records):
-            raise ValueError("fonts must not contain duplicate paths")
-
-        compatible: list[list[FontRecord]] = [[] for _ in self.classes]
-        for record in records:
-            if not record.path.is_file():
-                raise FileNotFoundError(f"font file does not exist: {record.path}")
-            try:
-                codepoints = FT2Font(str(record.path)).get_charmap()
-                font = ImageFont.truetype(str(record.path), render_size)
-            except (OSError, RuntimeError, ValueError) as exc:
-                raise ValueError(f"unable to load font: {record.path}") from exc
-
-            for class_index, character in enumerate(self.classes):
-                if ord(character) not in codepoints:
-                    continue
-                try:
-                    render_text(character, font)
-                except ValueError:
-                    continue
-                compatible[class_index].append(record)
-
-        self._font_groups: list[tuple[tuple[FontRecord, ...], ...]] = []
-        self._font_choices: list[tuple[FontRecord, ...]] = []
-        for character, choices in zip(self.classes, compatible, strict=True):
-            if not choices:
-                raise ValueError(f"no visible font supports character {character!r}")
-            families: dict[str, list[FontRecord]] = {}
-            for record in choices:
-                families.setdefault(record.family, []).append(record)
-            groups = tuple(tuple(styles) for styles in families.values())
-            self._font_groups.append(groups)
-            self._font_choices.append(tuple(record for group in groups for record in group))
-
+        records, compatible = _inspect_fonts(self.classes, fonts, render_size)
+        self._font_groups, self._font_choices, self.fonts = _group_fonts(self.classes, records, compatible)
         self.class_to_idx = {character: index for index, character in enumerate(self.classes)}
         self.render_size = render_size
         self.samples_per_epoch = samples_per_epoch
@@ -175,6 +201,40 @@ def _sha256(path: Path) -> str:
         return hashlib.file_digest(stream, "sha256").hexdigest()
 
 
+def _manifest_font_records(
+    font_dir: Path, manifest_path: Path, sources: dict[str, Any], font_entries: Sequence[Any]
+) -> tuple[FontRecord, ...]:
+    records = []
+    for entry in font_entries:
+        try:
+            filename = entry["filename"]
+            family = entry["family"]
+            expected_hash = entry["sha256"].lower()
+            source = entry["source"]
+        except (AttributeError, KeyError, TypeError) as exc:
+            raise ValueError(f"invalid font entry in manifest: {manifest_path}") from exc
+        if not all(isinstance(value, str) for value in (filename, family, expected_hash, source)):
+            raise ValueError(f"invalid font entry in manifest: {manifest_path}")
+        if source not in sources:
+            raise ValueError(f"unknown font source in manifest: {source}")
+        try:
+            valid_checksum = len(bytes.fromhex(expected_hash)) == 32
+        except ValueError:
+            valid_checksum = False
+        if not valid_checksum:
+            raise ValueError(f"invalid font checksum: {filename}")
+        if Path(filename).name != filename:
+            raise ValueError(f"invalid font filename: {filename}")
+        path = (font_dir / filename).resolve()
+        if not path.is_file():
+            raise FileNotFoundError(f"font file does not exist: {path}")
+        actual_hash = _sha256(path)
+        if actual_hash != expected_hash:
+            raise ValueError(f"font checksum mismatch: {path}")
+        records.append(FontRecord(path, family, entry.get("style"), actual_hash, source))
+    return tuple(records)
+
+
 def resolve_font_records(
     alphabet: Sequence[str], font_dir: Path | None, manifest_path: Path | None
 ) -> tuple[tuple[FontRecord, ...], dict[str, Any] | None]:
@@ -184,15 +244,13 @@ def resolve_font_records(
         font records and optional manifest metadata
 
     Raises:
-        FileNotFoundError: if a manifest font is missing
         NotADirectoryError: if the requested font directory does not exist
         TypeError: if a manifest source has an invalid type
         ValueError: if the inputs, manifest, checksums, or discovered corpus are invalid
     """
-    if manifest_path is not None and font_dir is None:
-        raise ValueError("--manifest requires --font-dir")
-
     if manifest_path is not None:
+        if font_dir is None:
+            raise ValueError("--manifest requires --font-dir")
         try:
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             if manifest.get("version") != 1:
@@ -206,41 +264,13 @@ def resolve_font_records(
         if any(not isinstance(source, dict) for source in sources.values()):
             raise TypeError(f"invalid font source in manifest: {manifest_path}")
 
-        records = []
-        for entry in font_entries:
-            try:
-                filename = entry["filename"]
-                family = entry["family"]
-                expected_hash = entry["sha256"].lower()
-                source = entry["source"]
-            except (AttributeError, KeyError, TypeError) as exc:
-                raise ValueError(f"invalid font entry in manifest: {manifest_path}") from exc
-            if not all(isinstance(value, str) for value in (filename, family, expected_hash, source)):
-                raise ValueError(f"invalid font entry in manifest: {manifest_path}")
-            if source not in sources:
-                raise ValueError(f"unknown font source in manifest: {source}")
-            try:
-                valid_checksum = len(bytes.fromhex(expected_hash)) == 32
-            except ValueError:
-                valid_checksum = False
-            if not valid_checksum:
-                raise ValueError(f"invalid font checksum: {filename}")
-            if Path(filename).name != filename:
-                raise ValueError(f"invalid font filename: {filename}")
-            path = (font_dir / filename).resolve()  # type: ignore[operator]
-            if not path.is_file():
-                raise FileNotFoundError(f"font file does not exist: {path}")
-            actual_hash = _sha256(path)
-            if actual_hash != expected_hash:
-                raise ValueError(f"font checksum mismatch: {path}")
-            records.append(FontRecord(path, family, entry.get("style"), actual_hash, source))
-
+        records = _manifest_font_records(font_dir, manifest_path, sources, font_entries)
         manifest_info = {
             "path": str(manifest_path.resolve()),
             "version": manifest["version"],
             "source_revisions": {name: source.get("revision") for name, source in sources.items()},
         }
-        return tuple(records), manifest_info
+        return records, manifest_info
 
     if font_dir is not None:
         if not font_dir.is_dir():
@@ -253,7 +283,7 @@ def resolve_font_records(
 
     if not paths:
         raise ValueError("no local font files found")
-    return tuple(FontRecord(path, str(path), sha256=_sha256(path)) for path in paths), None
+    return tuple(FontRecord(path, str(path)) for path in paths), None
 
 
 def square_pad(image: Image.Image, margin: int) -> Image.Image:
@@ -364,7 +394,7 @@ def benchmark_loader(loader: DataLoader, warmup_batches: int, measured_batches: 
     print(f"Hardware: {platform.processor() or platform.machine()} ({platform.platform()})")
     print(
         f"Loader: workers={loader.num_workers}, batch_size={loader.batch_size}, "
-        f"render_size={dataset.render_size}, image_size={image_size}, base_mask_cache=disabled"
+        f"render_size={dataset.render_size}, image_size={image_size}, font_cache=worker-local"
     )
     print(
         f"Measured {sample_count} samples after {warmup_batches} warm-up batches and "
@@ -412,7 +442,7 @@ def write_provenance(
             "path": str(path),
             "family": record.family,
             "style": record.style,
-            "sha256": record.sha256,
+            "sha256": record.sha256 or _sha256(record.path),
             "source": record.source,
         })
     payload = {
@@ -426,7 +456,6 @@ def write_provenance(
         "configuration": {key: _json_value(value) for key, value in vars(args).items()},
         "fonts": fonts,
         "manifest": manifest_info,
-        "base_mask_cache": False,
     }
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -584,14 +613,13 @@ def main(args: argparse.Namespace) -> None:
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
     checkpoint_path = args.output_dir / "checkpoint.pth"
-    checkpoint_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
+    best_loss = math.inf
 
-    def save_metadata(_metrics: dict[str, float]) -> None:
-        nonlocal checkpoint_mtime
-        current_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
-        if current_mtime != checkpoint_mtime:
-            write_provenance(args.output_dir / "checkpoint.json", args, train_set, records, manifest_info)
-            checkpoint_mtime = current_mtime
+    def save_metadata(metrics: dict[str, float]) -> None:
+        nonlocal best_loss
+        if metrics["val_loss"] < best_loss:
+            write_provenance(args.output_dir / "checkpoint.json", args, train_set, train_set.fonts, manifest_info)
+            best_loss = metrics["val_loss"]
 
     trainer = ClassificationTrainer(
         model,
@@ -608,6 +636,7 @@ def main(args: argparse.Namespace) -> None:
     if args.resume is not None:
         validate_resume_metadata(args.resume, args.arch, train_set.classes)
         trainer.load(torch.load(args.resume, map_location="cpu"))
+    best_loss = trainer.min_loss
     if args.check_setup:
         trainer.check_setup(lr=args.lr, num_it=100)
         return

--- a/tests/test_train_characters.py
+++ b/tests/test_train_characters.py
@@ -249,6 +249,31 @@ def test_manifest_checksum_is_verified(tmp_path):
         characters.resolve_font_records("A", font_dir, manifest)
 
 
+def test_alexnet_requires_supported_image_size():
+    args = characters.get_parser().parse_args(["--arch", "alexnet", "--image-size", "32"])
+    with pytest.raises(ValueError, match="at least 63"):
+        characters.main(args)
+
+
+def test_alexnet_dispatch(monkeypatch):
+    model = nn.Module()
+    kwargs = {}
+
+    def fake_alexnet(**values):
+        kwargs.update(values)
+        return model
+
+    monkeypatch.setattr(characters, "alexnet", fake_alexnet)
+
+    result = characters.build_model("alexnet", 62)
+
+    assert result is model
+    assert kwargs == {"weights": None, "num_classes": 62}
+    assert result.avgpool.output_size == 1
+    assert result.classifier.in_features == 256
+    assert result.classifier.out_features == 62
+
+
 def test_unmanifested_font_hashes_are_deferred(monkeypatch, tmp_path):
     font_dir = tmp_path / "fonts"
     font_dir.mkdir()

--- a/tests/test_train_characters.py
+++ b/tests/test_train_characters.py
@@ -77,6 +77,7 @@ def test_family_is_sampled_before_style():
     assert len(expected) == len(records)
 
     dataset = characters.SyntheticCharacterDataset("A", records, 32, 1, to_tensor)
+    assert {record.family for record in dataset.fonts} == {"DejaVu Sans", "DejaVu Serif"}
     torch.manual_seed(0)
     counts = Counter()
     for _ in range(1_000):
@@ -227,8 +228,6 @@ def test_cli_grid_training_resume_and_provenance(monkeypatch, tmp_path):
     assert metadata["architecture"] == "convnext_atto"
     assert metadata["fonts"][0]["path"] == "Test.ttf"
     assert metadata["manifest"]["source_revisions"] == {"test": "abc123"}
-    assert metadata["base_mask_cache"] is False
-
     metadata_before_resume = metadata_path.read_text(encoding="utf-8")
     monkeypatch.setattr(
         characters.ClassificationTrainer,
@@ -248,6 +247,24 @@ def test_manifest_checksum_is_verified(tmp_path):
     _write_manifest(manifest, font_path.name, "0" * 64)
     with pytest.raises(ValueError, match="checksum mismatch"):
         characters.resolve_font_records("A", font_dir, manifest)
+
+
+def test_unmanifested_font_hashes_are_deferred(monkeypatch, tmp_path):
+    font_dir = tmp_path / "fonts"
+    font_dir.mkdir()
+    shutil.copy2(SANS, font_dir / "Test.ttf")
+    hashes = []
+    monkeypatch.setattr(characters, "_sha256", lambda path: hashes.append(path) or "hash")
+
+    records, _ = characters.resolve_font_records("A", font_dir, None)
+    assert hashes == []
+    dataset = characters.SyntheticCharacterDataset("A", records, 32, 1, T.PILToTensor())
+    args = characters.get_parser().parse_args(["--font-dir", str(font_dir)])
+    metadata = tmp_path / "checkpoint.json"
+    characters.write_provenance(metadata, args, dataset, dataset.fonts, None)
+
+    assert hashes == [font_dir / "Test.ttf"]
+    assert json.loads(metadata.read_text(encoding="utf-8"))["fonts"][0]["sha256"] == "hash"
 
 
 def test_fixed_batch_can_lower_loss(monkeypatch, tmp_path):

--- a/tests/test_train_characters.py
+++ b/tests/test_train_characters.py
@@ -1,0 +1,285 @@
+import gc
+import json
+import shutil
+from collections import Counter
+from pathlib import Path
+
+import matplotlib as mpl
+import pytest
+import torch
+from PIL import ImageFont
+from torch import nn
+from torch.utils.data import SequentialSampler
+from torchvision.transforms import v2 as T
+
+from references.classification import train_characters as characters
+
+FONT_ROOT = Path(mpl.get_data_path()) / "fonts" / "ttf"
+SANS = FONT_ROOT / "DejaVuSans.ttf"
+
+
+def _transform_args(*args):
+    return characters.get_parser().parse_args([
+        "--image-size",
+        "24",
+        "--render-size",
+        "32",
+        "--margin",
+        "2",
+        *args,
+    ])
+
+
+def test_dataset_balance_outputs_and_reproducibility():
+    train_transform, val_transform = characters.build_transforms(
+        _transform_args("--rotation", "20", "--translate", "0.2", "--scale-jitter", "0.2")
+    )
+    record = characters.FontRecord(SANS, "DejaVu Sans")
+    dataset = characters.SyntheticCharacterDataset("ABC", [record], 32, 7, train_transform)
+
+    assert dataset.classes == ("A", "B", "C")
+    assert dataset.class_to_idx == {"A": 0, "B": 1, "C": 2}
+    assert Counter(dataset[index][1] for index in range(len(dataset))) == {0: 3, 1: 2, 2: 2}
+    image, target = dataset[1]
+    assert image.shape == (3, 24, 24)
+    assert image.dtype == torch.float32
+    assert target == 1
+
+    torch.manual_seed(3)
+    first = dataset[0][0]
+    torch.manual_seed(3)
+    repeated = dataset[0][0]
+    torch.manual_seed(4)
+    different = dataset[0][0]
+    assert torch.equal(first, repeated)
+    assert not torch.equal(first, different)
+
+    validation = characters.SyntheticCharacterDataset("ABC", [record], 32, 6, val_transform, deterministic=True)
+    first_pass = [validation[index] for index in range(len(validation))]
+    second_pass = [validation[index] for index in range(len(validation))]
+    assert [target for _, target in first_pass] == [0, 1, 2, 0, 1, 2]
+    assert all(torch.equal(first[0], second[0]) for first, second in zip(first_pass, second_pass, strict=True))
+
+
+def test_family_is_sampled_before_style():
+    records = [
+        characters.FontRecord(FONT_ROOT / "DejaVuSans.ttf", "Sans", "Regular"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSans-Bold.ttf", "Sans", "Bold"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSans-Oblique.ttf", "Sans", "Oblique"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSerif.ttf", "Serif", "Regular"),
+    ]
+    to_tensor = T.PILToTensor()
+    expected = {}
+    for record in records:
+        font = ImageFont.truetype(str(record.path), 32)
+        image = to_tensor(characters.render_text("A", font))
+        expected[tuple(image.shape), image.numpy().tobytes()] = (record.family, record.style)
+    assert len(expected) == len(records)
+
+    dataset = characters.SyntheticCharacterDataset("A", records, 32, 1, to_tensor)
+    torch.manual_seed(0)
+    counts = Counter()
+    for _ in range(1_000):
+        image, _ = dataset[0]
+        counts[expected[tuple(image.shape), image.numpy().tobytes()]] += 1
+
+    sans_count = sum(count for (family, _), count in counts.items() if family == "Sans")
+    assert 430 < sans_count < 570
+    for style in ("Regular", "Bold", "Oblique"):
+        assert 0.25 < counts["Sans", style] / sans_count < 0.42
+
+
+@pytest.mark.parametrize(
+    ("alphabet", "message"),
+    [
+        ("", "must not be empty"),
+        ("AA", "duplicate"),
+        (" ", "visible"),
+        ("你", "no visible font supports"),
+    ],
+)
+def test_dataset_rejects_invalid_alphabets(alphabet, message):
+    with pytest.raises(ValueError, match=message):
+        characters.SyntheticCharacterDataset(alphabet, [SANS], 32, 1, T.PILToTensor())
+
+
+def test_dataset_rejects_invalid_fonts(tmp_path):
+    missing = tmp_path / "missing.ttf"
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        characters.SyntheticCharacterDataset("A", [missing], 32, 1, T.PILToTensor())
+
+    corrupt = tmp_path / "corrupt.ttf"
+    corrupt.write_text("not a font", encoding="utf-8")
+    with pytest.raises(ValueError, match="unable to load"):
+        characters.SyntheticCharacterDataset("A", [corrupt], 32, 1, T.PILToTensor())
+
+
+def test_font_objects_are_reused(monkeypatch):
+    dataset = characters.SyntheticCharacterDataset("A", [SANS], 32, 2, T.PILToTensor())
+    original = characters.ImageFont.truetype
+    calls = 0
+
+    def counted_truetype(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(characters.ImageFont, "truetype", counted_truetype)
+    dataset[0]
+    dataset[1]
+    assert calls == 1
+    state = dataset.__getstate__()
+    assert state["_font_cache"] == {}
+    assert state["_font_cache_pid"] is None
+
+
+@pytest.mark.parametrize("workers", [0, 1])
+def test_dataloader_smoke(workers):
+    _, val_transform = characters.build_transforms(_transform_args())
+    dataset = characters.SyntheticCharacterDataset("AB", [SANS], 32, 4, val_transform, deterministic=True)
+    dataset[0]
+    loader = characters.build_loader(
+        dataset,
+        2,
+        workers,
+        SequentialSampler(dataset),
+        0,
+        pin_memory=False,
+    )
+    images, targets = next(iter(loader))
+    assert images.shape == (2, 3, 24, 24)
+    assert targets.tolist() == [0, 1]
+    del loader
+    gc.collect()
+
+
+def _write_manifest(path, filename, checksum):
+    path.write_text(
+        json.dumps({
+            "version": 1,
+            "sources": {"test": {"revision": "abc123"}},
+            "fonts": [
+                {
+                    "family": "DejaVu Sans",
+                    "style": "Regular",
+                    "source": "test",
+                    "filename": filename,
+                    "sha256": checksum,
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_cli_grid_training_resume_and_provenance(monkeypatch, tmp_path):
+    font_dir = tmp_path / "fonts"
+    font_dir.mkdir()
+    font_path = font_dir / "Test.ttf"
+    shutil.copy2(SANS, font_path)
+    manifest = tmp_path / "fonts.json"
+    _write_manifest(manifest, font_path.name, characters._sha256(font_path))
+
+    common = [
+        "--font-dir",
+        str(font_dir),
+        "--manifest",
+        str(manifest),
+        "--alphabet",
+        "AB",
+        "--arch",
+        "convnext_atto",
+        "--image-size",
+        "16",
+        "--render-size",
+        "32",
+        "--samples-per-epoch",
+        "4",
+        "--validation-fonts-per-class",
+        "1",
+        "--batch-size",
+        "2",
+        "--workers",
+        "0",
+        "--epochs",
+        "1",
+        "--device",
+        "cpu",
+    ]
+    grid_path = tmp_path / "grid.png"
+    characters.main(characters.get_parser().parse_args([*common, "--show-samples", str(grid_path)]))
+    assert grid_path.is_file()
+
+    def tiny_classifier(pretrained=False, *, num_classes=1, **_kwargs):
+        assert not pretrained
+        return nn.Sequential(nn.Flatten(), nn.Linear(3 * 16 * 16, num_classes))
+
+    monkeypatch.setattr(characters.classification, "convnext_atto", tiny_classifier)
+    output_dir = tmp_path / "output"
+    training_args = [*common, "--output-dir", str(output_dir)]
+    characters.main(characters.get_parser().parse_args(training_args))
+
+    checkpoint = output_dir / "checkpoint.pth"
+    metadata_path = output_dir / "checkpoint.json"
+    assert checkpoint.is_file()
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["class_to_index"] == {"A": 0, "B": 1}
+    assert metadata["architecture"] == "convnext_atto"
+    assert metadata["fonts"][0]["path"] == "Test.ttf"
+    assert metadata["manifest"]["source_revisions"] == {"test": "abc123"}
+    assert metadata["base_mask_cache"] is False
+
+    metadata_before_resume = metadata_path.read_text(encoding="utf-8")
+    monkeypatch.setattr(
+        characters.ClassificationTrainer,
+        "evaluate",
+        lambda _self: {"val_loss": float("inf"), "acc1": 0.0, "acc5": 0.0},
+    )
+    characters.main(characters.get_parser().parse_args([*training_args, "--resume", str(checkpoint)]))
+    assert metadata_path.read_text(encoding="utf-8") == metadata_before_resume
+
+
+def test_manifest_checksum_is_verified(tmp_path):
+    font_dir = tmp_path / "fonts"
+    font_dir.mkdir()
+    font_path = font_dir / "Test.ttf"
+    shutil.copy2(SANS, font_path)
+    manifest = tmp_path / "fonts.json"
+    _write_manifest(manifest, font_path.name, "0" * 64)
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        characters.resolve_font_records("A", font_dir, manifest)
+
+
+def test_fixed_batch_can_lower_loss(monkeypatch, tmp_path):
+    torch.manual_seed(0)
+    transform = T.Compose([
+        T.Resize((8, 8), antialias=True),
+        T.Grayscale(num_output_channels=3),
+        T.ToImage(),
+        T.ToDtype(torch.float32, scale=True),
+    ])
+    dataset = characters.SyntheticCharacterDataset("AB", [SANS], 32, 2, transform, deterministic=True)
+    loader = characters.build_loader(
+        dataset,
+        2,
+        0,
+        SequentialSampler(dataset),
+        0,
+        pin_memory=False,
+    )
+    model = nn.Sequential(nn.Flatten(), nn.Linear(3 * 8 * 8, 2))
+    criterion = nn.CrossEntropyLoss()
+    trainer = characters.ClassificationTrainer(
+        model,
+        loader,
+        loader,
+        criterion,
+        torch.optim.SGD(model.parameters(), lr=0.2),
+        output_file=str(tmp_path / "checkpoint.pth"),
+    )
+    images, targets = next(iter(loader))
+    initial_loss = criterion(model(images), targets).item()
+    monkeypatch.setattr(characters.plt, "show", lambda **_kwargs: None)
+    trainer.check_setup(lr=0.2, num_it=30)
+    final_loss = criterion(model(images), targets).item()
+    assert final_loss < initial_loss


### PR DESCRIPTION
## Summary

- add a map-style SyntheticCharacterDataset with stable balanced labels, real family-first font sampling, setup-time coverage validation, and worker-local lazy font reuse
- add deterministic validation, live TorchVision v2 augmentation, sample-grid, CPU/CUDA training, resume validation, provenance sidecars, and warmed-up loader benchmarking
- add an optional TorchVision AlexNet feature stack with a compact 2.49M-parameter task head for stable 64px training
- keep the reference self-contained: no public API, dependency, render_text, or checkpoint-format changes

## Adversarial review follow-up

- fix the repository header gate for this new 2026 file
- use actual font family/style metadata in manifest, directory, and system-font modes
- defer non-manifest SHA-256 work until provenance is written
- replace checkpoint-mtime sniffing with the trainer's explicit best-loss condition
- remove placeholder mask-cache metadata and split the two complexity hotspots into narrow validation helpers

## AlexNet stability

- three CPU LR-finder runs: seeds 0/1/2, 100 points each, batch 128, 64/128 image/render sizes, AdamW, LR 1e-7 to 1e-2
- per-seed minimum-loss LRs: 1.23e-3, 1.56e-3, and 3.13e-3; median-curve minimum: 2.21e-3
- retain 1e-3 as the conservative default before the curves separate
- tiny 10-epoch CPU run: validation loss 4.125 to 1.787, Top-1 1.61% to 50.65%, Top-5 9.03% to 87.10%

## Validation

- focused tests: 16 passed
- make quality
- make build-docs (completed with existing MkDocs, Griffe, and cross-reference warnings)
- exact GitHub header validator
- all four documented commands
- real convnext_atto CPU checkpoint save and resume
- real compact-AlexNet CPU checkpoint save and 10-epoch training
- visual inspection of the regenerated labeled sample grid and both learning-rate/training plots
- six requested independent review harnesses launched; five completed, Deepseek timed out after repository inspection and focused tests

## Loader benchmark

- hardware: Apple M3 Pro, 11 logical cores, 36 GiB RAM, macOS 15.7.7 arm64
- workers: 8
- batch size: 256
- render / image size: 128 / 64
- warm-up / measured batches: 10 / 100
- measured samples: 25,600
- throughput: 11,432.0 samples/s
- cache: worker-local font objects only; no base-mask cache

No timing assertion is added.
