### PR TITLE
feat: make Holocron a trustworthy CV research workbench

### DIFF
--- a/.agents/skills/holocron-research-workbench/SKILL.md
+++ b/.agents/skills/holocron-research-workbench/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: holocron-research-workbench
+description: Use Holocron as a trustworthy computer-vision research workbench. Use this skill whenever a user or coding agent needs to discover or compare Holocron models, inspect model maturity or checkpoints, start or resume a reproducible training run, interpret a run bundle, extract classifier features, evaluate detection or segmentation, export a model, benchmark latency, or add a model with evidence-backed support claims.
+---
+
+# Holocron research workbench
+
+Use Holocron's public Python contracts as the source of truth. Keep model selection, empirical evidence, and owner policy separate.
+
+## 1. Discover before importing a factory
+
+```python
+from holocron.models import get_model, get_model_info, list_checkpoints, list_models
+
+names = list_models(task="classification", pretrained=True)
+info = get_model_info(names[0])
+checkpoints = list_checkpoints(info.name)
+model = get_model(info.name, checkpoint=checkpoints[0] if checkpoints else None)
+```
+
+Filter by the user's task and constraints. Report each candidate's maturity and weight availability. Do not silently treat `preview` or `experimental` as validated, and do not invent a universal “best model” score.
+
+## 2. Inspect checkpoint evidence
+
+Use the typed checkpoint metadata for architecture, preprocessing, categories, recipe, evaluation, parameter count, size, and SHA-256. If a required field is absent, say `not reported`; do not fill it from a similarly named model or paper result.
+
+Published paper numbers and Holocron run results are different evidence. Keep dataset, split, resolution, hardware, and metric protocol attached to every comparison.
+
+## 3. Train into a completed run bundle
+
+Pass `run_dir` to `Trainer.fit_n_epochs(...)`. The returned `RunResult` is the in-process result; `manifest.json` is the durable completion marker. Read `metrics.jsonl` and artifact hashes from the bundle rather than scraping console output.
+
+An interrupted bundle without `manifest.json` is incomplete. Preserve it for diagnosis, but do not compare it as a finished experiment.
+
+## 4. Resume exactly when possible
+
+Load checkpoint schema v2 and pass its dictionary to `Trainer.load`. Schema v2 restores model, optimizer, scheduler, scaler, trainer position, recorded configuration, and available RNG state. Keep the original scheduler horizon.
+
+Legacy checkpoints restore model and basic counters only. Call that a warm restart. Custom DataLoader generator state is not serialized; disclose that limit when it affects determinism.
+
+## 5. Use task-appropriate evidence
+
+- Classification: top-1/top-5 on the recorded split and preprocessing.
+- Detection: AP50 and AP50:95 from the optional COCO evaluator. A fixed-batch overfit only proves the optimization path moves.
+- Segmentation: mean IoU plus the recorded class mapping and ignore-index policy.
+
+CPU tests do not prove CUDA behavior. Export success does not prove eager/export parity unless outputs were compared. Latency numbers need device, dtype, input shape, warmup, synchronization, and distribution—not a single wall-clock mean.
+
+## 6. Reuse researcher interfaces
+
+For classifiers, prefer `forward_features`, `forward_head`, `get_classifier`, and `reset_classifier`. Keep `forward(x)` equivalent to `forward_head(forward_features(x))`.
+
+Use the repository export and latency scripts for machine-readable reports. Do not build a second exporter or benchmark harness inside the caller's project.
+
+## 7. Diagnose failures in order
+
+1. Confirm model name, task, maturity, and checkpoint architecture.
+2. Confirm preprocessing, categories, dataset split, and target encoding.
+3. Check checkpoint schema and whether `manifest.json` exists.
+4. Reproduce on the smallest fixed batch.
+5. Separate CPU correctness from CUDA, export, and benchmark gates.
+6. Fix the shared root cause and leave one focused regression test.
+
+## Report back
+
+Return:
+
+1. selected model/checkpoint and maturity;
+2. exact command or Python call used;
+3. completed metrics and artifact paths;
+4. gates actually run;
+5. unverified or experimental boundaries;
+6. next empirical gate.

--- a/.agents/skills/holocron-research-workbench/evals/evals.json
+++ b/.agents/skills/holocron-research-workbench/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "holocron-research-workbench",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "In this Holocron checkout, choose a small pretrained classification model for a CPU transfer-learning experiment, show how to instantiate it without source introspection, and tell me exactly what evidence is and is not available.",
+      "expected_output": "Uses the public catalog and typed checkpoints, reports maturity and metadata, and avoids claiming unrun training or benchmark evidence.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "My Holocron training job stopped after epoch 2. I have its checkpoint and output directory. Explain how an agent should decide whether this is an exact resume, restart it safely, and validate the resulting evidence bundle.",
+      "expected_output": "Distinguishes schema-v2 exact resume from legacy warm restart, preserves the scheduler horizon, and treats manifest.json as the completion marker.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "A new Holocron detector passes shape tests and overfits one batch. Can we call it validated and publish a latency comparison? Give the next commands and gates an agent should run.",
+      "expected_output": "Keeps the detector experimental, requires AP50/AP50:95 and export parity, and separates CPU, CUDA, and latency evidence.",
+      "files": []
+    }
+  ]
+}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,15 +6,21 @@ on:
     paths:
       - '.github/workflows/package.yml'
       - 'holocron/**'
+      - 'scripts/**'
       - 'tests/**'
+      - 'README.md'
       - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches: main
     paths:
       - '.github/workflows/package.yml'
       - 'holocron/**'
+      - 'scripts/**'
       - 'tests/**'
+      - 'README.md'
       - 'pyproject.toml'
+      - 'uv.lock'
   release:
     types: [published]
 
@@ -30,10 +36,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ['3.11', '3.12', '3.13']
+        python: ['3.11', '3.12', '3.13', '3.14']
         exclude:
           - os: windows-latest
             python: '3.13'
+          - os: windows-latest
+            python: '3.14'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -49,8 +57,7 @@ jobs:
           UV_TORCH_BACKEND: cpu
         run: make install
       - name: Check that we can import the engine
-        run: |
-          python -c "import holocron; print(holocron.__version__)"
+        run: python -c "import holocron; print(holocron.__version__)"
 
   test:
     if: github.event_name != 'release'
@@ -98,38 +105,10 @@ jobs:
           fail_ci_if_error: true
 
   build:
-    if: github.event_name == 'pull_request'
-    needs: install
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ['3.11', '3.12', '3.13']
-        exclude:
-          - os: windows-latest
-            python: '3.13'
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: ${{ matrix.python }}
-          architecture: x64
-      - uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-      - name: Build the package
-        env:
-          UV_TORCH_BACKEND: cpu
-        run: make build
-
-  publish:
-    if: github.event_name == 'release'
+    if: github.event_name == 'pull_request' || github.event_name == 'release'
     runs-on: ubuntu-latest
-    permissions:
-      # For PyPI's trusted publishing.
-      id-token: write
     outputs:
-      package_version: ${{ steps.set_version.outputs.package_version }}
+      package_version: ${{ steps.set-version.outputs.package_version }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -140,34 +119,45 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
       - name: Set package version
-        id: set_version
+        id: set-version
+        shell: bash
         run: |
-          RELEASE_TAG=${{ github.ref_name }}
-          # Strip "v" prefix
-          BUILD_VERSION=${RELEASE_TAG#v}
-          # Replace SemVer pre-release separators with PEP440 compatible ones
-          BUILD_VERSION=${BUILD_VERSION//-alpha./a}
-          BUILD_VERSION=${BUILD_VERSION//-beta./b}
-          BUILD_VERSION=${BUILD_VERSION//-rc./rc}
-          echo "package_version=${BUILD_VERSION}" >> $GITHUB_OUTPUT
-          echo "BUILD_VERSION=${BUILD_VERSION}" >> $GITHUB_ENV
-      - name: Publish to PyPI
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RELEASE_TAG=${{ github.ref_name }}
+            BUILD_VERSION=${RELEASE_TAG#v}
+            BUILD_VERSION=${BUILD_VERSION//-alpha./a}
+            BUILD_VERSION=${BUILD_VERSION//-beta./b}
+            BUILD_VERSION=${BUILD_VERSION//-rc./rc}
+            echo "BUILD_VERSION=${BUILD_VERSION}" >> "$GITHUB_ENV"
+          else
+            BUILD_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          fi
+          echo "package_version=${BUILD_VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Apply release version
+        if: github.event_name == 'release'
+        run: make set-version
+      - name: Build distributions once
         env:
           UV_TORCH_BACKEND: cpu
-        run: |
-          make set-version
-          make build && make publish
+        run: make build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
 
-  verify-publish:
+  test-wheel:
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ['3.11', '3.12', '3.13']
+        python: ['3.11', '3.12', '3.13', '3.14']
         exclude:
           - os: windows-latest
             python: '3.13'
-    needs: publish
+          - os: windows-latest
+            python: '3.14'
     steps:
       - uses: actions/setup-python@v7
         with:
@@ -176,7 +166,80 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
-      - name: Install package
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist
+      - name: Install exact wheel
+        env:
+          UV_TORCH_BACKEND: cpu
+        run: python -c "from glob import glob; import subprocess; subprocess.check_call(['uv', 'pip', 'install', '--system', glob('dist/*.whl')[0]])"
+      - name: Verify wheel contents
+        run: python -c "from importlib.resources import files; import holocron; assert files('holocron').joinpath('py.typed').is_file(); print(holocron.__version__)"
+
+  test-sdist:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist
+      - name: Install exact source distribution
+        env:
+          UV_TORCH_BACKEND: cpu
+        run: python -c "from glob import glob; import subprocess; subprocess.check_call(['uv', 'pip', 'install', '--system', glob('dist/*.tar.gz')[0]])"
+      - name: Verify source distribution contents
+        run: python -c "from importlib.resources import files; import holocron; assert files('holocron').joinpath('py.typed').is_file(); print(holocron.__version__)"
+
+  publish:
+    if: github.event_name == 'release'
+    needs: [build, test-wheel, test-sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    outputs:
+      package_version: ${{ needs.build.outputs.package_version }}
+    steps:
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist
+      - name: Publish tested distributions to PyPI
+        run: uv publish --trusted-publishing always dist/*
+
+  verify-publish:
+    if: github.event_name == 'release'
+    needs: publish
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python: ['3.11', '3.12', '3.13', '3.14']
+        exclude:
+          - os: windows-latest
+            python: '3.13'
+          - os: windows-latest
+            python: '3.14'
+    steps:
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: x64
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+      - name: Install package from PyPI
         env:
           UV_TORCH_BACKEND: cpu
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Holocron contributor guide for coding agents
+
+Holocron is a compact computer-vision research library. Prefer a small change on an existing model, trainer, reference, or utility seam over a new framework.
+
+## Work safely
+
+- Use Python 3.11+ and the built-in typing syntax already used by the project.
+- Start with `uv run --python 3.12 --extra test pytest -q <focused tests>`.
+- Run `make quality` after focused tests. Run the broader suite only after the focused path is green.
+- Keep CPU, CUDA, dataset training, export parity, and benchmark evidence separate. Never report an unrun gate as passed.
+- Do not edit generated `llms.txt` files. Update source documentation under `docs/docs/`.
+
+## Public research workflow
+
+- Discover models through `holocron.models.list_models`, `get_model_info`, `list_checkpoints`, and `get_model`; do not index module `__dict__` values.
+- Use typed `Checkpoint` metadata and the central loader. Never bypass recorded hashes for published weights.
+- Save resumable work with trainer checkpoint schema v2. A model-only or legacy checkpoint is a warm restart, not exact resume.
+- Treat `manifest.json` as the completion marker for a run bundle. A directory without it is incomplete.
+- Preserve maturity labels: `validated`, `preview`, and `experimental`. Validation requires a published checkpoint, exact provenance, a reproducible recipe, standard task metrics, and a completed run manifest.
+
+## Model changes
+
+A model-family PR should include the factory and exports, focused forward/backward tests, checkpoint metadata when weights exist, standard task metrics, a reference recipe, export parity, and documentation. Without the full evidence set, keep the model preview or experimental.
+
+Reuse `forward_features`, `forward_head`, `get_classifier`, and `reset_classifier` for classifier research access. Avoid family-specific alternatives.
+
+Detection fixes need mathematical oracle tests. A tiny overfit proves learning behavior only; it is not benchmark evidence. Segmentation and detection claims use standard task metrics, not shape tests or custom error alone.
+
+## Scope boundaries
+
+- Prefer the Python API and machine-readable artifacts. Do not add an MCP server, hosted service, queue, or generic agent framework.
+- Avoid dependencies for logic already covered by PyTorch, torchvision, or the standard library. The COCO evaluator is the exception: use the optional `pycocotools` integration rather than reimplementing it.
+- Keep unrelated work out of the same commit. Parallel agents use separate worktrees and return commits for integration.

--- a/README.md
+++ b/README.md
@@ -188,15 +188,21 @@ In the table below, you will find a latency benchmark for all supported models:
 
 **The reported latency for RepVGG models is the one of the reparametrized version**
 
-This benchmark was performed over 100 iterations on (224, 224) inputs, on a laptop to better reflect performances that can be expected by common users. The hardware setup includes an [Intel(R) Core(TM) i7-10750H](https://ark.intel.com/content/www/us/en/ark/products/201837/intel-core-i710750h-processor-12m-cache-up-to-5-00-ghz.html) for the CPU, and a [NVIDIA GeForce RTX 2070 with Max-Q Design](https://www.nvidia.com/fr-fr/geforce/graphics-cards/rtx-2070/) for the GPU.
+The historical table above was measured over 100 iterations on (224, 224) inputs. The hardware setup included an [Intel(R) Core(TM) i7-10750H](https://ark.intel.com/content/www/us/en/ark/products/201837/intel-core-i710750h-processor-12m-cache-up-to-5-00-ghz.html) for the CPU, and a [NVIDIA GeForce RTX 2070 with Max-Q Design](https://www.nvidia.com/fr-fr/geforce/graphics-cards/rtx-2070/) for the GPU.
 
-You can run this latency benchmark for any model on your hardware as follows:
+Run a synchronized PyTorch/ONNX Runtime benchmark on your hardware. The current script uses `torch.utils.benchmark` and reports median, mean, and IQR; `--json` emits the same measurements with environment metadata:
 
 ```bash
-python scripts/eval_latency.py rexnet1_0x
+uv run --extra scripts python scripts/eval_latency.py rexnet1_0x --json
 ```
 
-*All script arguments can be checked using `python scripts/eval_latency.py --help`*
+Export a dynamic-batch ONNX model and optionally verify it with ONNX Runtime while saving a conversion report:
+
+```bash
+uv run --extra scripts python scripts/export_to_onnx.py rexnet1_0x --verify --report
+```
+
+*All arguments can be checked with the scripts' `--help` option.*
 
 ### Docker container
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holocron"
-version = "0.2.2.dev0"
+version = "0.3.0.dev0"
 description = "Backend template for your Vision API with Holocron"
 requires-python = ">=3.11,<4.0"
 license = { text = "Apache-2.0" }

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -330,7 +330,7 @@ wheels = [
 
 [[package]]
 name = "holocron"
-version = "0.2.2.dev0"
+version = "0.3.0.dev0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },

--- a/docs/docs/getting-started/model-cards.md
+++ b/docs/docs/getting-started/model-cards.md
@@ -1,0 +1,41 @@
+# Generate model cards
+
+Holocron can generate deterministic, Hugging Face-compatible Markdown from its typed model catalog. Cards include the
+model task and maturity, checkpoint provenance, preprocessing, training recipe, evaluation metrics, and explicit
+`unknown / not reported` markers for metadata Holocron does not have.
+
+Generate one checkpoint card:
+
+```shell
+python -m holocron.models.model_card convnext_atto --checkpoint 0 --output README.md
+```
+
+Attach provenance from a completed schema-v1 run bundle:
+
+```shell
+python -m holocron.models.model_card convnext_atto --output README.md --run-dir runs/experiment-1
+```
+
+The run directory must contain `manifest.json` and every artifact declared by the manifest. The generator verifies the
+schema version, file sizes, and SHA-256 values before rendering the card. A missing manifest is treated as an unfinished
+run and rejected.
+
+Generate one card per typed checkpoint of selected models (or one model-only card when typed checkpoint metadata is
+unavailable):
+
+```shell
+python -m holocron.models.model_card convnext_atto resnet18 --output-dir model-cards
+```
+
+Omit model names to generate the complete catalog. Generated cards are release artifacts; they are not maintained as a
+second metadata store in the repository.
+
+The Python API is available when a release workflow needs the Markdown directly:
+
+```python
+from holocron.models import list_checkpoints
+from holocron.models.model_card import generate_model_card
+
+checkpoint = list_checkpoints("convnext_atto")[0]
+markdown = generate_model_card("convnext_atto", checkpoint, run_dir="runs/experiment-1")
+```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -73,10 +73,12 @@ of checkpoint and benchmark coverage. See the
 [capability and maturity matrix](reference/models/models.md#support-status)
 before choosing a model.
 
-### Image classification — validated checkpoints
+### Image classification — preview checkpoints
 
 Published checkpoints and metrics cover Imagenette, plus selected ReXNet
-ImageNet-1K variants.
+ImageNet-1K variants. These historical checkpoints predate schema-v1 run
+manifests and verified export evidence, so v0.3 labels them `preview` rather
+than overstating their reproducibility.
 
 * TridentNet from ["Scale-Aware Trident Networks for Object Detection"](https://arxiv.org/pdf/1901.01892.pdf)
 * SKNet from ["Selective Kernel Networks"](https://arxiv.org/pdf/1903.06586.pdf)

--- a/docs/docs/notes/changelog.md
+++ b/docs/docs/notes/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.3.0 (unreleased)
+
+Holocron becomes a reproducible CV research workbench: programmatic model
+discovery and maturity, checkpoint-v2 exact resume, manifest-last run bundles,
+classifier feature extraction, repaired YOLOv4 training, COCO AP, verified
+ONNX export, structured latency reports, provenance model cards and
+artifact-first publishing. See the [v0.3 migration guide](v0.3-migration.md).
+
 ## v0.2.1 (2022-07-16)
 Release note: [v0.2.1](https://github.com/frgfm/Holocron/releases/tag/v0.2.1)
 

--- a/docs/docs/notes/v0.3-migration.md
+++ b/docs/docs/notes/v0.3-migration.md
@@ -1,0 +1,46 @@
+# Migrating to v0.3
+
+v0.3 raises the evidence bar and introduces a public research workflow. The
+package remains `pylocron`; imports remain under `holocron`.
+
+## Discover models
+
+Replace module-dictionary lookup with the catalog:
+
+```python
+from holocron.models import get_model, get_model_info, list_checkpoints, list_models
+
+name = list_models(task="classification", pretrained=True)[0]
+checkpoint = list_checkpoints(name)[0]
+model = get_model(name, checkpoint=checkpoint)
+print(get_model_info(name).maturity)
+```
+
+Historical weights are `preview` until they gain a completed run manifest and
+verified export evidence. Paper metrics are never promoted to Holocron results.
+
+## Resume training
+
+New trainer checkpoints use schema v2 and restore model, optimizer, scheduler,
+scaler, trainer position, recorded configuration and available RNG state.
+`Trainer.load` still accepts legacy dictionaries, but those are warm restarts.
+Custom DataLoader generator state is not serialized.
+
+`fit_n_epochs` now returns a frozen `RunResult`. Pass `run_dir` to write
+`metrics.jsonl`, checkpoint artifacts and a final `manifest.json`. Treat the
+manifest as the completion marker.
+
+## Evaluate and export
+
+Install `pylocron[evaluation]` for COCO AP50/AP50:95. Detection remains
+experimental until a reproducible benchmark is published.
+
+The ONNX script now uses the `torch.export`-based exporter, accepts raw or
+trainer checkpoints, supports dynamic batch sizes and can verify/report the
+conversion. The latency script uses `torch.utils.benchmark` and can emit JSON.
+
+## Environment changes
+
+- Python 3.11 through regular CPython 3.14 are supported.
+- PyTorch 2.9 and torchvision 0.24 are the minimum compatible pair.
+- The distribution includes `py.typed`.

--- a/docs/docs/notes/v0.3-migration.md
+++ b/docs/docs/notes/v0.3-migration.md
@@ -18,6 +18,8 @@ print(get_model_info(name).maturity)
 
 Historical weights are `preview` until they gain a completed run manifest and
 verified export evidence. Paper metrics are never promoted to Holocron results.
+`model_from_hf_hub` now requires an immutable commit `revision`; moving branch
+names are not accepted as reproducible provenance.
 
 ## Resume training
 

--- a/docs/docs/reference/models/classification/iformer.md
+++ b/docs/docs/reference/models/classification/iformer.md
@@ -1,0 +1,65 @@
+# iFormer
+
+iFormer is based on the ICLR 2025 paper
+["iFormer: Integrating ConvNet and Transformer for Mobile Application"](https://proceedings.iclr.cc/paper_files/paper/2025/hash/396a3fc4560b1fe85574ebebe2b2a739-Abstract-Conference.html)
+and its [official implementation](https://github.com/ChuanyangZheng/iFormer).
+
+## Architecture overview
+
+The compact variants use a fused inverted-bottleneck stem, depthwise
+convolutional blocks for early local processing, and self-modulation attention
+with convolutional feed-forward blocks in their final stages. The Holocron
+implementation follows the official T/S/M layouts using standard PyTorch
+operators and exposes `forward_features`, `forward_head`, `get_classifier`, and
+`reset_classifier`.
+
+## Paper evidence
+
+These are ImageNet-1K results reported by the authors for 224px inputs and a
+300-epoch, non-distilled recipe. They are not Holocron benchmark results.
+
+| Model | Parameters | MACs | Top-1 |
+|---|---:|---:|---:|
+| iFormer-T | 2.9M | 0.53G | 74.1% |
+| iFormer-S | 6.5M | 1.09G | 78.8% |
+| iFormer-M | 8.9M | 1.64G | 80.4% |
+
+The exact 1,000-class parameter counts below match the official implementation.
+
+| Model | Parameters | Holocron maturity | Holocron checkpoint | Holocron metrics |
+|---|---:|---|---|---|
+| iFormer-T | 2,886,456 | Preview | Not published | Not measured |
+| iFormer-S | 6,563,368 | Preview | Not published | Not measured |
+| iFormer-M | 8,907,424 | Preview | Not published | Not measured |
+
+## Low-memory Imagenette command
+
+The existing classification reference supports a physical batch of 16 with two
+gradient-accumulation steps for an effective batch size of 32:
+
+```shell
+uv run --extra training python references/classification/train.py ./imagenette2-320 \
+  --arch iformer_t --batch-size 16 --grad-acc 2 --amp --device 0 --epochs 20 \
+  --lr 1e-3 --opt adamp --sched onecycle --mixup-alpha 0.2 \
+  --label-smoothing 0.1 --seed 0
+```
+
+This is runnable guidance, not a completed benchmark. Record the completed run
+manifest, hardware/software versions, peak memory, elapsed time, top-1, and
+top-5 before promoting a variant from preview.
+
+## Model builders
+
+All builders rely on [`IFormer`][holocron.models.IFormer] and accept a custom
+class count through `num_classes`.
+
+::: holocron.models.classification
+    options:
+        heading_level: 3
+        show_root_heading: false
+        show_root_toc_entry: false
+        members:
+            - IFormer
+            - iformer_t
+            - iformer_s
+            - iformer_m

--- a/docs/docs/reference/models/models.md
+++ b/docs/docs/reference/models/models.md
@@ -4,6 +4,25 @@ The models subpackage contains definitions of models for addressing
 different tasks, including: image classification, pixelwise semantic
 segmentation and object detection.
 
+## Programmatic discovery
+
+Model discovery uses the public task modules as its source of truth, so agents
+and applications do not need to inspect module internals:
+
+```python
+from holocron.models import Maturity, get_model, get_model_info, list_checkpoints, list_models
+
+names = list_models(task="classification", maturity=Maturity.VALIDATED, pretrained=True)
+checkpoint = list_checkpoints(names[0])[0]
+model = get_model(names[0], checkpoint=checkpoint)
+info = get_model_info(names[0])
+```
+
+Maturity is assigned to each model from its available evidence. Classification
+models with typed evaluation-backed checkpoints are `validated`; other
+classification models and segmentation models are `preview`; detection models
+remain `experimental` until standard benchmark evidence is published.
+
 ## Support status
 
 | Task | Architectures | Published checkpoints | Training | ONNX | Status |

--- a/docs/docs/reference/models/models.md
+++ b/docs/docs/reference/models/models.md
@@ -12,29 +12,31 @@ and applications do not need to inspect module internals:
 ```python
 from holocron.models import Maturity, get_model, get_model_info, list_checkpoints, list_models
 
-names = list_models(task="classification", maturity=Maturity.VALIDATED, pretrained=True)
+names = list_models(task="classification", maturity=Maturity.PREVIEW, pretrained=True)
 checkpoint = list_checkpoints(names[0])[0]
 model = get_model(names[0], checkpoint=checkpoint)
 info = get_model_info(names[0])
 ```
 
-Maturity is assigned to each model from its available evidence. Classification
-models with typed evaluation-backed checkpoints are `validated`; other
-classification models and segmentation models are `preview`; detection models
-remain `experimental` until standard benchmark evidence is published.
+Maturity is assigned to each model and typed checkpoint from its available
+evidence. Historical classification checkpoints are `preview`: they include
+published metrics and hashes but predate completed schema-v1 run manifests and
+verified export reports. Detection remains `experimental` until a reproducible
+standard benchmark is published.
 
 ## Support status
 
 | Task | Architectures | Published checkpoints | Training | ONNX | Status |
 |---|---|---|---|---|---|
-| Classification | 15 families | Imagenette checkpoints with top-1/top-5 metrics; selected ReXNet ImageNet-1K checkpoints | [Reference script](https://github.com/frgfm/holocron/blob/main/references/classification/train.py) | [Classification export](https://github.com/frgfm/holocron/blob/main/scripts/export_to_onnx.py) | **Validated** |
-| Semantic segmentation | U-Net, U-Net++, UNet3+ | Only the legacy `unet_rexnet13` weights; dataset and metric are not documented | [Reference script](https://github.com/frgfm/holocron/blob/main/references/segmentation/train.py) | Not documented | **Unbenchmarked** |
+| Classification | 15 families | Imagenette checkpoints with top-1/top-5 metrics; selected ReXNet ImageNet-1K checkpoints | [Reference script](https://github.com/frgfm/holocron/blob/main/references/classification/train.py) | [Verified export tool](https://github.com/frgfm/holocron/blob/main/scripts/export_to_onnx.py) | **Preview** |
+| Semantic segmentation | U-Net, U-Net++, UNet3+ | Only the legacy `unet_rexnet13` weights; dataset and metric are not documented | [Reference script](https://github.com/frgfm/holocron/blob/main/references/segmentation/train.py) | Not documented | **Preview** |
 | Object detection | YOLOv1, YOLOv2, YOLOv4 | None | [Reference script](https://github.com/frgfm/holocron/blob/main/references/detection/train.py) | Not documented | **Experimental** ([#110](https://github.com/frgfm/holocron/issues/110), [#253](https://github.com/frgfm/holocron/issues/253), [discussion #230](https://github.com/frgfm/holocron/discussions/230)) |
 
-**Validated** means published task checkpoints and metrics are available.
-**Unbenchmarked** means an implementation or legacy weight exists without a
-documented evaluation dataset and metric. **Experimental** means the API is
-available, but published task weights and a confirmed benchmark are not.
+**Validated** requires a published checkpoint, exact provenance, reproducible
+recipe, standard task metrics, completed run manifest and verified export.
+**Preview** means an implementation or historical checkpoint exists but one of
+those gates is missing. **Experimental** means the API is available without a
+confirmed reproducible task benchmark.
 
 
 ## Classification

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -75,6 +75,7 @@ plugins:
       Getting started:
         - getting-started/installation.md
         - getting-started/classification.md
+        - getting-started/model-cards.md
         - getting-started/notebooks.md
       Package Reference:
         - reference/models/models.md
@@ -173,6 +174,7 @@ nav:
   - Getting started:
     - getting-started/installation.md
     - getting-started/classification.md
+    - getting-started/model-cards.md
     - getting-started/notebooks.md
   - Package Reference:
     - Models:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,6 +87,7 @@ plugins:
         - reference/utils.md
         - reference/utils.data.md
       Notes:
+        - notes/v0.3-migration.md
         - notes/changelog.md
   mkdocstrings:
     handlers:
@@ -204,4 +205,5 @@ nav:
       - reference/utils.md
       - Data: reference/utils.data.md
   - Notes:
+    - notes/v0.3-migration.md
     - notes/changelog.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -196,6 +196,7 @@ nav:
         - reference/models/classification/repvgg.md
         - reference/models/classification/mobileone.md
         - reference/models/classification/repvit.md
+        - reference/models/classification/iformer.md
     - Layers: reference/nn.md
     - Operators: reference/ops.md
     - Optimizers: reference/optim.md

--- a/holocron/models/__init__.py
+++ b/holocron/models/__init__.py
@@ -1,2 +1,3 @@
-from . import detection, segmentation
+from . import classification, detection, segmentation
+from .catalog import Maturity, ModelInfo, get_model, get_model_info, list_checkpoints, list_models
 from .classification import *

--- a/holocron/models/catalog.py
+++ b/holocron/models/catalog.py
@@ -6,7 +6,7 @@
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import Enum, StrEnum
+from enum import Enum
 from functools import cache
 from importlib import import_module
 from types import ModuleType
@@ -14,17 +14,9 @@ from typing import Any
 
 from torch import nn
 
-from .checkpoints import Checkpoint
+from .checkpoints import Checkpoint, Maturity
 
 __all__ = ["Maturity", "ModelInfo", "get_model", "get_model_info", "list_checkpoints", "list_models"]
-
-
-class Maturity(StrEnum):
-    """Evidence available for a model and its checkpoints."""
-
-    VALIDATED = "validated"
-    PREVIEW = "preview"
-    EXPERIMENTAL = "experimental"
 
 
 @dataclass(frozen=True)
@@ -108,7 +100,7 @@ def get_model_info(name: str) -> ModelInfo:
     elif task == "segmentation" or not checkpoints:
         maturity = Maturity.PREVIEW
     else:
-        maturity = Maturity.VALIDATED
+        maturity = min(checkpoints, key=lambda checkpoint: list(Maturity).index(checkpoint.maturity)).maturity
     return ModelInfo(name=name, task=task, maturity=maturity, pretrained=pretrained)
 
 

--- a/holocron/models/catalog.py
+++ b/holocron/models/catalog.py
@@ -86,12 +86,12 @@ def get_model_info(name: str) -> ModelInfo:
     configs = getattr(import_module(factory.__module__), "default_cfgs", {})
     config = configs.get(name, {}) if isinstance(configs, dict) else {}
     pretrained = bool(checkpoints) or (isinstance(config, dict) and bool(config.get("url")))
-    if task == "detection":
-        maturity = Maturity.EXPERIMENTAL
-    elif task == "segmentation" or not checkpoints:
-        maturity = Maturity.PREVIEW
-    else:
+    if checkpoints:
         maturity = min(checkpoints, key=lambda checkpoint: list(Maturity).index(checkpoint.maturity)).maturity
+    elif task == "detection":
+        maturity = Maturity.EXPERIMENTAL
+    else:
+        maturity = Maturity.PREVIEW
     return ModelInfo(name=name, task=task, maturity=maturity, pretrained=pretrained)
 
 

--- a/holocron/models/catalog.py
+++ b/holocron/models/catalog.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import cache
 from importlib import import_module
-from types import ModuleType
 from typing import Any
 
 from torch import nn
@@ -33,14 +32,10 @@ _TASKS = ("classification", "detection", "segmentation")
 
 
 @cache
-def _task_modules() -> dict[str, ModuleType]:
-    return {task: import_module(f"{__package__}.{task}") for task in _TASKS}
-
-
-@cache
 def _model_factories() -> dict[str, tuple[str, Callable[..., nn.Module]]]:
     factories: dict[str, tuple[str, Callable[..., nn.Module]]] = {}
-    for task, module in _task_modules().items():
+    for task in _TASKS:
+        module = import_module(f"{__package__}.{task}")
         for name, factory in vars(module).items():
             if name.startswith("_") or not inspect.isfunction(factory):
                 continue
@@ -70,12 +65,6 @@ def _checkpoint_map() -> dict[str, tuple[Checkpoint, ...]]:
     return {name: tuple(values) for name, values in checkpoints.items()}
 
 
-def _has_legacy_weights(name: str, factory: Callable[..., nn.Module]) -> bool:
-    configs = getattr(import_module(factory.__module__), "default_cfgs", {})
-    config = configs.get(name, {}) if isinstance(configs, dict) else {}
-    return isinstance(config, dict) and bool(config.get("url"))
-
-
 def get_model_info(name: str) -> ModelInfo:
     """Return task, maturity, and weight availability for a model.
 
@@ -94,7 +83,9 @@ def get_model_info(name: str) -> ModelInfo:
         raise ValueError(f"unknown model: {name}") from exc
 
     checkpoints = _checkpoint_map().get(name, ())
-    pretrained = bool(checkpoints) or _has_legacy_weights(name, factory)
+    configs = getattr(import_module(factory.__module__), "default_cfgs", {})
+    config = configs.get(name, {}) if isinstance(configs, dict) else {}
+    pretrained = bool(checkpoints) or (isinstance(config, dict) and bool(config.get("url")))
     if task == "detection":
         maturity = Maturity.EXPERIMENTAL
     elif task == "segmentation" or not checkpoints:

--- a/holocron/models/catalog.py
+++ b/holocron/models/catalog.py
@@ -1,0 +1,192 @@
+# Copyright (C) 2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum, StrEnum
+from functools import cache
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+from torch import nn
+
+from .checkpoints import Checkpoint
+
+__all__ = ["Maturity", "ModelInfo", "get_model", "get_model_info", "list_checkpoints", "list_models"]
+
+
+class Maturity(StrEnum):
+    """Evidence available for a model and its checkpoints."""
+
+    VALIDATED = "validated"
+    PREVIEW = "preview"
+    EXPERIMENTAL = "experimental"
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """Public metadata for a model factory."""
+
+    name: str
+    task: str
+    maturity: Maturity
+    pretrained: bool
+
+
+_TASKS = ("classification", "detection", "segmentation")
+
+
+@cache
+def _task_modules() -> dict[str, ModuleType]:
+    return {task: import_module(f"{__package__}.{task}") for task in _TASKS}
+
+
+@cache
+def _model_factories() -> dict[str, tuple[str, Callable[..., nn.Module]]]:
+    factories: dict[str, tuple[str, Callable[..., nn.Module]]] = {}
+    for task, module in _task_modules().items():
+        for name, factory in vars(module).items():
+            if name.startswith("_") or not inspect.isfunction(factory):
+                continue
+            if not factory.__module__.startswith(f"{module.__name__}."):
+                continue
+            return_type = inspect.get_annotations(factory, eval_str=True).get("return")
+            if not inspect.isclass(return_type) or not issubclass(return_type, nn.Module):
+                continue
+            if name in factories:
+                raise RuntimeError(f"duplicate model factory: {name}")
+            factories[name] = (task, factory)
+    return factories
+
+
+@cache
+def _checkpoint_map() -> dict[str, tuple[Checkpoint, ...]]:
+    checkpoints: dict[str, list[Checkpoint]] = {}
+    modules = {factory.__module__ for _, factory in _model_factories().values()}
+    for module_name in modules:
+        module = import_module(module_name)
+        for enum_cls in vars(module).values():
+            if not inspect.isclass(enum_cls) or enum_cls.__module__ != module_name or not issubclass(enum_cls, Enum):
+                continue
+            for member in enum_cls:
+                if isinstance(member.value, Checkpoint):
+                    checkpoints.setdefault(member.value.meta.arch, []).append(member.value)
+    return {name: tuple(values) for name, values in checkpoints.items()}
+
+
+def _has_legacy_weights(name: str, factory: Callable[..., nn.Module]) -> bool:
+    configs = getattr(import_module(factory.__module__), "default_cfgs", {})
+    config = configs.get(name, {}) if isinstance(configs, dict) else {}
+    return isinstance(config, dict) and bool(config.get("url"))
+
+
+def get_model_info(name: str) -> ModelInfo:
+    """Return task, maturity, and weight availability for a model.
+
+    Args:
+        name: public model factory name.
+
+    Returns:
+        Metadata discovered from the public factory and its checkpoints.
+
+    Raises:
+        ValueError: if the model name is unknown.
+    """
+    try:
+        task, factory = _model_factories()[name]
+    except KeyError as exc:
+        raise ValueError(f"unknown model: {name}") from exc
+
+    checkpoints = _checkpoint_map().get(name, ())
+    pretrained = bool(checkpoints) or _has_legacy_weights(name, factory)
+    if task == "detection":
+        maturity = Maturity.EXPERIMENTAL
+    elif task == "segmentation" or not checkpoints:
+        maturity = Maturity.PREVIEW
+    else:
+        maturity = Maturity.VALIDATED
+    return ModelInfo(name=name, task=task, maturity=maturity, pretrained=pretrained)
+
+
+def list_models(
+    task: str | None = None,
+    maturity: Maturity | str | None = None,
+    pretrained: bool | None = None,
+) -> list[str]:
+    """List public model factories, optionally filtered by evidence and task.
+
+    Args:
+        task: optional model task.
+        maturity: optional evidence maturity.
+        pretrained: optional pretrained-weight availability.
+
+    Returns:
+        Sorted model factory names matching every filter.
+
+    Raises:
+        ValueError: if the task or maturity is unknown.
+    """
+    if task is not None and task not in _TASKS:
+        raise ValueError(f"unknown task: {task}")
+    if maturity is not None:
+        maturity = Maturity(maturity)
+
+    names = []
+    for name in _model_factories():
+        info = get_model_info(name)
+        if task is not None and info.task != task:
+            continue
+        if maturity is not None and info.maturity != maturity:
+            continue
+        if pretrained is not None and info.pretrained is not pretrained:
+            continue
+        names.append(name)
+    return sorted(names)
+
+
+def list_checkpoints(name: str) -> tuple[Checkpoint, ...]:
+    """List typed checkpoints declared for a model.
+
+    Args:
+        name: public model factory name.
+
+    Returns:
+        Checkpoints whose metadata identifies the requested architecture.
+    """
+    get_model_info(name)
+    return _checkpoint_map().get(name, ())
+
+
+def get_model(name: str, *, checkpoint: Checkpoint | None = None, **kwargs: Any) -> nn.Module:
+    """Instantiate a public model by name.
+
+    Args:
+        name: public model factory name.
+        checkpoint: optional typed checkpoint matching the model.
+        kwargs: arguments forwarded to the model factory.
+
+    Returns:
+        Instantiated model.
+
+    Raises:
+        TypeError: if checkpoint is not checkpoint metadata.
+        ValueError: if the name is unknown or the checkpoint is incompatible.
+    """
+    try:
+        _, factory = _model_factories()[name]
+    except KeyError as exc:
+        raise ValueError(f"unknown model: {name}") from exc
+
+    if checkpoint is not None:
+        if not isinstance(checkpoint, Checkpoint):
+            raise TypeError("checkpoint must be a Checkpoint")
+        if checkpoint.meta.arch != name:
+            raise ValueError(f"checkpoint architecture {checkpoint.meta.arch!r} does not match {name!r}")
+        if "checkpoint" not in inspect.signature(factory).parameters:
+            raise ValueError(f"model {name!r} does not accept typed checkpoints")
+        kwargs["checkpoint"] = checkpoint
+    return factory(**kwargs)

--- a/holocron/models/checkpoints.py
+++ b/holocron/models/checkpoints.py
@@ -14,12 +14,21 @@ __all__ = [
     "Dataset",
     "Evaluation",
     "LoadingMeta",
+    "Maturity",
     "Metric",
     "PreProcessing",
     "TrainingRecipe",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+class Maturity(StrEnum):
+    """Evidence available for a model or checkpoint."""
+
+    VALIDATED = "validated"
+    PREVIEW = "preview"
+    EXPERIMENTAL = "experimental"
 
 
 @dataclass
@@ -93,6 +102,8 @@ class Checkpoint:
     pre_processing: PreProcessing
     # How to reproduce
     recipe: TrainingRecipe
+    # Strength of the recorded evidence
+    maturity: Maturity = Maturity.PREVIEW
 
 
 def _handle_legacy_pretrained(

--- a/holocron/models/classification/__init__.py
+++ b/holocron/models/classification/__init__.py
@@ -3,6 +3,7 @@ from .darknet import *
 from .darknetv2 import *
 from .darknetv3 import *
 from .darknetv4 import *
+from .iformer import *
 from .mobileone import *
 from .pyconv_resnet import *
 from .repvgg import *

--- a/holocron/models/classification/_features.py
+++ b/holocron/models/classification/_features.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2022-2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+from torch import Tensor, nn
+
+
+class _ClassifierMixin:
+    """Common feature-extraction interface for sequential classifiers."""
+
+    def _head(self) -> tuple[str, nn.Module]:
+        for name in ("head", "classifier"):
+            if name in self._modules:
+                return name, self._modules[name]
+        raise RuntimeError("classifier has no head module")
+
+    def forward_features(self, x: Tensor) -> Tensor:
+        """Return the spatial representation produced by the backbone.
+
+        Args:
+            x: input tensor
+
+        Returns:
+            spatial feature tensor
+        """
+        return self.features(x)
+
+    def forward_head(self, x: Tensor, pre_logits: bool = False) -> Tensor:
+        """Pool features and optionally return the embedding before classification.
+
+        Args:
+            x: spatial feature tensor
+            pre_logits: whether to return the embedding before the final classifier
+
+        Returns:
+            logits or pre-logits embedding
+        """
+        name, head = self._head()
+        if list(self._modules).index(name) < list(self._modules).index("pool"):
+            if pre_logits:
+                return self.pool(x)
+            return self.pool(head(x))
+
+        x = self.pool(x)
+        if isinstance(head, nn.Sequential):
+            modules = list(head.children())
+            for module in modules[:-1]:
+                x = module(x)
+            return x if pre_logits else modules[-1](x)
+        return x if pre_logits else head(x)
+
+    def get_classifier(self) -> nn.Module:
+        """Return the final classification module.
+
+        Returns:
+            final linear or convolutional classification module
+        """
+        _, head = self._head()
+        if isinstance(head, nn.Sequential):
+            return head[-1]
+        return head
+
+    def reset_classifier(self, num_classes: int) -> None:
+        """Replace the final classification module.
+
+        Args:
+            num_classes: number of outputs for the new classifier
+
+        Raises:
+            TypeError: if the existing classifier is not linear or convolutional
+        """
+        name, head = self._head()
+        classifier = self.get_classifier()
+        if isinstance(classifier, nn.Linear):
+            replacement: nn.Module = nn.Linear(
+                classifier.in_features,
+                num_classes,
+                bias=classifier.bias is not None,
+                device=classifier.weight.device,
+                dtype=classifier.weight.dtype,
+            )
+        elif isinstance(classifier, nn.Conv2d):
+            replacement = nn.Conv2d(
+                classifier.in_channels,
+                num_classes,
+                classifier.kernel_size,
+                classifier.stride,
+                classifier.padding,
+                classifier.dilation,
+                classifier.groups,
+                bias=classifier.bias is not None,
+                padding_mode=classifier.padding_mode,
+                device=classifier.weight.device,
+                dtype=classifier.weight.dtype,
+            )
+        else:
+            raise TypeError(f"unsupported classifier type: {type(classifier).__name__}")
+        replacement.train(classifier.training)
+
+        if isinstance(head, nn.Sequential):
+            head[-1] = replacement
+        else:
+            setattr(self, name, replacement)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.forward_head(self.forward_features(x))

--- a/holocron/models/classification/convnext.py
+++ b/holocron/models/classification/convnext.py
@@ -17,6 +17,7 @@ from holocron.nn import GlobalAvgPool2d
 
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..utils import _checkpoint, _configure_model, conv_sequence
+from ._features import _ClassifierMixin
 from .resnet import _ResBlock
 
 __all__ = [
@@ -113,7 +114,7 @@ class Bottlenext(_ResBlock):
         )
 
 
-class ConvNeXt(nn.Sequential):
+class ConvNeXt(_ClassifierMixin, nn.Sequential):
     def __init__(
         self,
         num_blocks: list[int],

--- a/holocron/models/classification/darknet.py
+++ b/holocron/models/classification/darknet.py
@@ -15,6 +15,7 @@ from holocron.nn.init import init_module
 
 from ..presets import IMAGENETTE
 from ..utils import conv_sequence, load_pretrained_params
+from ._features import _ClassifierMixin
 
 __all__ = ["DarknetV1", "darknet24"]
 
@@ -103,7 +104,7 @@ class DarknetBodyV1(nn.Sequential):
         return nn.Sequential(*layers)
 
 
-class DarknetV1(nn.Sequential):
+class DarknetV1(_ClassifierMixin, nn.Sequential):
     def __init__(
         self,
         layout: list[list[int]],

--- a/holocron/models/classification/darknetv2.py
+++ b/holocron/models/classification/darknetv2.py
@@ -17,6 +17,7 @@ from holocron.nn.init import init_module
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..presets import IMAGENETTE
 from ..utils import _checkpoint, _configure_model, conv_sequence
+from ._features import _ClassifierMixin
 
 __all__ = ["Darknet19_Checkpoint", "DarknetV2", "darknet19"]
 
@@ -151,7 +152,7 @@ class DarknetBodyV2(nn.Sequential):
         return super().forward(x)
 
 
-class DarknetV2(nn.Sequential):
+class DarknetV2(_ClassifierMixin, nn.Sequential):
     def __init__(
         self,
         layout: list[tuple[int, int]],

--- a/holocron/models/classification/darknetv3.py
+++ b/holocron/models/classification/darknetv3.py
@@ -16,6 +16,7 @@ from holocron.nn.init import init_module
 
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..utils import _checkpoint, _configure_model, conv_sequence
+from ._features import _ClassifierMixin
 from .resnet import _ResBlock
 
 __all__ = ["Darknet53_Checkpoint", "DarknetV3", "darknet53"]
@@ -166,7 +167,7 @@ class DarknetBodyV3(nn.Sequential):
         return features
 
 
-class DarknetV3(nn.Sequential):
+class DarknetV3(_ClassifierMixin, nn.Sequential):
     def __init__(
         self,
         layout: list[tuple[int, int]],

--- a/holocron/models/classification/darknetv4.py
+++ b/holocron/models/classification/darknetv4.py
@@ -17,6 +17,7 @@ from holocron.nn.init import init_module
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..presets import IMAGENETTE
 from ..utils import _checkpoint, _configure_model, conv_sequence
+from ._features import _ClassifierMixin
 from .darknetv3 import ResBlock
 
 __all__ = ["CSPDarknet53_Checkpoint", "CSPDarknet53_Mish_Checkpoint", "DarknetV4", "cspdarknet53", "cspdarknet53_mish"]
@@ -183,7 +184,7 @@ class DarknetBodyV4(nn.Sequential):
         return features
 
 
-class DarknetV4(nn.Sequential):
+class DarknetV4(_ClassifierMixin, nn.Sequential):
     def __init__(
         self,
         layout: list[tuple[int, int]],

--- a/holocron/models/classification/iformer.py
+++ b/holocron/models/classification/iformer.py
@@ -1,0 +1,357 @@
+# Copyright (C) 2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from torch import Tensor, nn
+from torchvision.ops import StochasticDepth
+
+from holocron.nn import GlobalAvgPool2d
+
+from ..checkpoints import Checkpoint, _handle_legacy_pretrained
+from ..utils import _configure_model, conv_sequence
+from ._features import _ClassifierMixin
+
+__all__ = ["IFormer", "iformer_m", "iformer_s", "iformer_t"]
+
+
+def _conv_norm(
+    in_channels: int,
+    out_channels: int,
+    kernel_size: int = 1,
+    stride: int = 1,
+    padding: int = 0,
+    groups: int = 1,
+) -> nn.Sequential:
+    return nn.Sequential(
+        *conv_sequence(
+            in_channels,
+            out_channels,
+            norm_layer=nn.BatchNorm2d,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            groups=groups,
+        )
+    )
+
+
+class _Residual(nn.Module):
+    def __init__(
+        self,
+        block: nn.Module,
+        channels: int,
+        stochastic_depth_prob: float,
+        layer_scale_init_value: float,
+    ) -> None:
+        super().__init__()
+        self.block = block
+        self.drop_path = StochasticDepth(stochastic_depth_prob, "row")
+        self.layer_scale = (
+            nn.Parameter(torch.full((1, channels, 1, 1), layer_scale_init_value))
+            if layer_scale_init_value > 0
+            else None
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        residual = self.drop_path(self.block(x))
+        if self.layer_scale is not None:
+            residual = self.layer_scale * residual
+        return x + residual
+
+
+class _ConvBlock(_Residual):
+    def __init__(
+        self,
+        channels: int,
+        ratio: int,
+        stochastic_depth_prob: float,
+        layer_scale_init_value: float,
+    ) -> None:
+        hidden_channels = ratio * channels
+        super().__init__(
+            nn.Sequential(
+                _conv_norm(channels, channels, 7, padding=3, groups=channels),
+                _conv_norm(channels, hidden_channels),
+                nn.GELU(),
+                _conv_norm(hidden_channels, channels),
+            ),
+            channels,
+            stochastic_depth_prob,
+            layer_scale_init_value,
+        )
+
+
+class _RepCPE(_Residual):
+    def __init__(self, channels: int, stochastic_depth_prob: float, layer_scale_init_value: float) -> None:
+        super().__init__(
+            _conv_norm(channels, channels, 3, padding=1, groups=channels),
+            channels,
+            stochastic_depth_prob,
+            layer_scale_init_value,
+        )
+
+
+class _SelfModulationAttention(nn.Module):
+    def __init__(self, channels: int, ratio: int, head_dim_reduce_ratio: int) -> None:
+        super().__init__()
+        hidden_channels = ratio * channels
+        attention_channels = channels // head_dim_reduce_ratio
+        self.scale = attention_channels**-0.5
+        self.q = _conv_norm(channels, attention_channels)
+        self.k = _conv_norm(channels, attention_channels)
+        self.v_gate = _conv_norm(channels, 2 * hidden_channels)
+        self.proj = _conv_norm(hidden_channels, channels)
+
+    def forward(self, x: Tensor) -> Tensor:
+        batch_size, _, height, width = x.shape
+        value, gate = self.v_gate(x).sigmoid().chunk(2, dim=1)
+        query = self.q(x).flatten(2) * self.scale
+        key = self.k(x).flatten(2)
+        attention = (query.transpose(-2, -1) @ key).softmax(dim=-1)
+        value = value.flatten(2) @ attention.transpose(-2, -1)
+        return self.proj(value.reshape(batch_size, -1, height, width) * gate)
+
+
+class _AttentionBlock(_Residual):
+    def __init__(
+        self,
+        channels: int,
+        ratio: int,
+        head_dim_reduce_ratio: int,
+        stochastic_depth_prob: float,
+        layer_scale_init_value: float,
+    ) -> None:
+        super().__init__(
+            _SelfModulationAttention(channels, ratio, head_dim_reduce_ratio),
+            channels,
+            stochastic_depth_prob,
+            layer_scale_init_value,
+        )
+
+
+class _FFN(_Residual):
+    def __init__(
+        self,
+        channels: int,
+        ratio: int,
+        stochastic_depth_prob: float,
+        layer_scale_init_value: float,
+    ) -> None:
+        hidden_channels = ratio * channels
+        super().__init__(
+            nn.Sequential(
+                _conv_norm(channels, hidden_channels),
+                nn.GELU(),
+                _conv_norm(hidden_channels, channels),
+            ),
+            channels,
+            stochastic_depth_prob,
+            layer_scale_init_value,
+        )
+
+
+class _FusedIB(nn.Sequential):
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int, stride: int) -> None:
+        hidden_channels = 4 * in_channels
+        super().__init__(
+            _conv_norm(
+                in_channels,
+                hidden_channels,
+                kernel_size,
+                stride=stride,
+                padding=kernel_size // 2,
+            ),
+            nn.GELU(),
+            _conv_norm(hidden_channels, out_channels),
+        )
+
+
+class IFormer(_ClassifierMixin, nn.Sequential):
+    """Implements iFormer as described in
+    ["iFormer: Integrating ConvNet and Transformer for Mobile Application"](https://arxiv.org/abs/2501.15369).
+
+    Args:
+        channels: number of output channels in each stage
+        stage_layouts: per-stage counts of leading convolution blocks, attention triplets, and trailing convolutions
+        conv_ratio: expansion ratio of convolution blocks
+        ffn_ratio: expansion ratio of feed-forward blocks
+        num_classes: number of output classes
+        in_channels: number of input channels
+        stochastic_depth_prob: maximum stochastic-depth probability
+        layer_scale_init_value: initial residual layer-scale value; disabled when zero
+        act_layer: activation used by the fused inverted-bottleneck stem
+    """
+
+    def __init__(
+        self,
+        channels: list[int],
+        stage_layouts: list[tuple[int, int, int]],
+        conv_ratio: int,
+        ffn_ratio: int,
+        num_classes: int = 10,
+        in_channels: int = 3,
+        stochastic_depth_prob: float = 0.0,
+        layer_scale_init_value: float = 0.0,
+        act_layer: Callable[[], nn.Module] = nn.GELU,
+    ) -> None:
+        if len(channels) != 4 or len(stage_layouts) != 4:
+            raise ValueError("`channels` and `stage_layouts` are expected to contain four stages")
+
+        num_blocks = sum(num_conv + 3 * num_attention + num_tail for num_conv, num_attention, num_tail in stage_layouts)
+        drop_rates = torch.linspace(0, stochastic_depth_prob, num_blocks).tolist()
+        block_idx = 0
+        features: list[nn.Module] = [
+            nn.Sequential(
+                _conv_norm(in_channels, channels[0] // 2, 5, stride=2, padding=2),
+                act_layer(),
+                _FusedIB(channels[0] // 2, channels[0], 5, stride=2),
+            )
+        ]
+        for stage_idx, (stage_channels, layout) in enumerate(zip(channels, stage_layouts, strict=True)):
+            if stage_idx:
+                features.append(_conv_norm(channels[stage_idx - 1], stage_channels, 3, stride=2, padding=1))
+
+            num_conv, num_attention, num_tail = layout
+            stage: list[nn.Module] = []
+            for _ in range(num_conv):
+                stage.append(
+                    _ConvBlock(
+                        stage_channels,
+                        conv_ratio,
+                        drop_rates[block_idx],
+                        layer_scale_init_value,
+                    )
+                )
+                block_idx += 1
+            for _ in range(num_attention):
+                stage.extend([
+                    _RepCPE(stage_channels, drop_rates[block_idx], layer_scale_init_value),
+                    _AttentionBlock(
+                        stage_channels,
+                        1,
+                        2 if stage_idx == 2 else 4,
+                        drop_rates[block_idx + 1],
+                        layer_scale_init_value,
+                    ),
+                    _FFN(
+                        stage_channels,
+                        ffn_ratio,
+                        drop_rates[block_idx + 2],
+                        layer_scale_init_value,
+                    ),
+                ])
+                block_idx += 3
+            for _ in range(num_tail):
+                stage.append(
+                    _ConvBlock(
+                        stage_channels,
+                        conv_ratio,
+                        drop_rates[block_idx],
+                        layer_scale_init_value,
+                    )
+                )
+                block_idx += 1
+            features.append(nn.Sequential(*stage))
+
+        head = nn.Sequential(nn.BatchNorm1d(channels[-1]), nn.Linear(channels[-1], num_classes))
+        super().__init__(
+            OrderedDict([
+                ("features", nn.Sequential(*features)),
+                ("pool", GlobalAvgPool2d(flatten=True)),
+                ("head", head),
+            ])
+        )
+
+        for module in self.modules():
+            if isinstance(module, (nn.Conv2d, nn.Linear)):
+                nn.init.trunc_normal_(module.weight, std=0.02)
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+
+
+def _iformer(
+    checkpoint: Checkpoint | None,
+    progress: bool,
+    channels: list[int],
+    stage_layouts: list[tuple[int, int, int]],
+    conv_ratio: int,
+    ffn_ratio: int,
+    **kwargs: Any,
+) -> IFormer:
+    model = IFormer(channels, stage_layouts, conv_ratio, ffn_ratio, **kwargs)
+    return _configure_model(model, checkpoint, progress=progress)
+
+
+def iformer_t(
+    pretrained: bool = False,
+    checkpoint: Checkpoint | None = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> IFormer:
+    """iFormer-T model.
+
+    Args:
+        pretrained: If True, loads the default checkpoint when one is available
+        checkpoint: If specified, sets the model parameters to the checkpoint values
+        progress: If True, displays a download progress bar
+        kwargs: keyword arguments of [`IFormer`][holocron.models.classification.iformer.IFormer]
+
+    Returns:
+        An iFormer-T model
+    """
+    checkpoint = _handle_legacy_pretrained(pretrained, checkpoint, None)
+    return _iformer(
+        checkpoint, progress, [32, 64, 128, 256], [(2, 0, 0), (2, 0, 0), (6, 3, 1), (0, 2, 0)], 3, 2, **kwargs
+    )
+
+
+def iformer_s(
+    pretrained: bool = False,
+    checkpoint: Checkpoint | None = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> IFormer:
+    """iFormer-S model.
+
+    Args:
+        pretrained: If True, loads the default checkpoint when one is available
+        checkpoint: If specified, sets the model parameters to the checkpoint values
+        progress: If True, displays a download progress bar
+        kwargs: keyword arguments of [`IFormer`][holocron.models.classification.iformer.IFormer]
+
+    Returns:
+        An iFormer-S model
+    """
+    checkpoint = _handle_legacy_pretrained(pretrained, checkpoint, None)
+    return _iformer(
+        checkpoint, progress, [32, 64, 176, 320], [(2, 0, 0), (2, 0, 0), (9, 3, 1), (0, 2, 0)], 4, 3, **kwargs
+    )
+
+
+def iformer_m(
+    pretrained: bool = False,
+    checkpoint: Checkpoint | None = None,
+    progress: bool = True,
+    **kwargs: Any,
+) -> IFormer:
+    """iFormer-M model.
+
+    Args:
+        pretrained: If True, loads the default checkpoint when one is available
+        checkpoint: If specified, sets the model parameters to the checkpoint values
+        progress: If True, displays a download progress bar
+        kwargs: keyword arguments of [`IFormer`][holocron.models.classification.iformer.IFormer]
+
+    Returns:
+        An iFormer-M model
+    """
+    checkpoint = _handle_legacy_pretrained(pretrained, checkpoint, None)
+    return _iformer(
+        checkpoint, progress, [48, 96, 192, 384], [(2, 0, 0), (2, 0, 0), (9, 4, 1), (0, 2, 0)], 4, 3, **kwargs
+    )

--- a/holocron/models/classification/mobileone.py
+++ b/holocron/models/classification/mobileone.py
@@ -15,6 +15,7 @@ from holocron.nn import GlobalAvgPool2d, init
 
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..utils import _checkpoint, _configure_model, conv_sequence, fuse_conv_bn
+from ._features import _ClassifierMixin
 
 __all__ = [
     "MobileOne",
@@ -179,7 +180,7 @@ class MobileOneBlock(nn.Sequential):
         self[2] = self[2].reparametrize()
 
 
-class MobileOne(nn.Sequential):
+class MobileOne(_ClassifierMixin, nn.Sequential):
     def __init__(
         self,
         num_blocks: list[int],

--- a/holocron/models/classification/repvgg.py
+++ b/holocron/models/classification/repvgg.py
@@ -15,6 +15,7 @@ from holocron.nn import GlobalAvgPool2d, init
 
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..utils import _checkpoint, _configure_model, conv_sequence, fuse_conv_bn
+from ._features import _ClassifierMixin
 
 __all__ = [
     "RepBlock",
@@ -111,7 +112,7 @@ class RepBlock(nn.Module):
         self.branches = rep
 
 
-class RepVGG(nn.Sequential):
+class RepVGG(_ClassifierMixin, nn.Sequential):
     """Implements a reparametrized version of VGG as described in
     `"RepVGG: Making VGG-style ConvNets Great Again" <https://arxiv.org/pdf/2101.03697.pdf>`_
 

--- a/holocron/models/classification/repvit.py
+++ b/holocron/models/classification/repvit.py
@@ -15,6 +15,7 @@ from holocron.nn import GlobalAvgPool2d
 
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..utils import _configure_model, fuse_conv_bn
+from ._features import _ClassifierMixin
 
 __all__ = ["RepViT", "repvit_m0_9", "repvit_m1_0", "repvit_m1_1"]
 
@@ -184,7 +185,7 @@ class _RepViTBlock(nn.Module):
         channel_mixer[-1] = cast(_ConvNorm, channel_mixer[-1]).reparametrize()
 
 
-class RepViT(nn.Sequential):
+class RepViT(_ClassifierMixin, nn.Sequential):
     """Implements RepViT as described in
     ["RepViT: Revisiting Mobile CNN From ViT Perspective"](https://arxiv.org/abs/2307.09283).
 

--- a/holocron/models/classification/resnet.py
+++ b/holocron/models/classification/resnet.py
@@ -15,6 +15,7 @@ from holocron.nn import GlobalAvgPool2d, init
 from ..checkpoints import Checkpoint, _handle_legacy_pretrained
 from ..presets import IMAGENET, IMAGENETTE
 from ..utils import _checkpoint, _configure_model, conv_sequence
+from ._features import _ClassifierMixin
 
 __all__ = [
     "BasicBlock",
@@ -221,7 +222,7 @@ class ChannelRepeat(nn.Module):
         return x.repeat(*repeats)
 
 
-class ResNet(nn.Sequential):
+class ResNet(_ClassifierMixin, nn.Sequential):
     def __init__(  # noqa: PLR0912
         self,
         block: type[BasicBlock | Bottleneck],

--- a/holocron/models/classification/rexnet.py
+++ b/holocron/models/classification/rexnet.py
@@ -17,6 +17,7 @@ from holocron.nn import GlobalAvgPool2d, init
 
 from ..checkpoints import Checkpoint, Dataset, _handle_legacy_pretrained
 from ..utils import _checkpoint, _configure_model, conv_sequence
+from ._features import _ClassifierMixin
 
 __all__ = [
     "ReXBlock",
@@ -143,7 +144,7 @@ class ReXBlock(nn.Module):
         return out
 
 
-class ReXNet(nn.Sequential):
+class ReXNet(_ClassifierMixin, nn.Sequential):
     def __init__(
         self,
         width_mult: float = 1.0,

--- a/holocron/models/detection/yolo.py
+++ b/holocron/models/detection/yolo.py
@@ -9,7 +9,7 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
-from torchvision.ops.boxes import box_iou, nms
+from torchvision.ops.boxes import batched_nms, box_iou
 
 from holocron.nn.init import init_module
 
@@ -190,34 +190,26 @@ class _YOLO(nn.Module):
             clamp=True,
         ).reshape(b_o.shape[0], -1, 4)
 
-        detections = []
-        for idx in range(b_coords.shape[0]):
-            coords = torch.zeros((0, 4), dtype=b_o.dtype, device=b_o.device)
-            scores = torch.zeros(0, dtype=b_o.dtype, device=b_o.device)
-            labels = torch.zeros(0, dtype=torch.long, device=b_o.device)
+        return _post_process(pred_xyxy, b_o, b_scores, rpn_nms_thresh, box_score_thresh)
 
-            # Objectness filter
-            obj_mask = b_o[idx] >= 0.5
-            if torch.any(obj_mask):
-                coords = pred_xyxy[idx, obj_mask]
-                scores, labels = b_scores[idx, obj_mask].max(dim=-1)
-                # Multiply by the objectness
-                scores.mul_(b_o[idx, obj_mask])
 
-                # Confidence threshold
-                coords = coords[scores >= box_score_thresh]
-                labels = labels[scores >= box_score_thresh]
-                scores = scores[scores >= box_score_thresh]
+def _post_process(
+    boxes: Tensor,
+    b_o: Tensor,
+    b_scores: Tensor,
+    rpn_nms_thresh: float = 0.7,
+    box_score_thresh: float = 0.05,
+) -> list[dict[str, Tensor]]:
+    detections: list[dict[str, Tensor]] = []
+    for idx in range(boxes.shape[0]):
+        scores, labels = b_scores[idx].max(dim=-1)
+        scores *= b_o[idx]
+        score_mask = scores >= box_score_thresh
+        coords, scores, labels = boxes[idx, score_mask], scores[score_mask], labels[score_mask]
+        kept_idxs = batched_nms(coords, scores, labels, iou_threshold=rpn_nms_thresh)
+        detections.append({"boxes": coords[kept_idxs], "scores": scores[kept_idxs], "labels": labels[kept_idxs]})
 
-                # NMS
-                kept_idxs = nms(coords, scores, iou_threshold=rpn_nms_thresh)
-                coords = coords[kept_idxs]
-                scores = scores[kept_idxs]
-                labels = labels[kept_idxs]
-
-            detections.append({"boxes": coords, "scores": scores, "labels": labels})
-
-        return detections
+    return detections
 
 
 class YOLOv1(_YOLO):

--- a/holocron/models/detection/yolov4.py
+++ b/holocron/models/detection/yolov4.py
@@ -9,7 +9,7 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
-from torchvision.ops.boxes import box_iou, nms
+from torchvision.ops.boxes import box_iou
 from torchvision.ops.misc import FrozenBatchNorm2d
 
 from holocron.nn import SPP, DropBlock2d
@@ -19,6 +19,7 @@ from holocron.ops.boxes import ciou_loss
 from ..classification.darknetv4 import DarknetBodyV4
 from ..classification.darknetv4 import default_cfgs as dark_cfgs
 from ..utils import conv_sequence, load_pretrained_params
+from .yolo import _post_process
 
 __all__ = ["PAN", "YOLOv4", "yolov4"]
 
@@ -239,16 +240,24 @@ class YoloLayer(nn.Module):
         scale_xy: float = 1.0,
         iou_thresh: float = 0.213,
         lambda_obj: float = 1,
-        lambda_noobj: float = 0.001,
-        lambda_class: float = 0.1,
-        lambda_coords: float = 1.0,
+        lambda_noobj: float = 1,
+        lambda_class: float = 1,
+        lambda_coords: float = 0.07,
         rpn_nms_thresh: float = 0.7,
         box_score_thresh: float = 0.05,
-        ignore_thresh: float = 0.5,
+        ignore_thresh: float = 0.7,
+        all_anchors: Tensor | None = None,
+        anchor_mask: Tensor | None = None,
     ) -> None:
         super().__init__()
         self.num_classes: int = num_classes
         self.register_buffer("anchors", anchors)
+        if all_anchors is None:
+            all_anchors = anchors
+        if anchor_mask is None:
+            anchor_mask = torch.arange(len(anchors), device=anchors.device)
+        self.register_buffer("all_anchors", all_anchors, persistent=False)
+        self.register_buffer("anchor_mask", anchor_mask, persistent=False)
 
         self.rpn_nms_thresh: float = rpn_nms_thresh
         self.box_score_thresh: float = box_score_thresh
@@ -284,9 +293,10 @@ class YoloLayer(nn.Module):
         b_xy[..., 1].div_(h)
 
         # Box dimension
-        b_wh = torch.exp(output[..., 2:4]) * self.anchors.view(1, 1, 1, -1, 2)
-        # Fix overflow by clipping
-        b_wh = b_wh.clamp_(0, 2)
+        anchors = self.anchors.to(dtype=output.dtype).view(1, 1, 1, -1, 2)
+        max_wh_logits = torch.log(2 / anchors)
+        wh_logits = torch.minimum(output[..., 2:4], max_wh_logits)
+        b_wh = (torch.exp(wh_logits) * anchors).clamp_min_(2 * torch.finfo(output.dtype).eps)
 
         top_left = b_xy - 0.5 * b_wh
         bot_right = top_left + b_wh
@@ -303,89 +313,56 @@ class YoloLayer(nn.Module):
     def post_process(
         boxes: Tensor, b_o: Tensor, b_scores: Tensor, rpn_nms_thresh: float = 0.7, box_score_thresh: float = 0.05
     ) -> list[dict[str, Tensor]]:
-        b_o = torch.sigmoid(b_o)
-        b_scores = torch.sigmoid(b_scores)
-
-        boxes = boxes.clamp_(0, 1)
-        detections = []
-        for idx in range(b_o.shape[0]):
-            coords = torch.zeros((0, 4), dtype=torch.float32, device=b_o.device)
-            scores = torch.zeros(0, dtype=torch.float32, device=b_o.device)
-            labels = torch.zeros(0, dtype=torch.long, device=b_o.device)
-
-            # Objectness filter
-            if torch.any(b_o[idx] >= 0.5):
-                coords = boxes[idx, b_o[idx] >= 0.5]
-                scores, labels = b_scores[idx, b_o[idx] >= 0.5].max(dim=-1)
-                # Multiply by the objectness
-                scores.mul_(b_o[idx, b_o[idx] >= 0.5])
-
-                # Confidence threshold
-                coords = coords[scores >= box_score_thresh]
-                labels = labels[scores >= box_score_thresh]
-                scores = scores[scores >= box_score_thresh]
-                coords = coords.clamp_(0, 1)
-                # NMS
-                kept_idxs = nms(coords, scores, iou_threshold=rpn_nms_thresh)
-                coords = coords[kept_idxs]
-                scores = scores[kept_idxs]
-                labels = labels[kept_idxs]
-
-            detections.append({"boxes": coords, "scores": scores, "labels": labels})
-
-        return detections
+        return _post_process(
+            boxes.clamp(0, 1).reshape(boxes.shape[0], -1, 4),
+            torch.sigmoid(b_o).flatten(1),
+            torch.sigmoid(b_scores).reshape(b_scores.shape[0], -1, b_scores.shape[-1]),
+            rpn_nms_thresh,
+            box_score_thresh,
+        )
 
     def _build_targets(
         self, pred_boxes: Tensor, b_o: Tensor, b_scores: Tensor, target: list[dict[str, Tensor]]
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-        b, h, w, num_anchors = b_o.shape
+        _b, h, w, num_anchors = b_o.shape
 
-        # Target formatting
-        target_o = torch.zeros((b, h, w, num_anchors), device=b_o.device)
-        target_scores = torch.zeros((b, h, w, num_anchors, self.num_classes), device=b_o.device)
-        obj_mask = torch.zeros((b, h, w, num_anchors), dtype=torch.bool, device=b_o.device)
-        noobj_mask = torch.ones((b, h, w, num_anchors), dtype=torch.bool, device=b_o.device)
+        target_boxes = torch.zeros_like(pred_boxes)
+        target_scores = torch.zeros_like(b_scores)
+        obj_mask = torch.zeros_like(b_o, dtype=torch.bool)
+        noobj_mask = torch.ones_like(b_o, dtype=torch.bool)
 
-        gt_boxes = [t["boxes"] for t in target]
-        gt_labels = [t["labels"] for t in target]
+        self.all_anchors: Tensor
+        self.anchor_mask: Tensor
+        anchor_boxes = torch.cat((-self.all_anchors / 2, self.all_anchors / 2), dim=-1)
+        for batch_idx, target_ in enumerate(target):
+            boxes, labels = target_["boxes"], target_["labels"]
+            if boxes.shape[0] == 0:
+                continue
 
-        # GT coords --> left, top, width, height
-        boxes = torch.cat(gt_boxes, dim=0)
-        gt_centers = boxes[..., [0, 2, 1, 3]].reshape(-1, 2, 2).mean(dim=-1)
-        gt_centers[:, 0] *= w
-        gt_centers[:, 1] *= h
-        gt_centers = gt_centers.to(dtype=torch.long)
+            ignored = box_iou(pred_boxes[batch_idx].detach().reshape(-1, 4), boxes).amax(dim=1)
+            noobj_mask[batch_idx] = ignored.reshape(h, w, num_anchors) <= self.ignore_thresh
 
-        target_selection = torch.tensor(
-            [idx_ for idx_, boxes_ in enumerate(gt_boxes) for _ in range(boxes_.shape[0])],
-            dtype=torch.long,
-            device=b_o.device,
-        )
-        if target_selection.shape[0] > 0:
-            # Anchors IoU
             gt_wh = boxes[:, 2:] - boxes[:, :2]
-            anchor_idxs = box_iou(
-                torch.cat((-gt_wh, gt_wh), dim=-1), torch.cat((-self.anchors, self.anchors), dim=-1)
-            ).argmax(dim=1)
+            anchor_ious = box_iou(torch.cat((-gt_wh / 2, gt_wh / 2), dim=-1), anchor_boxes)
+            selected = anchor_ious > self.iou_thresh
+            selected.scatter_(1, anchor_ious.argmax(dim=1, keepdim=True), True)
 
-            # Assign boxes
-            obj_mask[target_selection, gt_centers[:, 1], gt_centers[:, 0], anchor_idxs] = True
-            noobj_mask[target_selection, gt_centers[:, 1], gt_centers[:, 0], :] = False
+            centers = (boxes[:, :2] + boxes[:, 2:]) / 2
+            grid_x = (centers[:, 0] * w).long().clamp_(0, w - 1)
+            grid_y = (centers[:, 1] * h).long().clamp_(0, h - 1)
+            for gt_idx, global_anchor_idx in selected.nonzero():
+                local_anchor = (self.anchor_mask == global_anchor_idx).nonzero()
+                if local_anchor.numel() == 0:
+                    continue
+                anchor_idx = local_anchor.item()
+                y, x = grid_y[gt_idx], grid_x[gt_idx]
+                obj_mask[batch_idx, y, x, anchor_idx] = True
+                noobj_mask[batch_idx, y, x, anchor_idx] = False
+                target_boxes[batch_idx, y, x, anchor_idx] = boxes[gt_idx]
+                target_scores[batch_idx, y, x, anchor_idx] = 0
+                target_scores[batch_idx, y, x, anchor_idx, labels[gt_idx]] = 1
 
-            # B * cells * predictors * info
-            for idx in range(b):
-                if gt_boxes[idx].shape[0] > 0:
-                    # IoU with cells that enclose the GT centers
-                    gt_ious, gt_idxs = box_iou(pred_boxes[idx, obj_mask[idx]], gt_boxes[idx]).max(dim=1)
-                    # Objectness target
-                    target_o[idx, obj_mask[idx]] = gt_ious
-                    # Classification target
-                    target_scores[idx, obj_mask[idx], gt_labels[idx][gt_idxs]] = 1.0
-                    # Ignore predictions
-                    gt_ious = box_iou(pred_boxes[idx, noobj_mask[idx]], gt_boxes[idx]).max(dim=1).values
-                    noobj_mask[idx, noobj_mask[idx]][gt_ious >= self.ignore_thresh] = False
-
-        return target_o, target_scores, obj_mask, noobj_mask
+        return target_boxes, target_scores, obj_mask, noobj_mask
 
     def _compute_losses(
         self,
@@ -394,29 +371,24 @@ class YoloLayer(nn.Module):
         b_scores: Tensor,
         target: list[dict[str, Tensor]],
     ) -> dict[str, Tensor]:
-        target_o, target_scores, obj_mask, noobj_mask = self._build_targets(pred_boxes, b_o, b_scores, target)
+        target_boxes, target_scores, obj_mask, noobj_mask = self._build_targets(pred_boxes, b_o, b_scores, target)
 
-        # Bbox regression
-        bbox_loss = torch.zeros(1, device=b_o.device)
-        for idx, target_ in enumerate(target):
-            if target_["boxes"].shape[0] > 0 and torch.any(obj_mask[idx]):
-                bbox_loss += ciou_loss(pred_boxes[idx, obj_mask[idx]], target_["boxes"]).min(dim=1).values.sum()
-
-        b_o = torch.sigmoid(b_o)
+        bbox_loss = pred_boxes.sum() * 0
+        if torch.any(obj_mask):
+            matched_boxes = target_boxes[obj_mask]
+            areas = (matched_boxes[:, 2] - matched_boxes[:, 0]) * (matched_boxes[:, 3] - matched_boxes[:, 1])
+            bbox_loss = ((2 - areas) * ciou_loss(pred_boxes[obj_mask], matched_boxes).diagonal()).sum()
 
         return {
-            "obj_loss": self.lambda_obj * F.mse_loss(b_o[obj_mask], target_o[obj_mask], reduction="sum") / b_o.shape[0],
-            "noobj_loss": self.lambda_noobj * b_o[noobj_mask].pow(2).sum() / b_o.shape[0],
+            "obj_loss": self.lambda_obj
+            * F.binary_cross_entropy_with_logits(b_o[obj_mask], torch.ones_like(b_o[obj_mask]), reduction="sum")
+            / b_o.shape[0],
+            "noobj_loss": self.lambda_noobj
+            * F.binary_cross_entropy_with_logits(b_o[noobj_mask], torch.zeros_like(b_o[noobj_mask]), reduction="sum")
+            / b_o.shape[0],
             "bbox_loss": self.lambda_coords * bbox_loss / b_o.shape[0],
             "clf_loss": self.lambda_class
-            * F
-            .binary_cross_entropy_with_logits(
-                b_scores[obj_mask],
-                target_scores[obj_mask],
-                reduction="none",
-            )
-            .mean(1)
-            .sum(0)
+            * F.binary_cross_entropy_with_logits(b_scores[obj_mask], target_scores[obj_mask], reduction="sum")
             / b_o.shape[0],
         }
 
@@ -479,6 +451,7 @@ class Yolov4Head(nn.Module):
             raise AssertionError(f"The number of anchors is expected to be 3. received: {anchors.shape[0]}")
 
         super().__init__()
+        all_anchors = anchors.reshape(-1, 2)
 
         self.head1 = nn.Sequential(
             *conv_sequence(
@@ -487,7 +460,13 @@ class Yolov4Head(nn.Module):
             *conv_sequence(256, (5 + num_classes) * 3, None, None, None, conv_layer, kernel_size=1, bias=True),
         )
 
-        self.yolo1 = YoloLayer(anchors[0], num_classes=num_classes, scale_xy=1.2)
+        self.yolo1 = YoloLayer(
+            anchors[0],
+            num_classes=num_classes,
+            scale_xy=1.2,
+            all_anchors=all_anchors,
+            anchor_mask=torch.arange(3),
+        )
 
         self.pre_head2 = nn.Sequential(
             *conv_sequence(
@@ -543,7 +522,13 @@ class Yolov4Head(nn.Module):
             *conv_sequence(512, (5 + num_classes) * 3, None, None, None, conv_layer, kernel_size=1, bias=True),
         )
 
-        self.yolo2 = YoloLayer(anchors[1], num_classes=num_classes, scale_xy=1.1)
+        self.yolo2 = YoloLayer(
+            anchors[1],
+            num_classes=num_classes,
+            scale_xy=1.1,
+            all_anchors=all_anchors,
+            anchor_mask=torch.arange(3, 6),
+        )
 
         self.pre_head3 = nn.Sequential(
             *conv_sequence(
@@ -605,7 +590,13 @@ class Yolov4Head(nn.Module):
             *conv_sequence(1024, (5 + num_classes) * 3, None, None, None, conv_layer, kernel_size=1, bias=True),
         )
 
-        self.yolo3 = YoloLayer(anchors[2], num_classes=num_classes, scale_xy=1.05)
+        self.yolo3 = YoloLayer(
+            anchors[2],
+            num_classes=num_classes,
+            scale_xy=1.05,
+            all_anchors=all_anchors,
+            anchor_mask=torch.arange(6, 9),
+        )
         init_module(self, "leaky_relu")
         # Zero init
         self.head1[-1].weight.data.zero_()
@@ -629,20 +620,27 @@ class Yolov4Head(nn.Module):
         h3 = torch.cat([h3, feats[2]], dim=1)
         o3 = self.head3(h3)
 
-        # YOLO output
+        if not self.training:
+            outputs = [
+                layer._format_outputs(output)  # noqa: SLF001
+                for layer, output in zip((self.yolo1, self.yolo2, self.yolo3), (o1, o2, o3), strict=True)
+            ]
+            boxes = torch.cat([output[0].reshape(output[0].shape[0], -1, 4) for output in outputs], dim=1)
+            objectness = torch.cat([output[1].flatten(1) for output in outputs], dim=1).sigmoid()
+            scores = torch.cat(
+                [output[2].reshape(output[2].shape[0], -1, output[2].shape[-1]) for output in outputs], dim=1
+            ).sigmoid()
+            return _post_process(
+                boxes.clamp(0, 1),
+                objectness,
+                scores,
+                self.yolo1.rpn_nms_thresh,
+                self.yolo1.box_score_thresh,
+            )
+
         y1 = self.yolo1(o1, target)
         y2 = self.yolo2(o2, target)
         y3 = self.yolo3(o3, target)
-
-        if not self.training:
-            return [
-                {
-                    "boxes": torch.cat((det1["boxes"], det2["boxes"], det3["boxes"]), dim=0),
-                    "scores": torch.cat((det1["scores"], det2["scores"], det3["scores"]), dim=0),
-                    "labels": torch.cat((det1["labels"], det2["labels"], det3["labels"]), dim=0),
-                }
-                for det1, det2, det3 in zip(y1, y2, y3, strict=True)
-            ]
 
         return {k: y1[k] + y2[k] + y3[k] for k in y1}
 
@@ -730,24 +728,9 @@ def yolov4(pretrained: bool = False, progress: bool = True, pretrained_backbone:
     r"""YOLOv4 model from
     ["YOLOv4: Optimal Speed and Accuracy of Object Detection"](https://arxiv.org/pdf/2004.10934.pdf).
 
-    The architecture improves upon YOLOv3 by including: the usage of [DropBlock](https://arxiv.org/pdf/1810.12890.pdf) regularization, [Mish](https://arxiv.org/pdf/1908.08681.pdf) activation, [CSP](https://arxiv.org/pdf/2004.10934.pdf) and [SAM](https://arxiv.org/pdf/1807.06521.pdf) in the
-    backbone, [SPP](https://arxiv.org/pdf/1406.4729.pdf) and [PAN](https://arxiv.org/pdf/1803.01534.pdf) in the
-    neck.
-
-    For training, YOLOv4 uses the same multi-part loss as YOLOv3 apart from its box coordinate loss:
-
-    $$
-        \mathcal{L}_{coords} = \sum\limits_{i=0}^{S^2}  \sum\limits_{j=0}^{B}
-        \min\limits_{k \in [1, M]} C_{IoU}(\hat{loc}_{ij}, loc^{GT}_k)
-    $$
-
-    where:
-    - $S$ is size of the output feature map (13 for an input size $(416, 416)$),
-    - $B$ is the number of anchor boxes per grid cell (default: 3),
-    - $M$ is the number of ground truth boxes,
-    - $C_{IoU}$ is the complete IoU loss,
-    - $\hat{loc}_{ij}$ is the predicted bounding box for grid cell $i$ at anchor $j$,
-    and $loc^{GT}_k$ is the k-th ground truth bounding box.
+    The implementation combines a CSPDarknet53-Mish backbone with an SPP/PAN neck and three detection scales.
+    Training uses the YOLOv4 anchor masks and multi-anchor assignment, binary cross-entropy for objectness and
+    classification, and area-weighted Complete IoU for matched boxes.
 
     Args:
         pretrained: If True, returns a model pre-trained on ImageNet

--- a/holocron/models/model_card.py
+++ b/holocron/models/model_card.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2026, François-Guillaume Fernandez.
+
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 

--- a/holocron/models/model_card.py
+++ b/holocron/models/model_card.py
@@ -1,0 +1,320 @@
+# Copyright (C) 2026, François-Guillaume Fernandez.
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+"""Generate deterministic Hugging Face-compatible model cards."""
+
+import argparse
+import hashlib
+import json
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from holocron import __version__
+
+from .catalog import ModelInfo, get_model_info, list_checkpoints, list_models
+from .checkpoints import Checkpoint
+
+__all__ = ["generate_model_card", "write_model_cards"]
+
+_UNKNOWN = "unknown / not reported"
+_PIPELINE_TAGS = {
+    "classification": "image-classification",
+    "detection": "object-detection",
+    "segmentation": "image-segmentation",
+}
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+def _known(value: Any) -> str:
+    if value is None or not str(value) or str(value).lower() in {"n/a", "none", "unknown"}:
+        return _UNKNOWN
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _yaml(info: ModelInfo, checkpoint: Checkpoint | None) -> str:
+    lines = [
+        "---",
+        "library_name: holocron",
+        f"pipeline_tag: {_PIPELINE_TAGS[info.task]}",
+        "license: apache-2.0",
+        "tags:",
+        "  - pytorch",
+        "  - holocron",
+        "  - computer-vision",
+        f"  - {info.maturity.value}",
+    ]
+    if checkpoint is not None:
+        lines.extend(["datasets:", f"  - {checkpoint.evaluation.dataset.value}"])
+        if checkpoint.evaluation.results:
+            lines.append("metrics:")
+            lines.extend(f"  - {metric.value}" for metric in sorted(checkpoint.evaluation.results, key=str))
+    lines.extend(["---", ""])
+    return "\n".join(lines)
+
+
+def _validate_artifact(root: Path, artifact: Any) -> dict[str, str | int]:
+    if not isinstance(artifact, dict):
+        raise TypeError("malformed run manifest: artifact must be an object")
+    path, sha256, size = artifact.get("path"), artifact.get("sha256"), artifact.get("size")
+    if not isinstance(path, str) or not path or Path(path).is_absolute() or ".." in Path(path).parts:
+        raise ValueError("malformed run manifest: artifact path must be relative")
+    if not isinstance(sha256, str) or _SHA256.fullmatch(sha256) is None:
+        raise ValueError("malformed run manifest: artifact sha256 must be a lowercase SHA-256")
+    if not isinstance(size, int) or size < 0:
+        raise ValueError("malformed run manifest: artifact size must be a non-negative integer")
+
+    artifact_path = root / path
+    if not artifact_path.is_file():
+        raise ValueError(f"unfinished run bundle: missing artifact {path}")
+    if artifact_path.stat().st_size != size:
+        raise ValueError(f"malformed run manifest: size mismatch for {path}")
+    if _file_sha256(artifact_path) != sha256:
+        raise ValueError(f"malformed run manifest: SHA-256 mismatch for {path}")
+    return {"path": path, "sha256": sha256, "size": size}
+
+
+def _load_run_manifest(run_dir: str | Path) -> dict[str, Any]:
+    root = Path(run_dir)
+    manifest_path = root / "manifest.json"
+    if not manifest_path.is_file():
+        raise ValueError(f"unfinished run bundle: {manifest_path} is missing")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"malformed run manifest: {manifest_path}") from exc
+    if not isinstance(manifest, dict):
+        raise TypeError("malformed run manifest: root must be an object")
+    if manifest.get("schema_version") != 1:
+        raise ValueError(f"unsupported run manifest schema_version: {manifest.get('schema_version')!r}")
+    if not isinstance(manifest.get("run"), dict) or not isinstance(manifest.get("artifacts"), list):
+        raise TypeError("malformed run manifest: run and artifacts are required")
+    manifest["artifacts"] = [_validate_artifact(root, artifact) for artifact in manifest["artifacts"]]
+    return manifest
+
+
+def _checkpoint_sections(checkpoint: Checkpoint | None) -> list[str]:
+    if checkpoint is None:
+        return [
+            "## Checkpoint",
+            "",
+            f"Checkpoint metadata: **{_UNKNOWN}**",
+            "",
+            "## Preprocessing",
+            "",
+            f"Preprocessing metadata: **{_UNKNOWN}**",
+            "",
+            "## Training recipe and evaluation",
+            "",
+            f"Training recipe and metrics: **{_UNKNOWN}**",
+        ]
+
+    preprocessing = checkpoint.pre_processing
+    recipe = checkpoint.recipe
+    lines = [
+        "## Checkpoint",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Dataset | {_known(checkpoint.evaluation.dataset.value)} |",
+        f"| Download URL | {_known(checkpoint.meta.url)} |",
+        f"| SHA-256 | `{_known(checkpoint.meta.sha256)}` |",
+        f"| Size (bytes) | {_known(checkpoint.meta.size)} |",
+        f"| Parameters | {_known(checkpoint.meta.num_params)} |",
+        "",
+        "## Preprocessing",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Input shape | `{preprocessing.input_shape}` |",
+        f"| Mean | `{preprocessing.mean}` |",
+        f"| Standard deviation | `{preprocessing.std}` |",
+        f"| Interpolation | {_known(preprocessing.interpolation.value)} |",
+        "",
+        "## Training recipe and evaluation",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Source commit | `{_known(recipe.commit)}` |",
+        f"| Script | {_known(recipe.script)} |",
+        f"| Arguments | `{_known(recipe.args)}` |",
+        "",
+        "| Metric | Dataset | Value |",
+        "|---|---|---:|",
+    ]
+    if checkpoint.evaluation.results:
+        for metric, value in sorted(checkpoint.evaluation.results.items(), key=lambda item: str(item[0])):
+            lines.append(f"| {metric.value} | {checkpoint.evaluation.dataset.value} | {value:.6g} |")
+    else:
+        lines.append(f"| {_UNKNOWN} | {_known(checkpoint.evaluation.dataset.value)} | {_UNKNOWN} |")
+    return lines
+
+
+def _run_sections(manifest: dict[str, Any] | None) -> list[str]:
+    if manifest is None:
+        return ["## Run provenance", "", f"Run bundle: **{_UNKNOWN}**"]
+
+    run = manifest["run"]
+    lines = [
+        "## Run provenance",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Schema version | {manifest['schema_version']} |",
+        f"| Epoch | {_known(run.get('epoch'))} |",
+        f"| Step | {_known(run.get('step'))} |",
+        f"| Best metric | {_known(run.get('best_metric'))} |",
+        "",
+        "### Resolved configuration",
+        "",
+        "```json",
+        json.dumps(run.get("config", {}), indent=2, sort_keys=True),
+        "```",
+        "",
+        "### Run artifacts",
+        "",
+        "| Path | Size (bytes) | SHA-256 |",
+        "|---|---:|---|",
+    ]
+    artifacts = manifest["artifacts"]
+    if artifacts:
+        lines.extend(f"| {item['path']} | {item['size']} | `{item['sha256']}` |" for item in artifacts)
+    else:
+        lines.append(f"| {_UNKNOWN} | {_UNKNOWN} | {_UNKNOWN} |")
+    return lines
+
+
+def generate_model_card(
+    name: str,
+    checkpoint: Checkpoint | None = None,
+    run_dir: str | Path | None = None,
+) -> str:
+    """Render a deterministic model card from Holocron metadata.
+
+    Args:
+        name: public model factory name.
+        checkpoint: optional typed checkpoint for the model.
+        run_dir: optional completed schema-v1 run bundle.
+
+    Returns:
+        Hugging Face-compatible Markdown with YAML metadata.
+
+    Raises:
+        ValueError: if the model, checkpoint, or run bundle is invalid.
+    """
+    info = get_model_info(name)
+    if checkpoint is not None and checkpoint.meta.arch != name:
+        raise ValueError(f"checkpoint architecture {checkpoint.meta.arch!r} does not match {name!r}")
+    manifest = _load_run_manifest(run_dir) if run_dir is not None else None
+    availability = "available" if info.pretrained else "not reported"
+    lines = [
+        _yaml(info, checkpoint),
+        f"# {name}",
+        "",
+        "Generated from Holocron's typed catalog. Missing values are shown as unknown rather than inferred.",
+        "",
+        "## Model details",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Model | `{name}` |",
+        f"| Task | {info.task} |",
+        f"| Maturity | {info.maturity.value} |",
+        f"| Pretrained weights | {availability} |",
+        "| Library | Holocron (`pylocron`) |",
+        f"| Library version | `{__version__}` |",
+        "| Implementation license | Apache-2.0 |",
+        f"| Dataset/checkpoint-specific license | {_UNKNOWN} |",
+        "",
+        "## Intended use",
+        "",
+        f"Use this model through Holocron for {info.task} with the recorded checkpoint and preprocessing metadata.",
+        f"Deployment suitability and domain-specific uses are **{_UNKNOWN}**.",
+        "",
+        "## Limitations",
+        "",
+        f"Model-specific limitations are **{_UNKNOWN}**. The `{info.maturity.value}` maturity label describes available",
+        "evidence; it is not a fitness-for-purpose claim.",
+        "",
+        *_checkpoint_sections(checkpoint),
+        "",
+        *_run_sections(manifest),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _card_filename(name: str, checkpoint: Checkpoint | None, index: int) -> str:
+    if checkpoint is None:
+        return f"{name}.md"
+    dataset = checkpoint.evaluation.dataset.value
+    digest = checkpoint.meta.sha256[:8] if _SHA256.fullmatch(checkpoint.meta.sha256) else str(index)
+    return f"{name}-{dataset}-{digest}.md"
+
+
+def write_model_cards(output_dir: str | Path, names: Sequence[str] | None = None) -> tuple[Path, ...]:
+    """Write every typed checkpoint card for selected models to a directory.
+
+    Returns:
+        paths of the generated cards
+    """
+    root = Path(output_dir)
+    selected_names = sorted(names) if names is not None else list_models()
+    written: list[Path] = []
+    for name in selected_names:
+        checkpoints = list_checkpoints(name)
+        selections: tuple[Checkpoint | None, ...] = checkpoints or (None,)
+        for index, checkpoint in enumerate(selections):
+            path = root / _card_filename(name, checkpoint, index)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(generate_model_card(name, checkpoint), encoding="utf-8")
+            written.append(path)
+    return tuple(written)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("models", nargs="*", help="public model names; all models when omitted with --output-dir")
+    destination = parser.add_mutually_exclusive_group(required=True)
+    destination.add_argument("--output", type=Path, help="write one model/checkpoint card")
+    destination.add_argument("--output-dir", type=Path, help="write every selected model/checkpoint card")
+    parser.add_argument("--checkpoint", type=int, default=0, help="checkpoint index used with --output")
+    parser.add_argument("--run-dir", type=Path, help="completed schema-v1 run bundle used with --output")
+    args = parser.parse_args(argv)
+
+    if args.output is not None:
+        if len(args.models) != 1:
+            parser.error("--output requires exactly one model")
+        if args.checkpoint < 0:
+            parser.error("checkpoint index must be non-negative")
+        checkpoints = list_checkpoints(args.models[0])
+        if not checkpoints:
+            if args.checkpoint != 0:
+                parser.error("model has no typed checkpoints")
+            checkpoint = None
+        else:
+            try:
+                checkpoint = checkpoints[args.checkpoint]
+            except IndexError:
+                parser.error(f"checkpoint index must be between 0 and {len(checkpoints) - 1}")
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(generate_model_card(args.models[0], checkpoint, args.run_dir), encoding="utf-8")
+    else:
+        if args.run_dir is not None or args.checkpoint != 0:
+            parser.error("--run-dir and --checkpoint are only valid with --output")
+        write_model_cards(args.output_dir, args.models or None)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -209,7 +209,9 @@ def model_from_hf_hub(repo_id: str, **kwargs: Any) -> nn.Module:
         model.default_cfg.update(cfg)
 
     # Load the checkpoint
-    state_dict = torch.load(hf_hub_download(repo_id, filename="pytorch_model.bin", **kwargs), map_location="cpu")
+    state_dict = torch.load(
+        hf_hub_download(repo_id, filename="pytorch_model.bin", **kwargs), map_location="cpu", weights_only=True
+    )
     model.load_state_dict(state_dict)
 
     return model

--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -14,9 +14,9 @@ from huggingface_hub.file_download import hf_hub_download
 from torch import nn
 from torch.hub import load_state_dict_from_url
 
-from holocron import models
 from holocron.nn import BlurPool2d
 
+from .catalog import get_model
 from .checkpoints import Checkpoint, Dataset, Evaluation, LoadingMeta, Metric, PreProcessing, TrainingRecipe
 from .presets import IMAGENET, IMAGENETTE
 
@@ -165,7 +165,7 @@ def model_from_hf_hub(repo_id: str, **kwargs: Any) -> nn.Module:
     with Path(hf_hub_download(repo_id, filename="config.json", **kwargs)).open("rb") as f:
         cfg = json.load(f)
 
-    model = models.__dict__[cfg["arch"]](num_classes=len(cfg["classes"]), pretrained=False)
+    model = get_model(cfg["arch"], num_classes=len(cfg["classes"]), pretrained=False)
     # Patch the config
     if model.default_cfg is None:
         model.default_cfg = cfg

--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -3,16 +3,20 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+import hashlib
 import json
 import logging
+import os
+import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 import torch
 from huggingface_hub.file_download import hf_hub_download
 from torch import nn
-from torch.hub import load_state_dict_from_url
+from torch.hub import download_url_to_file, get_dir, load_state_dict_from_url
 
 from holocron.nn import BlurPool2d
 
@@ -93,20 +97,50 @@ def load_pretrained_params(
     progress: bool = True,
     key_replacement: tuple[str, str] | None = None,
     key_filter: str | None = None,
+    *,
+    sha256: str | None = None,
 ) -> None:
     """Loads a checkpoint on a model given its URL.
 
     Args:
         model: PyTorch model
         url: the URL of the checkpoint to download
-        progress: whether a progress br should be displayed when downloading the checkpoint
+        sha256: expected full SHA-256 digest
+        progress: whether a progress bar should be displayed when downloading the checkpoint
         key_replacement: a mapping to replace keys in the checkpoint before loading them
         key_filter: prefix of the checkpoint keys to be loaded
+
+    Raises:
+        ValueError: if the expected digest or checkpoint URL is invalid
     """
     if url is None:
         logger.warning("Invalid model URL, using default initialization.")
     else:
-        state_dict = load_state_dict_from_url(url, progress=progress, map_location="cpu")
+        if sha256 is None:
+            state_dict = load_state_dict_from_url(url, progress=progress, map_location="cpu")
+        else:
+            if len(sha256) != 64 or any(char not in "0123456789abcdef" for char in sha256.lower()):
+                raise ValueError("sha256 must be a 64-character hexadecimal digest")
+            filename = Path(urlparse(url).path).name
+            if not filename:
+                raise ValueError("checkpoint URL has no file name")
+            checkpoint_dir = Path(get_dir()) / "checkpoints"
+            checkpoint_dir.mkdir(parents=True, exist_ok=True)
+            checkpoint_path = checkpoint_dir / filename
+
+            digest = None
+            if checkpoint_path.is_file():
+                with checkpoint_path.open("rb") as file:
+                    digest = hashlib.file_digest(file, "sha256").hexdigest()
+            if digest != sha256.lower():
+                fd, tmp_name = tempfile.mkstemp(prefix=f".{filename}.", suffix=".tmp", dir=checkpoint_dir)
+                os.close(fd)
+                try:
+                    download_url_to_file(url, tmp_name, hash_prefix=sha256.lower(), progress=progress)
+                    Path(tmp_name).replace(checkpoint_path)
+                finally:
+                    Path(tmp_name).unlink(missing_ok=True)
+            state_dict = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
         if isinstance(key_filter, str):
             state_dict = {k: v for k, v in state_dict.items() if k.startswith(key_filter)}
         if isinstance(key_replacement, tuple):
@@ -189,7 +223,7 @@ def _configure_model(
     model.default_cfg = checkpoint  # type: ignore[assignment]
     # Load pretrained parameters
     if isinstance(checkpoint, Checkpoint):
-        load_pretrained_params(model, checkpoint.meta.url, **kwargs)
+        load_pretrained_params(model, checkpoint.meta.url, sha256=checkpoint.meta.sha256, **kwargs)
 
     return model
 

--- a/holocron/models/utils.py
+++ b/holocron/models/utils.py
@@ -182,21 +182,28 @@ def fuse_conv_bn(conv: nn.Conv2d, bn: nn.BatchNorm2d) -> tuple[torch.Tensor, tor
     return fused_kernel, fused_bias
 
 
-def model_from_hf_hub(repo_id: str, **kwargs: Any) -> nn.Module:
+def model_from_hf_hub(repo_id: str, *, revision: str, **kwargs: Any) -> nn.Module:
     """Instantiate & load a pretrained model from HF hub.
 
     from holocron.models.utils import model_from_hf_hub
-    model = model_from_hf_hub("frgfm/rexnet1_0x")
+    model = model_from_hf_hub("frgfm/rexnet1_0x", revision="<commit SHA>")
 
     Args:
         repo_id: HuggingFace model hub repo
+        revision: immutable Hub commit revision
         kwargs: kwargs of `hf_hub_download`
 
     Returns:
         Model loaded with the checkpoint
+
+    Raises:
+        ValueError: if revision is not an immutable commit SHA
     """
+    if len(revision) != 40 or set(revision.lower()) - set("0123456789abcdef"):
+        raise ValueError("revision must be a 40-character commit SHA")
+
     # Get the config
-    with Path(hf_hub_download(repo_id, filename="config.json", **kwargs)).open("rb") as f:
+    with Path(hf_hub_download(repo_id, filename="config.json", revision=revision, **kwargs)).open("rb") as f:
         cfg = json.load(f)
 
     model = get_model(cfg["arch"], num_classes=len(cfg["classes"]), pretrained=False)
@@ -210,7 +217,9 @@ def model_from_hf_hub(repo_id: str, **kwargs: Any) -> nn.Module:
 
     # Load the checkpoint
     state_dict = torch.load(
-        hf_hub_download(repo_id, filename="pytorch_model.bin", **kwargs), map_location="cpu", weights_only=True
+        hf_hub_download(repo_id, filename="pytorch_model.bin", revision=revision, **kwargs),
+        map_location="cpu",
+        weights_only=True,
     )
     model.load_state_dict(state_dict)
 

--- a/holocron/ops/boxes.py
+++ b/holocron/ops/boxes.py
@@ -212,10 +212,5 @@ def ciou_loss(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     iou = box_iou(boxes1, boxes2)
     v = aspect_ratio_consistency(boxes1, boxes2)
 
-    ciou_loss = 1 - iou + iou_penalty(boxes1, boxes2)
-
-    # Check
-    filter_ = (v != 0) & (iou != 0)
-    ciou_loss[filter_].addcdiv_(v[filter_], 1 - iou[filter_] + v[filter_])
-
-    return ciou_loss
+    aspect_denominator = (1 - iou + v).clamp_min(torch.finfo(v.dtype).tiny)
+    return 1 - iou + iou_penalty(boxes1, boxes2) + v.square() / aspect_denominator

--- a/holocron/py.typed
+++ b/holocron/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/holocron/trainer/__init__.py
+++ b/holocron/trainer/__init__.py
@@ -1,5 +1,6 @@
 from .core import *
 from .classification import *
 from .detection import *
+from .experiment import *
 from .segmentation import *
 from .utils import *

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -4,6 +4,8 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 import math
+import os
+import tempfile
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -19,11 +21,28 @@ from torch.amp.grad_scaler import GradScaler
 from torch.optim.lr_scheduler import CosineAnnealingLR, LRScheduler, MultiplicativeLR, OneCycleLR
 from torch.utils.data import DataLoader
 
+from .experiment import RunResult, write_run_bundle
 from .utils import freeze_bn, freeze_model, split_normalization_params
 
 ParamSeq = Sequence[torch.nn.Parameter]
 
 __all__ = ["Trainer"]
+
+
+def _type_name(value: Any) -> str:
+    return f"{type(value).__module__}.{type(value).__qualname__}"
+
+
+def _primitive(value: Any) -> Any:
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _primitive(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_primitive(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    return repr(value)
 
 
 class Trainer:
@@ -87,6 +106,12 @@ class Trainer:
         self._params: tuple[ParamSeq, ParamSeq] = ([], [])
         self.lr_recorder: list[float] = []
         self.loss_recorder: list[float] = []
+        self._run_config: dict[str, Any] = {}
+        self._metrics_history: list[dict[str, float | int | None]] = []
+        self._resume_scheduler_state: dict[str, Any] | None = None
+        self._resume_optimizer_state: dict[str, Any] | None = None
+        self._resume_scaler_state: dict[str, Any] | None = None
+        self._is_resuming = False
         self.set_device(gpu)
         self._reset_opt(self.optimizer.defaults["lr"])
 
@@ -116,17 +141,56 @@ class Trainer:
         Args:
             output_file: destination file path
         """
-        Path(output_file).parent.mkdir(parents=True, exist_ok=True)
-        torch.save(
-            {
-                "epoch": self.epoch,
-                "step": self.step,
-                "min_loss": self.min_loss,
-                "model": self.model.state_dict(),
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        rng_state: dict[str, Tensor | list[Tensor]] = {"cpu": torch.get_rng_state()}
+        if torch.cuda.is_available():
+            rng_state["cuda"] = torch.cuda.get_rng_state_all()
+        parameter_names = {id(parameter): name for name, parameter in self.model.named_parameters()}
+        state = {
+            "schema_version": 2,
+            "epoch": self.epoch,
+            "step": self.step,
+            "min_loss": self.min_loss,
+            "best_metric": self.min_loss,
+            "model": self.model.state_dict(),
+            "optimizer": self.optimizer.state_dict(),
+            "scheduler": self.scheduler.state_dict() if hasattr(self, "scheduler") else None,
+            "scaler": self.scaler.state_dict() if hasattr(self, "scaler") else None,
+            "rng_state": rng_state,
+            "metrics": self._metrics_history,
+            "config": self._checkpoint_config(),
+            "optimizer_param_names": [
+                [parameter_names[id(parameter)] for parameter in group["params"]]
+                for group in self.optimizer.param_groups
+            ],
+            "parameter_requires_grad": {
+                name: parameter.requires_grad for name, parameter in self.model.named_parameters()
             },
-            output_file,
-            _use_new_zipfile_serialization=False,
-        )
+        }
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{output_path.name}.", suffix=".tmp", dir=output_path.parent)
+        os.close(fd)
+        try:
+            torch.save(state, tmp_name)
+            Path(tmp_name).replace(output_path)
+        finally:
+            Path(tmp_name).unlink(missing_ok=True)
+
+    def _checkpoint_config(self) -> dict[str, Any]:
+        return {
+            "trainer": {
+                "class": _type_name(self),
+                "model": _type_name(self.model),
+                "criterion": _type_name(self.criterion),
+                "optimizer": _type_name(self.optimizer),
+                "amp": self.amp,
+                "gradient_acc": self.gradient_acc,
+                "gradient_clip": self.grad_clip,
+                "skip_nan_loss": self.skip_nan_loss,
+                "nan_tolerance": self.nan_tolerance,
+            },
+            "run": self._run_config.copy(),
+        }
 
     def load(self, state: dict[str, Any]) -> None:
         """Resume from a trainer state
@@ -134,11 +198,42 @@ class Trainer:
         Args:
             state: checkpoint dictionary
         """
-        self.start_epoch = state["epoch"]
+        self.start_epoch = state.get("epoch", 0)
         self.epoch = self.start_epoch
-        self.step = state["step"]
-        self.min_loss = state["min_loss"]
+        self.step = state.get("step", 0)
+        self.min_loss = state.get("best_metric", state.get("min_loss", math.inf))
         self.model.load_state_dict(state["model"])
+        if state.get("schema_version") != 2:
+            self._run_config = {}
+            self._metrics_history = []
+            self._is_resuming = False
+            return
+
+        config = state.get("config", {})
+        self._run_config = dict(config.get("run", {}))
+        self._metrics_history = [dict(metric) for metric in state.get("metrics", [])]
+        self._resume_optimizer_state = state.get("optimizer")
+        self._resume_scheduler_state = state.get("scheduler")
+        self._resume_scaler_state = state.get("scaler")
+        self._is_resuming = bool(self._run_config and self._resume_scheduler_state is not None)
+
+        if self._resume_optimizer_state is not None:
+            named_parameters = dict(self.model.named_parameters())
+            for name, requires_grad in state.get("parameter_requires_grad", {}).items():
+                named_parameters[name].requires_grad_(requires_grad)
+            parameter_groups = state.get("optimizer_param_names", [])
+            if parameter_groups:
+                self.optimizer.state = defaultdict(dict)
+                self.optimizer.param_groups = []
+                for group in parameter_groups:
+                    self.optimizer.add_param_group({"params": [named_parameters[name] for name in group]})
+            self.optimizer.load_state_dict(self._resume_optimizer_state)
+
+        rng_state = state.get("rng_state", {})
+        if "cpu" in rng_state:
+            torch.set_rng_state(rng_state["cpu"])
+        if torch.cuda.is_available() and rng_state.get("cuda"):
+            torch.cuda.set_rng_state_all(rng_state["cuda"])
 
     def _fit_epoch(self, mb: ConsoleMasterBar | NBMasterBar) -> None:
         """Fit a single epoch
@@ -307,9 +402,13 @@ class Trainer:
         freeze_until: str | None = None,
         sched_type: str = "onecycle",
         norm_weight_decay: float | None = None,
+        run_dir: str | None = None,
         **kwargs: Any,
-    ) -> None:
+    ) -> RunResult:
         """Train the model for a given number of epochs.
+
+        A resumed run reuses its stored optimizer and scheduler configuration;
+        ``num_epochs`` is the number of remaining epochs to execute.
 
         Args:
             num_epochs: number of epochs to train
@@ -317,21 +416,63 @@ class Trainer:
             freeze_until: last layer to freeze
             sched_type: type of scheduler to use
             norm_weight_decay: weight decay to apply to normalization parameters
+            run_dir: optional directory for a schema-v1 run bundle
             **kwargs: keyword args passed to the [`LRScheduler`][torch.optim.lr_scheduler.LRScheduler]
-        """
-        freeze_model(self.model.train(), freeze_until)
-        # Update param groups & LR
-        self._reset_opt(lr, norm_weight_decay)
-        # Scheduler
-        self._reset_scheduler(lr, num_epochs, sched_type, **kwargs)
 
-        if self.amp:
-            self.scaler = GradScaler("cuda")
+        Returns:
+            run result including metrics, resolved configuration, and checkpoint path
+
+        Raises:
+            ValueError: if a resumed run would exceed its original schedule
+        """
+        if self._is_resuming:
+            resume_config = self._run_config
+            if self.epoch + num_epochs > int(resume_config["end_epoch"]):
+                raise ValueError("resumed run exceeds the original scheduler length")
+            freeze_until = resume_config.get("freeze_until")
+            freeze_model(self.model.train(), freeze_until)
+            self._reset_scheduler(
+                float(resume_config["lr"]),
+                int(resume_config["num_epochs"]),
+                str(resume_config["sched_type"]),
+                **resume_config.get("scheduler_kwargs", {}),
+            )
+            if self._resume_scheduler_state is not None:
+                self.scheduler.load_state_dict(self._resume_scheduler_state)
+            if self._resume_optimizer_state is not None:
+                self.optimizer.load_state_dict(self._resume_optimizer_state)
+            if self.amp:
+                self.scaler = GradScaler("cuda")
+                if self._resume_scaler_state is not None:
+                    self.scaler.load_state_dict(self._resume_scaler_state)
+            self._is_resuming = False
+        else:
+            self.start_epoch = self.epoch
+            self._run_config = {
+                "num_epochs": num_epochs,
+                "start_epoch": self.start_epoch,
+                "end_epoch": self.start_epoch + num_epochs,
+                "lr": lr,
+                "freeze_until": freeze_until,
+                "sched_type": sched_type,
+                "norm_weight_decay": norm_weight_decay,
+                "scheduler_kwargs": _primitive(kwargs),
+            }
+            self._metrics_history = []
+            freeze_model(self.model.train(), freeze_until)
+            self._reset_opt(lr, norm_weight_decay)
+            self._reset_scheduler(lr, num_epochs, sched_type, **kwargs)
+
+            if self.amp:
+                self.scaler = GradScaler("cuda")
 
         mb = master_bar(range(num_epochs))
         for _ in mb:
             self._fit_epoch(mb)
             eval_metrics = self.evaluate()
+            metric_record: dict[str, float | int | None] = {"epoch": self.epoch, "step": self.step}
+            metric_record.update({key: None if value is None else float(value) for key, value in eval_metrics.items()})
+            self._metrics_history.append(metric_record)
 
             # master bar
             mb.main_bar.comment = f"Epoch {self.epoch}/{self.start_epoch + num_epochs}"
@@ -342,10 +483,24 @@ class Trainer:
                     f"Validation loss decreased {self.min_loss:.4} --> {eval_metrics['val_loss']:.4}: saving state..."
                 )
                 self.min_loss = eval_metrics["val_loss"]
-                self.save(self.output_file)
+            self.save(self.output_file)
 
             if self.on_epoch_end is not None:
                 self.on_epoch_end(eval_metrics)
+
+        checkpoint = str(Path(self.output_file)) if Path(self.output_file).is_file() else None
+        result = RunResult(
+            epoch=self.epoch,
+            step=self.step,
+            best_metric=self.min_loss,
+            metrics=tuple(self._metrics_history),
+            config=self._checkpoint_config(),
+            checkpoint=checkpoint,
+            bundle_dir=run_dir,
+        )
+        if run_dir is not None:
+            write_run_bundle(run_dir, result)
+        return result
 
     def find_lr(
         self,

--- a/holocron/trainer/core.py
+++ b/holocron/trainer/core.py
@@ -136,7 +136,10 @@ class Trainer:
                 self.criterion = self.criterion.cuda()
 
     def save(self, output_file: str) -> None:
-        """Save a trainer checkpoint
+        """Save the latest resumable trainer state.
+
+        ``best_metric`` records the best validation metric observed so far; the
+        model state is always from the latest completed epoch.
 
         Args:
             output_file: destination file path
@@ -480,13 +483,14 @@ class Trainer:
 
             if eval_metrics["val_loss"] < self.min_loss:
                 print(  # noqa: T201
-                    f"Validation loss decreased {self.min_loss:.4} --> {eval_metrics['val_loss']:.4}: saving state..."
+                    f"Validation loss decreased {self.min_loss:.4} --> {eval_metrics['val_loss']:.4}"
                 )
                 self.min_loss = eval_metrics["val_loss"]
-            self.save(self.output_file)
 
-            if self.on_epoch_end is not None:
-                self.on_epoch_end(eval_metrics)
+            try:
+                (self.on_epoch_end or (lambda _: None))(eval_metrics)
+            finally:
+                self.save(self.output_file)
 
         checkpoint = str(Path(self.output_file)) if Path(self.output_file).is_file() else None
         result = RunResult(

--- a/holocron/trainer/detection.py
+++ b/holocron/trainer/detection.py
@@ -68,8 +68,8 @@ def detection_average_precision(  # noqa: PLR0912, PLR0915
         return {"ap50": 0.0, "ap50_95": 0.0}
 
     try:
-        from pycocotools.coco import COCO  # noqa: PLC0415
-        from pycocotools.cocoeval import COCOeval  # noqa: PLC0415
+        from pycocotools.coco import COCO  # ty: ignore[unresolved-import]  # noqa: PLC0415
+        from pycocotools.cocoeval import COCOeval  # ty: ignore[unresolved-import]  # noqa: PLC0415
     except ImportError as exc:
         raise ImportError(
             "COCO AP evaluation requires pycocotools; install the evaluation extra with "

--- a/holocron/trainer/detection.py
+++ b/holocron/trainer/detection.py
@@ -13,7 +13,7 @@ from .core import Trainer
 __all__ = ["DetectionTrainer"]
 
 
-def assign_iou(gt_boxes: Tensor, pred_boxes: Tensor, iou_threshold: float = 0.5) -> tuple[list[int], list[int]]:
+def assign_iou(gt_boxes: Tensor, pred_boxes: Tensor, iou_threshold: float = 0.5) -> tuple[Tensor, Tensor]:
     """Assigns boxes by IoU
 
     Args:
@@ -27,17 +27,20 @@ def assign_iou(gt_boxes: Tensor, pred_boxes: Tensor, iou_threshold: float = 0.5)
     iou = box_iou(gt_boxes, pred_boxes)
     iou = iou.max(dim=1)
     gt_kept = iou.values >= iou_threshold
-    assign_unique = torch.unique(iou.indices[gt_kept])
+    kept_pred_indices = iou.indices[gt_kept]
+    assign_unique = torch.unique(kept_pred_indices)
+    kept_gt_indices = torch.arange(gt_boxes.shape[0], device=gt_boxes.device)[gt_kept]
     # Filter
-    if iou.indices[gt_kept].shape[0] == assign_unique.shape[0]:
-        return torch.arange(gt_boxes.shape[0])[gt_kept], iou.indices[gt_kept]  # type: ignore[return-value]
+    if kept_pred_indices.shape[0] == assign_unique.shape[0]:
+        return kept_gt_indices, kept_pred_indices
 
     gt_indices, pred_indices = [], []
     for pred_idx in assign_unique:
-        selection = iou.values[gt_kept][iou.indices[gt_kept] == pred_idx].argmax()
-        gt_indices.append(torch.arange(gt_boxes.shape[0])[gt_kept][selection].item())
-        pred_indices.append(iou.indices[gt_kept][selection].item())
-    return gt_indices, pred_indices  # type: ignore[return-value]
+        candidates = kept_pred_indices == pred_idx
+        selection = iou.values[gt_kept][candidates].argmax()
+        gt_indices.append(kept_gt_indices[candidates][selection])
+        pred_indices.append(pred_idx)
+    return torch.stack(gt_indices), torch.stack(pred_indices)
 
 
 class DetectionTrainer(Trainer):

--- a/holocron/trainer/detection.py
+++ b/holocron/trainer/detection.py
@@ -4,13 +4,132 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 
+import contextlib
+import io
+
 import torch
 from torch import Tensor
 from torchvision.ops.boxes import box_iou
 
 from .core import Trainer
 
-__all__ = ["DetectionTrainer"]
+__all__ = ["DetectionTrainer", "detection_average_precision"]
+
+
+def detection_average_precision(  # noqa: PLR0912, PLR0915
+    predictions: list[dict[str, Tensor]], targets: list[dict[str, Tensor]]
+) -> dict[str, float | None]:
+    """Compute COCO AP for normalized ``xyxy`` detections.
+
+    Image IDs are assigned from list order. Boxes therefore need no pixel-size
+    metadata: IoU and the all-area AP metrics are scale invariant.
+
+    Returns:
+        AP at IoU 0.50 and mean AP at IoUs 0.50 through 0.95. Both are ``None``
+            when the inputs contain no targets.
+
+    Raises:
+        ImportError: if pycocotools is not installed
+        ValueError: if predictions and targets do not follow the detection format
+    """
+    if len(predictions) != len(targets):
+        raise ValueError("predictions and targets must contain the same number of images")
+
+    labels: set[int] = set()
+    num_targets = 0
+    num_predictions = 0
+    for records, with_scores in ((targets, False), (predictions, True)):
+        for record in records:
+            required = {"boxes", "labels", *(("scores",) if with_scores else ())}
+            if missing := required.difference(record):
+                raise ValueError(f"missing detection fields: {', '.join(sorted(missing))}")
+            boxes = record["boxes"]
+            if boxes.ndim != 2 or boxes.shape[1] != 4:
+                raise ValueError("boxes must have shape (N, 4)")
+            record_labels = record["labels"]
+            scores = record["scores"] if with_scores else None
+            if record_labels.ndim != 1 or (scores is not None and scores.ndim != 1):
+                raise ValueError("labels and scores must have shape (N,)")
+            if record_labels.shape[0] != boxes.shape[0] or (scores is not None and scores.shape[0] != boxes.shape[0]):
+                raise ValueError("boxes, labels and scores must describe the same number of detections")
+            if torch.is_floating_point(record_labels) or torch.is_complex(record_labels):
+                raise ValueError("labels must use an integer dtype")
+            if torch.any(boxes[:, 2:] < boxes[:, :2]):
+                raise ValueError("boxes must use xyxy order")
+            labels.update(record_labels.detach().cpu().tolist())
+            if with_scores:
+                num_predictions += boxes.shape[0]
+            else:
+                num_targets += boxes.shape[0]
+
+    if num_targets == 0:
+        return {"ap50": None, "ap50_95": None}
+    if num_predictions == 0:
+        return {"ap50": 0.0, "ap50_95": 0.0}
+
+    try:
+        from pycocotools.coco import COCO  # noqa: PLC0415
+        from pycocotools.cocoeval import COCOeval  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError(
+            "COCO AP evaluation requires pycocotools; install the evaluation extra with "
+            "`pip install pylocron[evaluation]`."
+        ) from exc
+
+    category_ids = {label: idx for idx, label in enumerate(sorted(labels), start=1)}
+    images = [{"id": idx, "width": 1, "height": 1} for idx in range(1, len(targets) + 1)]
+    annotations: list[dict[str, int | float | list[float]]] = []
+    results: list[dict[str, int | float | list[float]]] = []
+    annotation_id = 1
+
+    for image_id, (prediction, target) in enumerate(zip(predictions, targets, strict=True), start=1):
+        for box, label in zip(
+            target["boxes"].detach().cpu().tolist(), target["labels"].detach().cpu().tolist(), strict=True
+        ):
+            x1, y1, x2, y2 = box
+            width, height = x2 - x1, y2 - y1
+            annotations.append({
+                "id": annotation_id,
+                "image_id": image_id,
+                "category_id": category_ids[label],
+                "bbox": [x1, y1, width, height],
+                "area": width * height,
+                "iscrowd": 0,
+            })
+            annotation_id += 1
+
+        for box, label, score in zip(
+            prediction["boxes"].detach().cpu().tolist(),
+            prediction["labels"].detach().cpu().tolist(),
+            prediction["scores"].detach().cpu().tolist(),
+            strict=True,
+        ):
+            x1, y1, x2, y2 = box
+            results.append({
+                "image_id": image_id,
+                "category_id": category_ids[label],
+                "bbox": [x1, y1, x2 - x1, y2 - y1],
+                "score": score,
+            })
+
+    sink = io.StringIO()
+    with contextlib.redirect_stdout(sink):
+        ground_truth = COCO()
+        ground_truth.dataset = {
+            "info": {},
+            "images": images,
+            "categories": [{"id": category_id} for category_id in category_ids.values()],
+            "annotations": annotations,
+        }
+        ground_truth.createIndex()
+        coco_eval = COCOeval(ground_truth, ground_truth.loadRes(results), "bbox")
+        coco_eval.params.imgIds = [image["id"] for image in images]
+        coco_eval.params.catIds = list(category_ids.values())
+        coco_eval.evaluate()
+        coco_eval.accumulate()
+        coco_eval.summarize()
+
+    return {"ap50": float(coco_eval.stats[1]), "ap50_95": float(coco_eval.stats[0])}
 
 
 def assign_iou(gt_boxes: Tensor, pred_boxes: Tensor, iou_threshold: float = 0.5) -> tuple[Tensor, Tensor]:
@@ -86,7 +205,11 @@ class DetectionTrainer(Trainer):
         loc_str = f"{eval_metrics['loc_err']:.2%}" if isinstance(eval_metrics["loc_err"], float) else "N/A"
         clf_str = f"{eval_metrics['clf_err']:.2%}" if isinstance(eval_metrics["clf_err"], float) else "N/A"
         det_str = f"{eval_metrics['det_err']:.2%}" if isinstance(eval_metrics["det_err"], float) else "N/A"
-        return f"Loc error: {loc_str} | Clf error: {clf_str} | Det error: {det_str}"
+        ap50_str = f"{eval_metrics['ap50']:.2%}" if isinstance(eval_metrics["ap50"], float) else "N/A"
+        ap_str = f"{eval_metrics['ap50_95']:.2%}" if isinstance(eval_metrics["ap50_95"], float) else "N/A"
+        return (
+            f"Loc error: {loc_str} | Clf error: {clf_str} | Det error: {det_str} | AP50: {ap50_str} | AP50:95: {ap_str}"
+        )
 
     @torch.inference_mode()
     def evaluate(self, iou_threshold: float = 0.5) -> dict[str, float | None]:
@@ -96,12 +219,15 @@ class DetectionTrainer(Trainer):
             iou_threshold: IoU threshold for pair assignment
 
         Returns:
-            evaluation metrics (validation loss, localization error rate, classification error rate, detection error rate)
+            evaluation metrics (validation loss, localization error rate, classification error rate, detection error rate,
+            AP50 and AP50:95)
         """
         self.model.eval()
 
         loc_assigns = 0
         correct, clf_error, loc_fn, loc_fp, num_samples = 0, 0, 0, 0, 0
+        ap_predictions: list[dict[str, Tensor]] = []
+        ap_targets: list[dict[str, Tensor]] = []
 
         for x, target in self.val_loader:
             x, target = self.to_cuda(x, target)
@@ -113,6 +239,8 @@ class DetectionTrainer(Trainer):
                 detections = self.model(x)
 
             for dets, t in zip(detections, target, strict=True):
+                ap_predictions.append({key: dets[key].detach().cpu() for key in ("boxes", "labels", "scores")})
+                ap_targets.append({key: t[key].detach().cpu() for key in ("boxes", "labels")})
                 if t["boxes"].shape[0] > 0 and dets["boxes"].shape[0] > 0:
                     gt_indices, pred_indices = assign_iou(t["boxes"], dets["boxes"], iou_threshold)
                     loc_assigns += len(gt_indices)
@@ -133,4 +261,10 @@ class DetectionTrainer(Trainer):
         clf_err = 1 - correct / loc_assigns if loc_assigns > 0 else None
         # End-to-end
         det_err = 1 - 2 * correct / (nb_preds + num_samples) if nb_preds + num_samples > 0 else None
-        return {"loc_err": loc_err, "clf_err": clf_err, "det_err": det_err, "val_loss": loc_err}
+        return {
+            "loc_err": loc_err,
+            "clf_err": clf_err,
+            "det_err": det_err,
+            "val_loss": loc_err,
+            **detection_average_precision(ap_predictions, ap_targets),
+        }

--- a/holocron/trainer/experiment.py
+++ b/holocron/trainer/experiment.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2019-2026, François-Guillaume Fernandez.
+
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 

--- a/holocron/trainer/experiment.py
+++ b/holocron/trainer/experiment.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2019-2026, François-Guillaume Fernandez.
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = ["RunResult", "write_run_bundle"]
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Result of a completed training run."""
+
+    epoch: int
+    step: int
+    best_metric: float
+    metrics: tuple[dict[str, float | int | None], ...]
+    config: dict[str, Any]
+    checkpoint: str | None = None
+    bundle_dir: str | None = None
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            file.write(content)
+            file.flush()
+            os.fsync(file.fileno())
+        Path(tmp_name).replace(path)
+    finally:
+        Path(tmp_name).unlink(missing_ok=True)
+
+
+def _atomic_copy(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.resolve() == destination.resolve():
+        return
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent)
+    os.close(fd)
+    try:
+        shutil.copyfile(source, tmp_name)
+        Path(tmp_name).replace(destination)
+    finally:
+        Path(tmp_name).unlink(missing_ok=True)
+
+
+def _artifact(path: Path, root: Path) -> dict[str, str | int]:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "path": path.relative_to(root).as_posix(),
+        "sha256": digest.hexdigest(),
+        "size": path.stat().st_size,
+    }
+
+
+def write_run_bundle(
+    output_dir: str | Path,
+    result: RunResult,
+    artifacts: Sequence[str | Path] = (),
+) -> Path:
+    """Write a portable schema-v1 run bundle and return its manifest path.
+
+    The manifest is removed before updating a bundle and written only after all
+    referenced artifacts are durable, so its presence marks a complete bundle.
+
+    Returns:
+        path to the completed manifest
+
+    Raises:
+        FileNotFoundError: if an artifact does not exist
+        ValueError: if multiple artifacts have the same file name
+    """
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    manifest_path = root / "manifest.json"
+    manifest_path.unlink(missing_ok=True)
+
+    metrics_path = root / "metrics.jsonl"
+    metrics = "".join(f"{json.dumps(metric, sort_keys=True)}\n" for metric in result.metrics)
+    _atomic_write(metrics_path, metrics)
+    bundle_artifacts = [_artifact(metrics_path, root)]
+
+    if result.checkpoint is not None:
+        checkpoint = Path(result.checkpoint)
+        if checkpoint.is_file():
+            bundled_checkpoint = root / "checkpoints" / checkpoint.name
+            _atomic_copy(checkpoint, bundled_checkpoint)
+            bundle_artifacts.append(_artifact(bundled_checkpoint, root))
+
+    used_names: set[str] = set()
+    for artifact in artifacts:
+        source = Path(artifact)
+        if not source.is_file():
+            raise FileNotFoundError(source)
+        if source.name in used_names:
+            raise ValueError(f"duplicate artifact name: {source.name}")
+        used_names.add(source.name)
+        bundled_artifact = root / "artifacts" / source.name
+        _atomic_copy(source, bundled_artifact)
+        bundle_artifacts.append(_artifact(bundled_artifact, root))
+
+    manifest = {
+        "schema_version": 1,
+        "run": {
+            "epoch": result.epoch,
+            "step": result.step,
+            "best_metric": result.best_metric,
+            "config": result.config,
+        },
+        "artifacts": bundle_artifacts,
+    }
+    _atomic_write(manifest_path, f"{json.dumps(manifest, indent=2, sort_keys=True)}\n")
+    return manifest_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "torch>=2.0.0,<3.0.0",
+    "torch>=2.9.0,<3.0.0",
     "torchvision>=0.24.0,<1.0.0",
     "tqdm>=4.1.0",
     "numpy>=1.19.5,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "uv_build"
 
 [project]
 name = "pylocron"
-version = "0.2.2.dev0"
+version = "0.3.0.dev0"
 description = "Modules, operations and models for computer vision in PyTorch"
 authors = [{name = "François-Guillaume Fernandez", email = "fg-feedback@protonmail.com"}]
 maintainers = [{ name = "François-Guillaume Fernandez", email = "fg-feedback@protonmail.com" }]
 readme = "README.md"
 requires-python = ">=3.11,<4"
-license = {file = "LICENSE"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 keywords = ["pytorch", "deep learning", "computer vision", "models"]
 classifiers = [
     # https://pypi.org/classifiers/
@@ -18,7 +19,6 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
@@ -55,10 +55,14 @@ test = [
     "pytest-pretty==1.3.0",
     "onnx>=1.13.0,<2.0.0",
     "onnxscript>=0.5.0,<1.0.0",
+    "pycocotools>=2.0.11,<3.0.0",
 ]
 training = [
     "wandb>=0.10.31,<1.0.0",
     "codecarbon>=2.0.0,<3.0.0",
+]
+evaluation = [
+    "pycocotools>=2.0.11,<3.0.0",
 ]
 quality = [
     "ruff==0.16.0",

--- a/references/README.md
+++ b/references/README.md
@@ -7,7 +7,7 @@ This section is specific to train computer vision models.
 
 ### Prerequisites
 
-Python 3.8 (or higher) and [pip](https://pip.pypa.io/en/stable/) & [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) are required to install Holocron.
+Python 3.11 (or higher) and [pip](https://pip.pypa.io/en/stable/) & [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) are required to install Holocron.
 
 
 ### Developer mode

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -26,6 +26,8 @@ python train.py imagenette2-320/ --arch darknet53 --seed 0 --lr 5e-3 -b 32 -j 16
 
 ## Synthetic character classification
 
+> **Experimental recipe:** this is a reproducible starting point, not a validated benchmark or published checkpoint.
+
 Prepare the checksum-verified starter fonts once:
 
 ```shell
@@ -66,6 +68,16 @@ uv run --python 3.12 --extra training \
 ```
 
 `--render-size` controls glyph rasterization resolution; `--image-size` controls the final model input resolution. To expand the corpus, prepare another local manifest and directory and pass those paths to the same script—no Python changes are needed. Training itself never downloads data or fonts.
+
+Training holds out whole font families for validation (`--validation-family-fraction 0.2` by default), so at least two families are required. The output directory is a schema-v1 run bundle containing metrics, the resumable checkpoint-v2, font provenance, and a manifest written last. Resume an interrupted run by passing the remaining epoch count:
+
+```shell
+uv run --python 3.12 --extra training \
+  references/classification/train_characters.py \
+  --font-dir /tmp/holocron-fonts \
+  --manifest references/fonts/latin-starter.json \
+  --resume checkpoints/characters/checkpoint.pth --epochs 4
+```
 
 ## Personal leaderboard
 

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -21,7 +21,7 @@ tar -xvzf imagenette2-320.tgz
 From there, you can run your training with the following command
 
 ```
-python train.py imagenette2-320/ --arch darknet53 --lr 5e-3 -b 32 -j 16 --epochs 40 --opt adamp --sched onecycle
+python train.py imagenette2-320/ --arch darknet53 --seed 0 --lr 5e-3 -b 32 -j 16 --epochs 40 --opt adamp --sched onecycle
 ```
 
 ## Synthetic character classification

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -24,6 +24,49 @@ From there, you can run your training with the following command
 python train.py imagenette2-320/ --arch darknet53 --lr 5e-3 -b 32 -j 16 --epochs 40 --opt adamp --sched onecycle
 ```
 
+## Synthetic character classification
+
+Prepare the checksum-verified starter fonts once:
+
+```shell
+uv run --python 3.12 scripts/prepare_fonts.py \
+  --output /tmp/holocron-fonts --quiet
+```
+
+Generate and inspect fresh augmented samples without starting training:
+
+```shell
+uv run --python 3.12 --extra training \
+  references/classification/train_characters.py \
+  --font-dir /tmp/holocron-fonts \
+  --manifest references/fonts/latin-starter.json \
+  --show-samples /tmp/character-samples.png
+```
+
+Run a small CPU smoke training job:
+
+```shell
+uv run --python 3.12 --extra training \
+  references/classification/train_characters.py \
+  --font-dir /tmp/holocron-fonts \
+  --manifest references/fonts/latin-starter.json \
+  --device cpu --workers 0 --epochs 1 \
+  --image-size 32 --render-size 64 \
+  --samples-per-epoch 256 --batch-size 32
+```
+
+Measure live-image DataLoader throughput after worker warm-up:
+
+```shell
+uv run --python 3.12 --extra training \
+  references/classification/train_characters.py \
+  --font-dir /tmp/holocron-fonts \
+  --manifest references/fonts/latin-starter.json \
+  --benchmark-loader
+```
+
+`--render-size` controls glyph rasterization resolution; `--image-size` controls the final model input resolution. To expand the corpus, prepare another local manifest and directory and pass those paths to the same script—no Python changes are needed. Training itself never downloads data or fonts.
+
 
 
 ## Personal leaderboard

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -67,8 +67,6 @@ uv run --python 3.12 --extra training \
 
 `--render-size` controls glyph rasterization resolution; `--image-size` controls the final model input resolution. To expand the corpus, prepare another local manifest and directory and pass those paths to the same script—no Python changes are needed. Training itself never downloads data or fonts.
 
-
-
 ## Personal leaderboard
 
 The updated list of available checkpoints can be found in the [documentation](https://frgfm.github.io/Holocron/latest/models.html#classification).

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -16,8 +16,6 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-import wandb
-from codecarbon import track_emissions
 from torch import nn
 from torch.utils.data import RandomSampler, SequentialSampler
 from torch.utils.data._utils.collate import default_collate
@@ -73,8 +71,15 @@ def plot_samples(images, targets, num_samples=8):
     plt.show()
 
 
-@track_emissions()
 def main(args):
+    from codecarbon import track_emissions  # noqa: PLC0415 - keep parser importable without training extras
+
+    return track_emissions()(_main)(args)
+
+
+def _main(args):
+    import wandb  # noqa: PLC0415 - keep parser importable without training extras
+
     print(args)
 
     torch.manual_seed(args.seed)

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -294,6 +294,7 @@ def _main(args):
         args.freeze_until,
         args.sched,
         norm_weight_decay=args.norm_wd,
+        run_dir=args.run_dir,
         div_factor=100,
         pct_start=0.1,
     )
@@ -316,6 +317,7 @@ def get_parser():
     group.add_argument("--arch", default="darknet19", type=str, help="architecture to use")
     group.add_argument("--pretrained", action="store_true", help="Use pre-trained models from the modelzoo")
     group.add_argument("--output-file", default="./checkpoints/checkpoint.pth", help="path where to save")
+    group.add_argument("--run-dir", default=None, help="optional run bundle directory")
     group.add_argument("--resume", default="", help="resume from checkpoint")
     group.add_argument("--seed", default=0, type=int, help="random seed")
     # Hardware

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -231,7 +231,7 @@ def _main(args):
     )
     if args.resume:
         print(f"Resuming {args.resume}")
-        checkpoint = torch.load(args.resume, map_location="cpu")
+        checkpoint = torch.load(args.resume, map_location="cpu", weights_only=True)
         trainer.load(checkpoint)
 
     if args.test_only:

--- a/references/classification/train_characters.py
+++ b/references/classification/train_characters.py
@@ -12,7 +12,6 @@ import math
 import os
 import platform
 import time
-import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from functools import partial
@@ -29,19 +28,13 @@ from torchvision.transforms import v2 as T
 from torchvision.transforms.v2 import functional as F
 from torchvision.transforms.v2.functional import InterpolationMode, to_pil_image
 
-from holocron.models import classification
-from holocron.trainer import ClassificationTrainer
+from holocron.models import get_model, list_models
+from holocron.trainer import ClassificationTrainer, write_run_bundle
 from holocron.utils import find_fonts, render_text
 
 DEFAULT_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 FONT_EXTENSIONS = {".otf", ".ttc", ".ttf"}
-MODEL_NAMES = tuple(
-    sorted(
-        name
-        for name, value in vars(classification).items()
-        if name.islower() and not name.startswith("_") and callable(value)
-    )
-)
+MODEL_NAMES = tuple(list_models(task="classification"))
 
 
 @dataclass(frozen=True)
@@ -286,6 +279,34 @@ def resolve_font_records(
     return tuple(FontRecord(path, str(path)) for path in paths), None
 
 
+def split_font_families(
+    alphabet: Sequence[str],
+    records: Sequence[FontRecord],
+    render_size: int,
+    validation_fraction: float,
+    seed: int,
+) -> tuple[tuple[FontRecord, ...], tuple[FontRecord, ...]]:
+    """Hold out whole font families for validation.
+
+    Returns:
+        disjoint training and validation font records
+
+    Raises:
+        ValueError: if fewer than two font families are available
+    """
+    resolved, _ = _inspect_fonts(alphabet, records, render_size)
+    families = sorted({record.family for record in resolved})
+    if len(families) < 2:
+        raise ValueError("held-out-family validation requires at least 2 font families")
+    families = [families[index] for index in torch.randperm(len(families), generator=_generator(seed)).tolist()]
+    validation_count = min(len(families) - 1, max(1, round(len(families) * validation_fraction)))
+    validation_families = set(families[:validation_count])
+    return (
+        tuple(record for record in resolved if record.family not in validation_families),
+        tuple(record for record in resolved if record.family in validation_families),
+    )
+
+
 def square_pad(image: Image.Image, margin: int) -> Image.Image:
     """Add a margin and center a tight glyph in a square without resizing it.
 
@@ -424,13 +445,13 @@ def _json_value(value: Any) -> Any:
     return str(value) if isinstance(value, Path) else value
 
 
-def write_provenance(
-    output_path: Path,
+def recipe_metadata(
     args: argparse.Namespace,
-    dataset: SyntheticCharacterDataset,
+    train_set: SyntheticCharacterDataset,
+    val_set: SyntheticCharacterDataset,
     records: Sequence[FontRecord],
     manifest_info: dict[str, Any] | None,
-) -> None:
+) -> dict[str, Any]:
     font_root = args.font_dir.resolve() if args.font_dir is not None else None
     fonts = []
     for record in records:
@@ -445,35 +466,22 @@ def write_provenance(
             "sha256": record.sha256 or _sha256(record.path),
             "source": record.source,
         })
-    payload = {
-        "version": 1,
-        "alphabet": list(dataset.classes),
-        "class_to_index": dataset.class_to_idx,
+    return {
+        "maturity": "experimental",
+        "alphabet": list(train_set.classes),
+        "class_to_index": train_set.class_to_idx,
         "seed": args.seed,
         "image_size": args.image_size,
         "render_size": args.render_size,
         "architecture": args.arch,
         "configuration": {key: _json_value(value) for key, value in vars(args).items()},
+        "font_split": {
+            "training_families": sorted({record.family for record in train_set.fonts}),
+            "validation_families": sorted({record.family for record in val_set.fonts}),
+        },
         "fonts": fonts,
         "manifest": manifest_info,
     }
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-
-def validate_resume_metadata(resume_path: Path, architecture: str, classes: Sequence[str]) -> None:
-    metadata_path = resume_path.with_suffix(".json")
-    if not metadata_path.is_file():
-        warnings.warn(
-            f"resume metadata not found at {metadata_path}; architecture and alphabet cannot be verified",
-            stacklevel=2,
-        )
-        return
-    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    if metadata.get("architecture") != architecture:
-        raise ValueError("resume checkpoint architecture does not match --arch")
-    if metadata.get("alphabet") != list(classes):
-        raise ValueError("resume checkpoint alphabet does not match --alphabet")
 
 
 def _positive_int(value: str) -> int:
@@ -518,6 +526,13 @@ def _scale_jitter(value: str) -> float:
     return parsed
 
 
+def _heldout_fraction(value: str) -> float:
+    parsed = float(value)
+    if not 0 < parsed < 1:
+        raise argparse.ArgumentTypeError("expected a fraction between 0 and 1")
+    return parsed
+
+
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     data = parser.add_argument_group("Data and model")
@@ -529,6 +544,7 @@ def get_parser() -> argparse.ArgumentParser:
     data.add_argument("--render-size", type=_positive_int, default=128, help="font rasterization size")
     data.add_argument("--samples-per-epoch", type=_positive_int, default=62_000)
     data.add_argument("--validation-fonts-per-class", type=_positive_int, default=5)
+    data.add_argument("--validation-family-fraction", type=_heldout_fraction, default=0.2)
 
     loading = parser.add_argument_group("Data loading")
     loading.add_argument("--batch-size", type=_positive_int, default=256)
@@ -574,7 +590,16 @@ def main(args: argparse.Namespace) -> None:
     alphabet = tuple(args.alphabet)
     records, manifest_info = resolve_font_records(alphabet, args.font_dir, args.manifest)
     train_transform, val_transform = build_transforms(args)
-    train_set = SyntheticCharacterDataset(alphabet, records, args.render_size, args.samples_per_epoch, train_transform)
+    if args.show_samples is not None or args.benchmark_loader:
+        train_records = records
+        val_records: tuple[FontRecord, ...] = ()
+    else:
+        train_records, val_records = split_font_families(
+            alphabet, records, args.render_size, args.validation_family_fraction, args.seed
+        )
+    train_set = SyntheticCharacterDataset(
+        alphabet, train_records, args.render_size, args.samples_per_epoch, train_transform
+    )
     train_sampler = RandomSampler(train_set, generator=_generator(args.seed))
     train_loader = build_loader(
         train_set,
@@ -592,14 +617,17 @@ def main(args: argparse.Namespace) -> None:
         benchmark_loader(train_loader, args.benchmark_warmup_batches, args.benchmark_batches)
         return
 
-    val_set = SyntheticCharacterDataset(
-        alphabet,
-        records,
-        args.render_size,
-        len(alphabet) * args.validation_fonts_per_class,
-        val_transform,
-        deterministic=True,
-    )
+    try:
+        val_set = SyntheticCharacterDataset(
+            alphabet,
+            val_records,
+            args.render_size,
+            len(alphabet) * args.validation_fonts_per_class,
+            val_transform,
+            deterministic=True,
+        )
+    except ValueError as exc:
+        raise ValueError(f"held-out validation families do not support the full alphabet: {exc}") from exc
     val_loader = build_loader(
         val_set,
         args.batch_size,
@@ -609,18 +637,11 @@ def main(args: argparse.Namespace) -> None:
         pin_memory=gpu is not None,
     )
 
-    model = getattr(classification, args.arch)(False, num_classes=len(alphabet))
+    print("Recipe maturity: experimental; no benchmark or validated checkpoint is claimed.")
+    model = get_model(args.arch, num_classes=len(alphabet))
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
     checkpoint_path = args.output_dir / "checkpoint.pth"
-    best_loss = math.inf
-
-    def save_metadata(metrics: dict[str, float]) -> None:
-        nonlocal best_loss
-        if metrics["val_loss"] < best_loss:
-            write_provenance(args.output_dir / "checkpoint.json", args, train_set, train_set.fonts, manifest_info)
-            best_loss = metrics["val_loss"]
-
     trainer = ClassificationTrainer(
         model,
         train_loader,
@@ -630,18 +651,19 @@ def main(args: argparse.Namespace) -> None:
         gpu,
         str(checkpoint_path),
         amp=args.amp,
-        on_epoch_end=save_metadata,
     )
 
     if args.resume is not None:
-        validate_resume_metadata(args.resume, args.arch, train_set.classes)
-        trainer.load(torch.load(args.resume, map_location="cpu"))
-    best_loss = trainer.min_loss
+        trainer.load(torch.load(args.resume, map_location="cpu", weights_only=True))
     if args.check_setup:
         trainer.check_setup(lr=args.lr, num_it=100)
         return
 
-    trainer.fit_n_epochs(args.epochs, args.lr, sched_type="onecycle")
+    result = trainer.fit_n_epochs(args.epochs, args.lr, sched_type="onecycle")
+    metadata = recipe_metadata(args, train_set, val_set, (*train_set.fonts, *val_set.fonts), manifest_info)
+    result = replace(result, config={**result.config, "recipe": metadata}, bundle_dir=str(args.output_dir))
+    artifacts = (args.manifest,) if args.manifest is not None else ()
+    write_run_bundle(args.output_dir, result, artifacts)
 
 
 if __name__ == "__main__":

--- a/references/classification/train_characters.py
+++ b/references/classification/train_characters.py
@@ -1,0 +1,619 @@
+# Copyright (C) 2019-2026, François-Guillaume Fernandez.
+#
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+"""Train a character classifier from live synthetic images."""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import time
+import warnings
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import torch
+from matplotlib.ft2font import FT2Font
+from PIL import Image, ImageFont
+from torch import Tensor, nn
+from torch.utils.data import DataLoader, Dataset, RandomSampler, Sampler, SequentialSampler
+from torchvision.transforms import v2 as T
+from torchvision.transforms.v2 import functional as F
+from torchvision.transforms.v2.functional import InterpolationMode, to_pil_image
+
+from holocron.models import classification
+from holocron.trainer import ClassificationTrainer
+from holocron.utils import find_fonts, render_text
+
+DEFAULT_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+FONT_EXTENSIONS = {".otf", ".ttc", ".ttf"}
+MODEL_NAMES = tuple(
+    sorted(
+        name
+        for name, value in vars(classification).items()
+        if name.islower() and not name.startswith("_") and callable(value)
+    )
+)
+
+
+@dataclass(frozen=True)
+class FontRecord:
+    """Resolved local font and its optional manifest metadata."""
+
+    path: Path
+    family: str
+    style: str | None = None
+    sha256: str | None = None
+    source: str | None = None
+
+
+class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
+    """Map-style dataset that renders one live character image per sample."""
+
+    def __init__(
+        self,
+        alphabet: Sequence[str],
+        fonts: Sequence[FontRecord | str | Path],
+        render_size: int,
+        samples_per_epoch: int,
+        transform: Callable[[Image.Image], Tensor],
+        *,
+        deterministic: bool = False,
+    ) -> None:
+        self.classes = tuple(alphabet)
+        if not self.classes:
+            raise ValueError("alphabet must not be empty")
+        if any(not isinstance(character, str) or len(character) != 1 for character in self.classes):
+            raise ValueError("alphabet entries must each be one Unicode code point")
+        if len(set(self.classes)) != len(self.classes):
+            raise ValueError("alphabet must not contain duplicate characters")
+        if any(not character.isprintable() or character.isspace() for character in self.classes):
+            raise ValueError("alphabet must contain visible characters only")
+        if isinstance(render_size, bool) or not isinstance(render_size, int) or render_size <= 0:
+            raise ValueError("render_size must be a positive integer")
+        if isinstance(samples_per_epoch, bool) or not isinstance(samples_per_epoch, int) or samples_per_epoch <= 0:
+            raise ValueError("samples_per_epoch must be a positive integer")
+        if not callable(transform):
+            raise TypeError("transform must be callable")
+
+        records = tuple(
+            record
+            if isinstance(record, FontRecord)
+            else FontRecord(Path(record).expanduser().resolve(), str(Path(record).expanduser().resolve()))
+            for record in fonts
+        )
+        if not records:
+            raise ValueError("fonts must not be empty")
+        if len({record.path for record in records}) != len(records):
+            raise ValueError("fonts must not contain duplicate paths")
+
+        compatible: list[list[FontRecord]] = [[] for _ in self.classes]
+        for record in records:
+            if not record.path.is_file():
+                raise FileNotFoundError(f"font file does not exist: {record.path}")
+            try:
+                codepoints = FT2Font(str(record.path)).get_charmap()
+                font = ImageFont.truetype(str(record.path), render_size)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise ValueError(f"unable to load font: {record.path}") from exc
+
+            for class_index, character in enumerate(self.classes):
+                if ord(character) not in codepoints:
+                    continue
+                try:
+                    render_text(character, font)
+                except ValueError:
+                    continue
+                compatible[class_index].append(record)
+
+        self._font_groups: list[tuple[tuple[FontRecord, ...], ...]] = []
+        self._font_choices: list[tuple[FontRecord, ...]] = []
+        for character, choices in zip(self.classes, compatible, strict=True):
+            if not choices:
+                raise ValueError(f"no visible font supports character {character!r}")
+            families: dict[str, list[FontRecord]] = {}
+            for record in choices:
+                families.setdefault(record.family, []).append(record)
+            groups = tuple(tuple(styles) for styles in families.values())
+            self._font_groups.append(groups)
+            self._font_choices.append(tuple(record for group in groups for record in group))
+
+        self.class_to_idx = {character: index for index, character in enumerate(self.classes)}
+        self.render_size = render_size
+        self.samples_per_epoch = samples_per_epoch
+        self.transform = transform
+        self.deterministic = deterministic
+        self._font_cache: dict[Path, ImageFont.FreeTypeFont] = {}
+        self._font_cache_pid: int | None = os.getpid()
+
+    def __len__(self) -> int:
+        return self.samples_per_epoch
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = vars(self).copy()
+        state["_font_cache"] = {}
+        state["_font_cache_pid"] = None
+        return state
+
+    def _select_font(self, index: int, class_index: int) -> FontRecord:
+        if self.deterministic:
+            choices = self._font_choices[class_index]
+            return choices[(index // len(self.classes)) % len(choices)]
+
+        families = self._font_groups[class_index]
+        family = families[torch.randint(len(families), ()).item()]
+        return family[torch.randint(len(family), ()).item()]
+
+    def _get_font(self, path: Path) -> ImageFont.FreeTypeFont:
+        process_id = os.getpid()
+        if process_id != self._font_cache_pid:
+            self._font_cache.clear()
+            self._font_cache_pid = process_id
+        font = self._font_cache.get(path)
+        if font is None:
+            font = ImageFont.truetype(str(path), self.render_size)
+            self._font_cache[path] = font
+        return font
+
+    def __getitem__(self, index: int) -> tuple[Tensor, int]:
+        class_index = index % len(self.classes)
+        record = self._select_font(index, class_index)
+        image = render_text(self.classes[class_index], self._get_font(record.path))
+        return self.transform(image), class_index
+
+
+def _sha256(path: Path) -> str:
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def resolve_font_records(
+    alphabet: Sequence[str], font_dir: Path | None, manifest_path: Path | None
+) -> tuple[tuple[FontRecord, ...], dict[str, Any] | None]:
+    """Resolve local font files and optional manifest provenance.
+
+    Returns:
+        font records and optional manifest metadata
+
+    Raises:
+        FileNotFoundError: if a manifest font is missing
+        NotADirectoryError: if the requested font directory does not exist
+        TypeError: if a manifest source has an invalid type
+        ValueError: if the inputs, manifest, checksums, or discovered corpus are invalid
+    """
+    if manifest_path is not None and font_dir is None:
+        raise ValueError("--manifest requires --font-dir")
+
+    if manifest_path is not None:
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if manifest.get("version") != 1:
+                raise ValueError("unsupported font manifest version")
+            sources = manifest["sources"]
+            font_entries = manifest["fonts"]
+        except (KeyError, TypeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"invalid font manifest: {manifest_path}") from exc
+        if not isinstance(sources, dict) or not isinstance(font_entries, list):
+            raise TypeError(f"invalid font manifest structure: {manifest_path}")
+        if any(not isinstance(source, dict) for source in sources.values()):
+            raise TypeError(f"invalid font source in manifest: {manifest_path}")
+
+        records = []
+        for entry in font_entries:
+            try:
+                filename = entry["filename"]
+                family = entry["family"]
+                expected_hash = entry["sha256"].lower()
+                source = entry["source"]
+            except (AttributeError, KeyError, TypeError) as exc:
+                raise ValueError(f"invalid font entry in manifest: {manifest_path}") from exc
+            if not all(isinstance(value, str) for value in (filename, family, expected_hash, source)):
+                raise ValueError(f"invalid font entry in manifest: {manifest_path}")
+            if source not in sources:
+                raise ValueError(f"unknown font source in manifest: {source}")
+            try:
+                valid_checksum = len(bytes.fromhex(expected_hash)) == 32
+            except ValueError:
+                valid_checksum = False
+            if not valid_checksum:
+                raise ValueError(f"invalid font checksum: {filename}")
+            if Path(filename).name != filename:
+                raise ValueError(f"invalid font filename: {filename}")
+            path = (font_dir / filename).resolve()  # type: ignore[operator]
+            if not path.is_file():
+                raise FileNotFoundError(f"font file does not exist: {path}")
+            actual_hash = _sha256(path)
+            if actual_hash != expected_hash:
+                raise ValueError(f"font checksum mismatch: {path}")
+            records.append(FontRecord(path, family, entry.get("style"), actual_hash, source))
+
+        manifest_info = {
+            "path": str(manifest_path.resolve()),
+            "version": manifest["version"],
+            "source_revisions": {name: source.get("revision") for name, source in sources.items()},
+        }
+        return tuple(records), manifest_info
+
+    if font_dir is not None:
+        if not font_dir.is_dir():
+            raise NotADirectoryError(f"font directory does not exist: {font_dir}")
+        paths = sorted(
+            path.resolve() for path in font_dir.rglob("*") if path.is_file() and path.suffix.lower() in FONT_EXTENSIONS
+        )
+    else:
+        paths = [Path(path).resolve() for path in find_fonts("".join(alphabet))]
+
+    if not paths:
+        raise ValueError("no local font files found")
+    return tuple(FontRecord(path, str(path), sha256=_sha256(path)) for path in paths), None
+
+
+def square_pad(image: Image.Image, margin: int) -> Image.Image:
+    """Add a margin and center a tight glyph in a square without resizing it.
+
+    Returns:
+        square grayscale image
+    """
+    image = F.pad(image, [margin, margin, margin, margin], fill=0)
+    width, height = image.size
+    delta = abs(width - height)
+    padding = [0, delta // 2, 0, delta - delta // 2] if width > height else [delta // 2, 0, delta - delta // 2, 0]
+    return F.pad(image, padding, fill=0)
+
+
+def build_transforms(args: argparse.Namespace) -> tuple[T.Compose, T.Compose]:
+    finalize = [
+        T.Resize((args.image_size, args.image_size), interpolation=InterpolationMode.LANCZOS, antialias=True),
+        T.Grayscale(num_output_channels=3),
+        T.ToImage(),
+        T.ToDtype(torch.float32, scale=True),
+        T.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+    ]
+    pad = partial(square_pad, margin=args.margin)
+    train_transform = T.Compose([
+        pad,
+        T.RandomAffine(
+            args.rotation,
+            translate=(args.translate, args.translate),
+            scale=(1 - args.scale_jitter, 1 + args.scale_jitter),
+            shear=args.shear,
+            interpolation=InterpolationMode.BILINEAR,
+            fill=0,
+        ),
+        T.RandomApply([T.GaussianBlur(3, sigma=(0.1, 1.0))], p=args.blur_prob),
+        T.RandomInvert(p=args.invert_prob),
+        *finalize,
+    ])
+    return train_transform, T.Compose([pad, *finalize])
+
+
+def _generator(seed: int) -> torch.Generator:
+    return torch.Generator().manual_seed(seed)
+
+
+def build_loader(
+    dataset: SyntheticCharacterDataset,
+    batch_size: int,
+    workers: int,
+    sampler: Sampler[int],
+    seed: int,
+    *,
+    pin_memory: bool,
+) -> DataLoader:
+    kwargs: dict[str, Any] = {
+        "batch_size": batch_size,
+        "drop_last": False,
+        "sampler": sampler,
+        "num_workers": workers,
+        "pin_memory": pin_memory,
+        "generator": _generator(seed),
+    }
+    if workers > 0:
+        kwargs.update(persistent_workers=True, prefetch_factor=2)
+    return DataLoader(dataset, **kwargs)
+
+
+def save_sample_grid(loader: DataLoader, classes: Sequence[str], output_path: Path) -> None:
+    images, targets = next(iter(loader))
+    count = min(32, len(targets))
+    columns = min(8, count)
+    rows = math.ceil(count / columns)
+    figure, axes = plt.subplots(rows, columns, figsize=(2 * columns, 2 * rows), squeeze=False)
+    for index, axis in enumerate(axes.flat):
+        axis.axis("off")
+        if index >= count:
+            continue
+        image = (images[index] * 0.5 + 0.5).clamp(0, 1)
+        axis.imshow(to_pil_image(image))
+        axis.set_title(classes[targets[index].item()])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)
+    print(f"Saved {count} samples to {output_path}")
+
+
+def benchmark_loader(loader: DataLoader, warmup_batches: int, measured_batches: int) -> None:
+    required_batches = warmup_batches + measured_batches
+    if required_batches > len(loader):
+        raise ValueError(
+            f"benchmark needs {required_batches} batches, but the loader only has {len(loader)}; "
+            "increase --samples-per-epoch"
+        )
+
+    iterator = iter(loader)
+    for _ in range(warmup_batches):
+        next(iterator)
+    start = time.perf_counter()
+    sample_count = 0
+    image_size = None
+    for _ in range(measured_batches):
+        images, targets = next(iterator)
+        sample_count += len(targets)
+        image_size = images.shape[-1]
+    elapsed = time.perf_counter() - start
+    dataset = loader.dataset
+    print(f"Hardware: {platform.processor() or platform.machine()} ({platform.platform()})")
+    print(
+        f"Loader: workers={loader.num_workers}, batch_size={loader.batch_size}, "
+        f"render_size={dataset.render_size}, image_size={image_size}, base_mask_cache=disabled"
+    )
+    print(
+        f"Measured {sample_count} samples after {warmup_batches} warm-up batches and "
+        f"{measured_batches} measured batches: {sample_count / elapsed:.1f} samples/s"
+    )
+
+
+def resolve_device(device: str) -> int | None:
+    if device == "auto":
+        return 0 if torch.cuda.is_available() else None
+    if device == "cpu":
+        return None
+    if device == "cuda":
+        index = 0
+    elif device.startswith("cuda:") and device[5:].isdigit():
+        index = int(device[5:])
+    else:
+        raise ValueError("--device must be 'auto', 'cpu', 'cuda', or 'cuda:N'")
+    if not torch.cuda.is_available():
+        raise ValueError("CUDA was requested but is not available")
+    if index >= torch.cuda.device_count():
+        raise ValueError(f"CUDA device index is out of range: {index}")
+    return index
+
+
+def _json_value(value: Any) -> Any:
+    return str(value) if isinstance(value, Path) else value
+
+
+def write_provenance(
+    output_path: Path,
+    args: argparse.Namespace,
+    dataset: SyntheticCharacterDataset,
+    records: Sequence[FontRecord],
+    manifest_info: dict[str, Any] | None,
+) -> None:
+    font_root = args.font_dir.resolve() if args.font_dir is not None else None
+    fonts = []
+    for record in records:
+        try:
+            path = record.path.relative_to(font_root) if font_root is not None else record.path
+        except ValueError:
+            path = record.path
+        fonts.append({
+            "path": str(path),
+            "family": record.family,
+            "style": record.style,
+            "sha256": record.sha256,
+            "source": record.source,
+        })
+    payload = {
+        "version": 1,
+        "alphabet": list(dataset.classes),
+        "class_to_index": dataset.class_to_idx,
+        "seed": args.seed,
+        "image_size": args.image_size,
+        "render_size": args.render_size,
+        "architecture": args.arch,
+        "configuration": {key: _json_value(value) for key, value in vars(args).items()},
+        "fonts": fonts,
+        "manifest": manifest_info,
+        "base_mask_cache": False,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def validate_resume_metadata(resume_path: Path, architecture: str, classes: Sequence[str]) -> None:
+    metadata_path = resume_path.with_suffix(".json")
+    if not metadata_path.is_file():
+        warnings.warn(
+            f"resume metadata not found at {metadata_path}; architecture and alphabet cannot be verified",
+            stacklevel=2,
+        )
+        return
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if metadata.get("architecture") != architecture:
+        raise ValueError("resume checkpoint architecture does not match --arch")
+    if metadata.get("alphabet") != list(classes):
+        raise ValueError("resume checkpoint alphabet does not match --alphabet")
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer")
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative number")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive number")
+    return parsed
+
+
+def _probability(value: str) -> float:
+    parsed = float(value)
+    if not 0 <= parsed <= 1:
+        raise argparse.ArgumentTypeError("expected a probability between 0 and 1")
+    return parsed
+
+
+def _scale_jitter(value: str) -> float:
+    parsed = float(value)
+    if not 0 <= parsed < 1:
+        raise argparse.ArgumentTypeError("expected a scale jitter between 0 and 1")
+    return parsed
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    data = parser.add_argument_group("Data and model")
+    data.add_argument("--font-dir", type=Path, help="local font directory; system fonts are used when omitted")
+    data.add_argument("--manifest", type=Path, help="optional version-1 font manifest")
+    data.add_argument("--alphabet", default=DEFAULT_ALPHABET, help="ordered character classes")
+    data.add_argument("--arch", choices=MODEL_NAMES, default="convnext_atto", help="classifier architecture")
+    data.add_argument("--image-size", type=_positive_int, default=64, help="square model input size")
+    data.add_argument("--render-size", type=_positive_int, default=128, help="font rasterization size")
+    data.add_argument("--samples-per-epoch", type=_positive_int, default=62_000)
+    data.add_argument("--validation-fonts-per-class", type=_positive_int, default=5)
+
+    loading = parser.add_argument_group("Data loading")
+    loading.add_argument("--batch-size", type=_positive_int, default=256)
+    loading.add_argument("--workers", type=_nonnegative_int, default=min(os.cpu_count() or 1, 8))
+    loading.add_argument("--seed", type=int, default=0)
+
+    augmentation = parser.add_argument_group("Augmentation")
+    augmentation.add_argument("--margin", type=_nonnegative_int, default=8)
+    augmentation.add_argument("--rotation", type=_nonnegative_float, default=8.0)
+    augmentation.add_argument("--translate", type=_probability, default=0.08)
+    augmentation.add_argument("--scale-jitter", type=_scale_jitter, default=0.1)
+    augmentation.add_argument("--shear", type=_nonnegative_float, default=5.0)
+    augmentation.add_argument("--blur-prob", type=_probability, default=0.1)
+    augmentation.add_argument("--invert-prob", type=_probability, default=0.5)
+
+    optimization = parser.add_argument_group("Optimization")
+    optimization.add_argument("--epochs", type=_positive_int, default=10)
+    optimization.add_argument("--lr", type=_positive_float, default=1e-3)
+    optimization.add_argument("--weight-decay", type=_nonnegative_float, default=1e-4)
+    optimization.add_argument("--device", default="auto", help="auto, cpu, cuda, or cuda:N")
+    optimization.add_argument("--amp", action="store_true", help="use CUDA automatic mixed precision")
+    optimization.add_argument("--output-dir", type=Path, default=Path("checkpoints/characters"))
+    optimization.add_argument("--resume", type=Path, help="checkpoint to resume")
+
+    actions = parser.add_argument_group("Actions")
+    action = actions.add_mutually_exclusive_group()
+    action.add_argument("--show-samples", type=Path, metavar="PATH", help="save an augmented grid and exit")
+    action.add_argument("--benchmark-loader", action="store_true", help="benchmark live image loading and exit")
+    action.add_argument("--check-setup", action="store_true", help="run the trainer's one-batch overfit check")
+    actions.add_argument("--benchmark-warmup-batches", type=_nonnegative_int, default=10)
+    actions.add_argument("--benchmark-batches", type=_positive_int, default=100)
+    return parser
+
+
+def main(args: argparse.Namespace) -> None:
+    if args.render_size < args.image_size:
+        raise ValueError("--render-size must be at least --image-size")
+    torch.manual_seed(args.seed)
+    gpu = resolve_device(args.device)
+    if args.amp and gpu is None:
+        raise ValueError("--amp requires a CUDA device")
+
+    alphabet = tuple(args.alphabet)
+    records, manifest_info = resolve_font_records(alphabet, args.font_dir, args.manifest)
+    train_transform, val_transform = build_transforms(args)
+    train_set = SyntheticCharacterDataset(alphabet, records, args.render_size, args.samples_per_epoch, train_transform)
+    train_sampler = RandomSampler(train_set, generator=_generator(args.seed))
+    train_loader = build_loader(
+        train_set,
+        min(args.batch_size, 32) if args.show_samples is not None else args.batch_size,
+        args.workers,
+        train_sampler,
+        args.seed + 1,
+        pin_memory=gpu is not None,
+    )
+
+    if args.show_samples is not None:
+        save_sample_grid(train_loader, train_set.classes, args.show_samples)
+        return
+    if args.benchmark_loader:
+        benchmark_loader(train_loader, args.benchmark_warmup_batches, args.benchmark_batches)
+        return
+
+    val_set = SyntheticCharacterDataset(
+        alphabet,
+        records,
+        args.render_size,
+        len(alphabet) * args.validation_fonts_per_class,
+        val_transform,
+        deterministic=True,
+    )
+    val_loader = build_loader(
+        val_set,
+        args.batch_size,
+        args.workers,
+        SequentialSampler(val_set),
+        args.seed + 2,
+        pin_memory=gpu is not None,
+    )
+
+    model = getattr(classification, args.arch)(False, num_classes=len(alphabet))
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    checkpoint_path = args.output_dir / "checkpoint.pth"
+    checkpoint_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
+
+    def save_metadata(_metrics: dict[str, float]) -> None:
+        nonlocal checkpoint_mtime
+        current_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
+        if current_mtime != checkpoint_mtime:
+            write_provenance(args.output_dir / "checkpoint.json", args, train_set, records, manifest_info)
+            checkpoint_mtime = current_mtime
+
+    trainer = ClassificationTrainer(
+        model,
+        train_loader,
+        val_loader,
+        criterion,
+        optimizer,
+        gpu,
+        str(checkpoint_path),
+        amp=args.amp,
+        on_epoch_end=save_metadata,
+    )
+
+    if args.resume is not None:
+        validate_resume_metadata(args.resume, args.arch, train_set.classes)
+        trainer.load(torch.load(args.resume, map_location="cpu"))
+    if args.check_setup:
+        trainer.check_setup(lr=args.lr, num_it=100)
+        return
+
+    trainer.fit_n_epochs(args.epochs, args.lr, sched_type="onecycle")
+
+
+if __name__ == "__main__":
+    main(get_parser().parse_args())

--- a/references/classification/train_characters.py
+++ b/references/classification/train_characters.py
@@ -1,5 +1,5 @@
-# Copyright (C) 2019-2026, François-Guillaume Fernandez.
-#
+# Copyright (C) 2026, François-Guillaume Fernandez.
+
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
@@ -14,7 +14,7 @@ import platform
 import time
 import warnings
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -55,6 +55,80 @@ class FontRecord:
     source: str | None = None
 
 
+def _validate_alphabet(alphabet: Sequence[str]) -> tuple[str, ...]:
+    classes = tuple(alphabet)
+    if not classes:
+        raise ValueError("alphabet must not be empty")
+    if any(not isinstance(character, str) or len(character) != 1 for character in classes):
+        raise ValueError("alphabet entries must each be one Unicode code point")
+    if len(set(classes)) != len(classes):
+        raise ValueError("alphabet must not contain duplicate characters")
+    if any(not character.isprintable() or character.isspace() for character in classes):
+        raise ValueError("alphabet must contain visible characters only")
+    return classes
+
+
+def _as_font_record(record: FontRecord | str | Path) -> FontRecord:
+    if isinstance(record, FontRecord):
+        return record
+    path = Path(record).expanduser().resolve()
+    return FontRecord(path, str(path))
+
+
+def _inspect_fonts(
+    classes: Sequence[str], fonts: Sequence[FontRecord | str | Path], render_size: int
+) -> tuple[tuple[FontRecord, ...], list[list[FontRecord]]]:
+    records = tuple(_as_font_record(record) for record in fonts)
+    if not records:
+        raise ValueError("fonts must not be empty")
+    if len({record.path for record in records}) != len(records):
+        raise ValueError("fonts must not contain duplicate paths")
+
+    compatible: list[list[FontRecord]] = [[] for _ in classes]
+    validated_records = []
+    for record in records:
+        if not record.path.is_file():
+            raise FileNotFoundError(f"font file does not exist: {record.path}")
+        try:
+            font_info = FT2Font(str(record.path))
+            codepoints = font_info.get_charmap()
+            font = ImageFont.truetype(str(record.path), render_size)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ValueError(f"unable to load font: {record.path}") from exc
+
+        resolved_record = replace(record, family=font_info.family_name, style=font_info.style_name)
+        validated_records.append(resolved_record)
+        for class_index, character in enumerate(classes):
+            if ord(character) not in codepoints:
+                continue
+            try:
+                render_text(character, font)
+            except ValueError:
+                continue
+            compatible[class_index].append(resolved_record)
+    return tuple(validated_records), compatible
+
+
+def _group_fonts(
+    classes: Sequence[str], records: Sequence[FontRecord], compatible: Sequence[Sequence[FontRecord]]
+) -> tuple[list[tuple[tuple[FontRecord, ...], ...]], list[tuple[FontRecord, ...]], tuple[FontRecord, ...]]:
+    font_groups = []
+    font_choices = []
+    for character, choices in zip(classes, compatible, strict=True):
+        if not choices:
+            raise ValueError(f"no visible font supports character {character!r}")
+        families: dict[str, list[FontRecord]] = {}
+        for record in choices:
+            families.setdefault(record.family, []).append(record)
+        groups = tuple(tuple(styles) for styles in families.values())
+        font_groups.append(groups)
+        font_choices.append(tuple(record for group in groups for record in group))
+
+    selected_paths = {record.path for choices in compatible for record in choices}
+    selected_records = tuple(record for record in records if record.path in selected_paths)
+    return font_groups, font_choices, selected_records
+
+
 class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
     """Map-style dataset that renders one live character image per sample."""
 
@@ -68,15 +142,7 @@ class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
         *,
         deterministic: bool = False,
     ) -> None:
-        self.classes = tuple(alphabet)
-        if not self.classes:
-            raise ValueError("alphabet must not be empty")
-        if any(not isinstance(character, str) or len(character) != 1 for character in self.classes):
-            raise ValueError("alphabet entries must each be one Unicode code point")
-        if len(set(self.classes)) != len(self.classes):
-            raise ValueError("alphabet must not contain duplicate characters")
-        if any(not character.isprintable() or character.isspace() for character in self.classes):
-            raise ValueError("alphabet must contain visible characters only")
+        self.classes = _validate_alphabet(alphabet)
         if isinstance(render_size, bool) or not isinstance(render_size, int) or render_size <= 0:
             raise ValueError("render_size must be a positive integer")
         if isinstance(samples_per_epoch, bool) or not isinstance(samples_per_epoch, int) or samples_per_epoch <= 0:
@@ -84,48 +150,8 @@ class SyntheticCharacterDataset(Dataset[tuple[Tensor, int]]):
         if not callable(transform):
             raise TypeError("transform must be callable")
 
-        records = tuple(
-            record
-            if isinstance(record, FontRecord)
-            else FontRecord(Path(record).expanduser().resolve(), str(Path(record).expanduser().resolve()))
-            for record in fonts
-        )
-        if not records:
-            raise ValueError("fonts must not be empty")
-        if len({record.path for record in records}) != len(records):
-            raise ValueError("fonts must not contain duplicate paths")
-
-        compatible: list[list[FontRecord]] = [[] for _ in self.classes]
-        for record in records:
-            if not record.path.is_file():
-                raise FileNotFoundError(f"font file does not exist: {record.path}")
-            try:
-                codepoints = FT2Font(str(record.path)).get_charmap()
-                font = ImageFont.truetype(str(record.path), render_size)
-            except (OSError, RuntimeError, ValueError) as exc:
-                raise ValueError(f"unable to load font: {record.path}") from exc
-
-            for class_index, character in enumerate(self.classes):
-                if ord(character) not in codepoints:
-                    continue
-                try:
-                    render_text(character, font)
-                except ValueError:
-                    continue
-                compatible[class_index].append(record)
-
-        self._font_groups: list[tuple[tuple[FontRecord, ...], ...]] = []
-        self._font_choices: list[tuple[FontRecord, ...]] = []
-        for character, choices in zip(self.classes, compatible, strict=True):
-            if not choices:
-                raise ValueError(f"no visible font supports character {character!r}")
-            families: dict[str, list[FontRecord]] = {}
-            for record in choices:
-                families.setdefault(record.family, []).append(record)
-            groups = tuple(tuple(styles) for styles in families.values())
-            self._font_groups.append(groups)
-            self._font_choices.append(tuple(record for group in groups for record in group))
-
+        records, compatible = _inspect_fonts(self.classes, fonts, render_size)
+        self._font_groups, self._font_choices, self.fonts = _group_fonts(self.classes, records, compatible)
         self.class_to_idx = {character: index for index, character in enumerate(self.classes)}
         self.render_size = render_size
         self.samples_per_epoch = samples_per_epoch
@@ -175,6 +201,40 @@ def _sha256(path: Path) -> str:
         return hashlib.file_digest(stream, "sha256").hexdigest()
 
 
+def _manifest_font_records(
+    font_dir: Path, manifest_path: Path, sources: dict[str, Any], font_entries: Sequence[Any]
+) -> tuple[FontRecord, ...]:
+    records = []
+    for entry in font_entries:
+        try:
+            filename = entry["filename"]
+            family = entry["family"]
+            expected_hash = entry["sha256"].lower()
+            source = entry["source"]
+        except (AttributeError, KeyError, TypeError) as exc:
+            raise ValueError(f"invalid font entry in manifest: {manifest_path}") from exc
+        if not all(isinstance(value, str) for value in (filename, family, expected_hash, source)):
+            raise ValueError(f"invalid font entry in manifest: {manifest_path}")
+        if source not in sources:
+            raise ValueError(f"unknown font source in manifest: {source}")
+        try:
+            valid_checksum = len(bytes.fromhex(expected_hash)) == 32
+        except ValueError:
+            valid_checksum = False
+        if not valid_checksum:
+            raise ValueError(f"invalid font checksum: {filename}")
+        if Path(filename).name != filename:
+            raise ValueError(f"invalid font filename: {filename}")
+        path = (font_dir / filename).resolve()
+        if not path.is_file():
+            raise FileNotFoundError(f"font file does not exist: {path}")
+        actual_hash = _sha256(path)
+        if actual_hash != expected_hash:
+            raise ValueError(f"font checksum mismatch: {path}")
+        records.append(FontRecord(path, family, entry.get("style"), actual_hash, source))
+    return tuple(records)
+
+
 def resolve_font_records(
     alphabet: Sequence[str], font_dir: Path | None, manifest_path: Path | None
 ) -> tuple[tuple[FontRecord, ...], dict[str, Any] | None]:
@@ -184,15 +244,13 @@ def resolve_font_records(
         font records and optional manifest metadata
 
     Raises:
-        FileNotFoundError: if a manifest font is missing
         NotADirectoryError: if the requested font directory does not exist
         TypeError: if a manifest source has an invalid type
         ValueError: if the inputs, manifest, checksums, or discovered corpus are invalid
     """
-    if manifest_path is not None and font_dir is None:
-        raise ValueError("--manifest requires --font-dir")
-
     if manifest_path is not None:
+        if font_dir is None:
+            raise ValueError("--manifest requires --font-dir")
         try:
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             if manifest.get("version") != 1:
@@ -206,41 +264,13 @@ def resolve_font_records(
         if any(not isinstance(source, dict) for source in sources.values()):
             raise TypeError(f"invalid font source in manifest: {manifest_path}")
 
-        records = []
-        for entry in font_entries:
-            try:
-                filename = entry["filename"]
-                family = entry["family"]
-                expected_hash = entry["sha256"].lower()
-                source = entry["source"]
-            except (AttributeError, KeyError, TypeError) as exc:
-                raise ValueError(f"invalid font entry in manifest: {manifest_path}") from exc
-            if not all(isinstance(value, str) for value in (filename, family, expected_hash, source)):
-                raise ValueError(f"invalid font entry in manifest: {manifest_path}")
-            if source not in sources:
-                raise ValueError(f"unknown font source in manifest: {source}")
-            try:
-                valid_checksum = len(bytes.fromhex(expected_hash)) == 32
-            except ValueError:
-                valid_checksum = False
-            if not valid_checksum:
-                raise ValueError(f"invalid font checksum: {filename}")
-            if Path(filename).name != filename:
-                raise ValueError(f"invalid font filename: {filename}")
-            path = (font_dir / filename).resolve()  # type: ignore[operator]
-            if not path.is_file():
-                raise FileNotFoundError(f"font file does not exist: {path}")
-            actual_hash = _sha256(path)
-            if actual_hash != expected_hash:
-                raise ValueError(f"font checksum mismatch: {path}")
-            records.append(FontRecord(path, family, entry.get("style"), actual_hash, source))
-
+        records = _manifest_font_records(font_dir, manifest_path, sources, font_entries)
         manifest_info = {
             "path": str(manifest_path.resolve()),
             "version": manifest["version"],
             "source_revisions": {name: source.get("revision") for name, source in sources.items()},
         }
-        return tuple(records), manifest_info
+        return records, manifest_info
 
     if font_dir is not None:
         if not font_dir.is_dir():
@@ -253,7 +283,7 @@ def resolve_font_records(
 
     if not paths:
         raise ValueError("no local font files found")
-    return tuple(FontRecord(path, str(path), sha256=_sha256(path)) for path in paths), None
+    return tuple(FontRecord(path, str(path)) for path in paths), None
 
 
 def square_pad(image: Image.Image, margin: int) -> Image.Image:
@@ -364,7 +394,7 @@ def benchmark_loader(loader: DataLoader, warmup_batches: int, measured_batches: 
     print(f"Hardware: {platform.processor() or platform.machine()} ({platform.platform()})")
     print(
         f"Loader: workers={loader.num_workers}, batch_size={loader.batch_size}, "
-        f"render_size={dataset.render_size}, image_size={image_size}, base_mask_cache=disabled"
+        f"render_size={dataset.render_size}, image_size={image_size}, font_cache=worker-local"
     )
     print(
         f"Measured {sample_count} samples after {warmup_batches} warm-up batches and "
@@ -412,7 +442,7 @@ def write_provenance(
             "path": str(path),
             "family": record.family,
             "style": record.style,
-            "sha256": record.sha256,
+            "sha256": record.sha256 or _sha256(record.path),
             "source": record.source,
         })
     payload = {
@@ -426,7 +456,6 @@ def write_provenance(
         "configuration": {key: _json_value(value) for key, value in vars(args).items()},
         "fonts": fonts,
         "manifest": manifest_info,
-        "base_mask_cache": False,
     }
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -584,14 +613,13 @@ def main(args: argparse.Namespace) -> None:
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
     checkpoint_path = args.output_dir / "checkpoint.pth"
-    checkpoint_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
+    best_loss = math.inf
 
-    def save_metadata(_metrics: dict[str, float]) -> None:
-        nonlocal checkpoint_mtime
-        current_mtime = checkpoint_path.stat().st_mtime_ns if checkpoint_path.is_file() else None
-        if current_mtime != checkpoint_mtime:
-            write_provenance(args.output_dir / "checkpoint.json", args, train_set, records, manifest_info)
-            checkpoint_mtime = current_mtime
+    def save_metadata(metrics: dict[str, float]) -> None:
+        nonlocal best_loss
+        if metrics["val_loss"] < best_loss:
+            write_provenance(args.output_dir / "checkpoint.json", args, train_set, train_set.fonts, manifest_info)
+            best_loss = metrics["val_loss"]
 
     trainer = ClassificationTrainer(
         model,
@@ -608,6 +636,7 @@ def main(args: argparse.Namespace) -> None:
     if args.resume is not None:
         validate_resume_metadata(args.resume, args.arch, train_set.classes)
         trainer.load(torch.load(args.resume, map_location="cpu"))
+    best_loss = trainer.min_loss
     if args.check_setup:
         trainer.check_setup(lr=args.lr, num_it=100)
         return

--- a/references/clean_checkpoint.py
+++ b/references/clean_checkpoint.py
@@ -11,7 +11,7 @@ import torch
 
 
 def main(args):
-    checkpoint = torch.load(args.checkpoint, map_location="cpu")["model"]
+    checkpoint = torch.load(args.checkpoint, map_location="cpu", weights_only=True)["model"]
     torch.save(checkpoint, args.outfile, _use_new_zipfile_serialization=False)
 
     sha_hash = hashlib.sha256(Path(args.outfile).read_bytes()).hexdigest()

--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -8,7 +8,7 @@ Ensure that you have holocron installed
 
 ```bash
 git clone https://github.com/frgfm/Holocron.git
-pip install -e "Holocron/.[training]"
+pip install -e "Holocron/.[training,evaluation]"
 ```
 
 No need to download the dataset, torchvision will handle [this](https://pytorch.org/docs/stable/torchvision/datasets.html#torchvision.datasets.VOCDetection) for you! From there, you can run your training with the following command

--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -14,7 +14,7 @@ pip install -e "Holocron/.[training]"
 No need to download the dataset, torchvision will handle [this](https://pytorch.org/docs/stable/torchvision/datasets.html#torchvision.datasets.VOCDetection) for you! From there, you can run your training with the following command
 
 ```bash
-python train.py VOC2012 --arch yolov2 --lr 1e-5 -b 32 -j 16 --epochs 20 --opt radam --sched onecycle
+python train.py VOC2012 --arch yolov2 --seed 0 --lr 1e-5 -b 32 -j 16 --epochs 20 --opt radam --sched onecycle
 ```
 
 
@@ -40,7 +40,7 @@ Here, the recall being the ratio of correctly predicted ground truth predictions
 
 | Size (px) | Epochs | args                                                         | Loc@.5 | Clf@.5 | Det@.5 | # Runs |
 | --------- | ------ | ------------------------------------------------------------ | ------ | ------ | ------ | ------ |
-| 416       | 40     | VOC2012 --arch yolov2 --img-size 416 --lr 5e-4 -b 64 -j 16 --epochs 40 --opt tadam --freeze-backbone --sched onecycle | 83.09  | 52.82  | 92.02  | 1      |
+| 416       | 40     | VOC2012 --arch yolov2 --img-size 416 --lr 5e-4 -b 64 -j 16 --epochs 40 --opt tadam --freeze-until backbone --sched onecycle | 83.09  | 52.82  | 92.02  | 1      |
 
 
 

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -224,7 +224,7 @@ def _main(args):
 
     if args.resume:
         print(f"Resuming {args.resume}")
-        checkpoint = torch.load(args.resume, map_location="cpu")
+        checkpoint = torch.load(args.resume, map_location="cpu", weights_only=True)
         trainer.load(checkpoint)
 
     if args.test_only:

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -272,7 +272,9 @@ def _main(args):
 
     print("Start training")
     start_time = time.time()
-    trainer.fit_n_epochs(args.epochs, args.lr, args.freeze_until, args.sched, norm_weight_decay=args.norm_wd)
+    trainer.fit_n_epochs(
+        args.epochs, args.lr, args.freeze_until, args.sched, norm_weight_decay=args.norm_wd, run_dir=args.run_dir
+    )
     total_time_str = str(datetime.timedelta(seconds=int(time.time() - start_time)))
     print(f"Training time {total_time_str}")
 
@@ -290,6 +292,7 @@ def get_parser():
     group.add_argument("--source", type=str, default="holocron", help="where should the architecture be taken from")
     group.add_argument("--pretrained", action="store_true", help="Use pre-trained models from the modelzoo")
     group.add_argument("--output-file", default="./checkpoints/model.pth", help="path where to save")
+    group.add_argument("--run-dir", default=None, help="optional run bundle directory")
     group.add_argument("--resume", default="", help="resume from checkpoint")
     group.add_argument("--seed", default=0, type=int, help="random seed")
     # Hardware

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -15,8 +15,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.utils.data
-import wandb
-from codecarbon import track_emissions
 from matplotlib.patches import Rectangle
 from torch.utils.data import RandomSampler, SequentialSampler
 from torchvision.datasets import VOCDetection
@@ -93,10 +91,18 @@ def plot_samples(images, targets, num_samples=8):
     plt.show()
 
 
-@track_emissions()
 def main(args):
+    from codecarbon import track_emissions  # noqa: PLC0415 - keep parser importable without training extras
+
+    return track_emissions()(_main)(args)
+
+
+def _main(args):
+    import wandb  # noqa: PLC0415 - keep parser importable without training extras
+
     print(args)
 
+    torch.manual_seed(args.seed)
     torch.backends.cudnn.benchmark = True
 
     # Data loading
@@ -260,6 +266,7 @@ def main(args):
                 "input_size": args.img_size,
                 "optimizer": args.opt,
                 "dataset": "PASCAL VOC2012 Detection",
+                "seed": args.seed,
             },
         )
 
@@ -284,6 +291,7 @@ def get_parser():
     group.add_argument("--pretrained", action="store_true", help="Use pre-trained models from the modelzoo")
     group.add_argument("--output-file", default="./checkpoints/model.pth", help="path where to save")
     group.add_argument("--resume", default="", help="resume from checkpoint")
+    group.add_argument("--seed", default=0, type=int, help="random seed")
     # Hardware
     group = parser.add_argument_group("Hardware")
     group.add_argument("--device", default=None, type=int, help="device")

--- a/references/segmentation/README.md
+++ b/references/segmentation/README.md
@@ -1,6 +1,6 @@
 # Semantic segmentation
 
-The sample training script was made to train object detection models on [PASCAL VOC 2012](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/).
+The sample training script was made to train semantic segmentation models on [PASCAL VOC 2012](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/).
 
 ## Getting started
 
@@ -14,7 +14,7 @@ pip install -e "Holocron/.[training]"
 No need to download the dataset, torchvision will handle [this](https://pytorch.org/docs/stable/torchvision/datasets.html#torchvision.datasets.VOCSegmentation) for you! From there, you can run your training with the following command
 
 ```bash
-python train.py VOC2012 --arch unet3p -b 4 -j 16 --opt radam --lr 1e-5 --sched onecycle --epochs 20
+python train.py VOC2012 --arch unet3p --seed 0 --img-size 256 -b 4 -j 16 --opt radam --lr 1e-5 --sched onecycle --epochs 20
 ```
 
 
@@ -27,8 +27,8 @@ Performances are evaluated on the validation set of the dataset using the mean I
 
 | Size (px) | Epochs | args                                                         | mean IoU | # Runs |
 | --------- | ------ | ------------------------------------------------------------ | -------- | ------ |
-| 256       | 200    | VOC2012 --arch unet_rexnet13 -b 16 --loss label_smoothing --opt adamp --device 0 --lr 2e-3 --epochs 200 | 32.14    | 1      |
-| 256       | 20     | VOC2012 --arch unet3p -b 4 -j 16 --opt radam --lr 1e-5 --sched onecycle --epochs 20 | 14.17    | 1      |
+| 256       | 200    | VOC2012 --arch unet_rexnet13 --img-size 256 -b 16 --loss label_smoothing --opt adamp --device 0 --lr 2e-3 --epochs 200 | 32.14    | 1      |
+| 256       | 20     | VOC2012 --arch unet3p --img-size 256 -b 4 -j 16 --opt radam --lr 1e-5 --sched onecycle --epochs 20 | 14.17    | 1      |
 
 
 

--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -304,7 +304,14 @@ def _main(args):
 
     print("Start training")
     start_time = time.time()
-    trainer.fit_n_epochs(args.epochs, args.lr, args.freeze_until, args.sched, norm_weight_decay=args.norm_weight_decay)
+    trainer.fit_n_epochs(
+        args.epochs,
+        args.lr,
+        args.freeze_until,
+        args.sched,
+        norm_weight_decay=args.norm_weight_decay,
+        run_dir=args.run_dir,
+    )
     total_time_str = str(datetime.timedelta(seconds=int(time.time() - start_time)))
     print(f"Training time {total_time_str}")
 
@@ -322,6 +329,7 @@ def get_parser():
     group.add_argument("--source", type=str, default="holocron", help="where should the architecture be taken from")
     group.add_argument("--pretrained", action="store_true", help="Use pre-trained models from the modelzoo")
     group.add_argument("--output-file", default="./checkpoints/model.pth", help="path where to save")
+    group.add_argument("--run-dir", default=None, help="optional run bundle directory")
     group.add_argument("--resume", default="", help="resume from checkpoint")
     group.add_argument("--seed", default=0, type=int, help="random seed")
     # Hardware

--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -14,8 +14,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.utils.data
-import wandb
-from codecarbon import track_emissions
 from torch import nn
 from torch.utils.data import RandomSampler, SequentialSampler
 from torchvision.datasets import VOCSegmentation
@@ -108,16 +106,24 @@ def plot_predictions(images, preds, targets, ignore_index=None):
     plt.show()
 
 
-@track_emissions()
 def main(args):
+    from codecarbon import track_emissions  # noqa: PLC0415 - keep parser importable without training extras
+
+    return track_emissions()(_main)(args)
+
+
+def _main(args):
+    import wandb  # noqa: PLC0415 - keep parser importable without training extras
+
     print(args)
 
+    torch.manual_seed(args.seed)
     torch.backends.cudnn.benchmark = True
 
     # Data loading
     normalize = T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-    base_size = 320
-    crop_size = 256
+    crop_size = args.img_size
+    base_size = round(1.25 * crop_size)
     min_size, max_size = int(0.5 * base_size), int(2.0 * base_size)
 
     interpolation_mode = InterpolationMode.BILINEAR
@@ -288,10 +294,11 @@ def main(args):
                 "batch_size": args.batch_size,
                 "architecture": args.arch,
                 "source": args.source,
-                "input_size": 256,
+                "input_size": args.img_size,
                 "optimizer": args.opt,
                 "dataset": "Pascal VOC2012 Segmentation",
                 "loss": args.loss,
+                "seed": args.seed,
             },
         )
 
@@ -311,11 +318,12 @@ def get_parser():
     # Data & model
     group = parser.add_argument_group("Data & model")
     group.add_argument("data_path", type=str, help="path to dataset folder")
-    group.add_argument("--arch", default="yolov2", type=str, help="architecture to use")
+    group.add_argument("--arch", default="unet3p", type=str, help="architecture to use")
     group.add_argument("--source", type=str, default="holocron", help="where should the architecture be taken from")
     group.add_argument("--pretrained", action="store_true", help="Use pre-trained models from the modelzoo")
     group.add_argument("--output-file", default="./checkpoints/model.pth", help="path where to save")
     group.add_argument("--resume", default="", help="resume from checkpoint")
+    group.add_argument("--seed", default=0, type=int, help="random seed")
     # Hardware
     group = parser.add_argument_group("Hardware")
     group.add_argument("--device", default=None, type=int, help="device")
@@ -328,7 +336,7 @@ def get_parser():
     )
     # Transformations
     group = parser.add_argument_group("Transformations")
-    group.add_argument("--img-size", default=416, type=int, help="image size")
+    group.add_argument("--img-size", default=256, type=int, help="image size")
     # Optimization
     group = parser.add_argument_group("Optimization")
     group.add_argument("--epochs", default=20, type=int, help="number of total epochs to run")

--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -245,7 +245,7 @@ def _main(args):
     )
     if args.resume:
         print(f"Resuming {args.resume}")
-        checkpoint = torch.load(args.resume, map_location="cpu")
+        checkpoint = torch.load(args.resume, map_location="cpu", weights_only=True)
         trainer.load(checkpoint)
 
     if args.show_preds:

--- a/references/segmentation/transforms.py
+++ b/references/segmentation/transforms.py
@@ -7,7 +7,8 @@
 
 import numpy as np
 import torch
-from torchvision.transforms.v2 import InterpolationMode, transforms
+from torchvision import transforms
+from torchvision.transforms import InterpolationMode
 from torchvision.transforms.v2 import functional as F
 
 

--- a/scripts/eval_latency.py
+++ b/scripts/eval_latency.py
@@ -67,10 +67,10 @@ def _format_measurement(name: str, result: dict[str, float | int]) -> str:
 
 @torch.inference_mode()
 def main(args: argparse.Namespace) -> dict[str, Any]:
-    factory = getattr(models, args.arch, None)
-    if not callable(factory):
-        raise TypeError(f"unknown architecture: {args.arch}")
-    model = factory(pretrained=args.pretrained).eval()
+    try:
+        model = models.get_model(args.arch, pretrained=args.pretrained).eval()
+    except ValueError as exc:
+        raise TypeError(f"unknown architecture: {args.arch}") from exc
     if hasattr(model, "reparametrize"):
         model.reparametrize()
 

--- a/scripts/eval_latency.py
+++ b/scripts/eval_latency.py
@@ -8,99 +8,154 @@ Holocron model latency benchmark
 """
 
 import argparse
-import time
+import importlib
+import json
+import platform
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
 
-import numpy as np
-import onnxruntime
 import torch
+from torch.utils import benchmark
 
 from holocron import models
 
 
-@torch.inference_mode()
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    elif device.type == "mps":
+        torch.mps.synchronize()
+
+
 def run_evaluation(
-    model: torch.nn.Module, img_tensor: torch.Tensor, num_it: int = 100, warmup_it: int = 10
-) -> np.array:
-    # Warmup
+    fn: Callable[[], Any],
+    *,
+    device: torch.device,
+    min_run_time: float = 1.0,
+    warmup_it: int = 10,
+    num_threads: int = 1,
+) -> dict[str, float | int]:
+    """Benchmark a callable with accelerator-aware synchronization.
+
+    Returns:
+        Machine-readable timing statistics.
+    """
     for _ in range(warmup_it):
-        _ = model(img_tensor)
+        fn()
+    _synchronize(device)
 
-    timings = []
+    measurement = benchmark.Timer(
+        stmt="fn()",
+        globals={"fn": fn},
+        num_threads=num_threads,
+    ).blocked_autorange(min_run_time=min_run_time)
+    return {
+        "mean_ms": 1000 * measurement.mean,
+        "median_ms": 1000 * measurement.median,
+        "iqr_ms": 1000 * measurement.iqr,
+        "measurements": len(measurement.raw_times),
+        "runs_per_measurement": measurement.number_per_run,
+        "threads": num_threads,
+    }
 
-    # Evaluation runs
-    for _ in range(num_it):
-        start_ts = time.perf_counter()
-        _ = model(img_tensor)
-        timings.append(time.perf_counter() - start_ts)
 
-    return np.array(timings)
-
-
-def run_onnx_evaluation(
-    model: onnxruntime.InferenceSession, img_tensor: np.array, num_it: int = 100, warmup_it: int = 10
-) -> np.array:
-    # Set input
-    ort_input = {model.get_inputs()[0].name: img_tensor}
-    # Warmup
-    for _ in range(warmup_it):
-        _ = model.run(None, ort_input)
-
-    timings = []
-
-    # Evaluation runs
-    for _ in range(num_it):
-        start_ts = time.perf_counter()
-        _ = model.run(None, ort_input)
-        timings.append(time.perf_counter() - start_ts)
-
-    return np.array(timings)
+def _format_measurement(name: str, result: dict[str, float | int]) -> str:
+    return f"{name} - median {result['median_ms']:.2f}ms, mean {result['mean_ms']:.2f}ms, IQR {result['iqr_ms']:.2f}ms"
 
 
 @torch.inference_mode()
-def main(args):
-    # Pretrained imagenet model
-    model = models.__dict__[args.arch](pretrained=args.pretrained).eval()
-    # Reparametrizable models
+def main(args: argparse.Namespace) -> dict[str, Any]:
+    factory = getattr(models, args.arch, None)
+    if not callable(factory):
+        raise TypeError(f"unknown architecture: {args.arch}")
+    model = factory(pretrained=args.pretrained).eval()
     if hasattr(model, "reparametrize"):
         model.reparametrize()
 
-    # Input
-    img_tensor = torch.rand((1, 3, args.size, args.size))
+    input_shape = (args.batch_size, 3, args.size, args.size)
+    cpu = torch.device("cpu")
+    cpu_input = torch.rand(input_shape)
+    results: dict[str, dict[str, float | int]] = {
+        "pytorch_cpu": run_evaluation(
+            lambda: model(cpu_input),
+            device=cpu,
+            min_run_time=args.min_run_time,
+            warmup_it=args.warmup,
+            num_threads=args.num_threads,
+        )
+    }
 
-    timings = run_evaluation(model, img_tensor, args.it)
-    cpu_str = f"mean {1000 * timings.mean():.2f}ms, std {1000 * timings.std():.2f}ms"
+    onnxruntime = importlib.import_module("onnxruntime")
 
-    # ONNX
-    torch.onnx.export(
-        model,
-        img_tensor,
-        "tmp.onnx",
-        export_params=True,
-        opset_version=20,
-        dynamo=False,
-        verbose=False,
-    )
-    onnx_session = onnxruntime.InferenceSession("tmp.onnx")
-    npy_tensor = img_tensor.numpy()
-    timings = run_onnx_evaluation(onnx_session, npy_tensor, args.it)
-    onnx_str = f"mean {1000 * timings.mean():.2f}ms, std {1000 * timings.std():.2f}ms"
+    with TemporaryDirectory(prefix="holocron-onnx-") as tmp_dir:
+        onnx_path = Path(tmp_dir) / "model.onnx"
+        torch.onnx.export(
+            model,
+            (cpu_input,),
+            onnx_path,
+            export_params=True,
+            opset_version=20,
+            dynamo=True,
+            input_names=("input",),
+            output_names=("output",),
+            dynamic_shapes=({0: torch.export.Dim("batch", min=1)},),
+            verbose=False,
+        )
+        session_options = onnxruntime.SessionOptions()
+        session_options.intra_op_num_threads = args.num_threads
+        session = onnxruntime.InferenceSession(
+            onnx_path,
+            sess_options=session_options,
+            providers=("CPUExecutionProvider",),
+        )
+        ort_input = {session.get_inputs()[0].name: cpu_input.numpy()}
+        results["onnxruntime_cpu"] = run_evaluation(
+            lambda: session.run(None, ort_input),
+            device=cpu,
+            min_run_time=args.min_run_time,
+            warmup_it=args.warmup,
+            num_threads=args.num_threads,
+        )
 
-    # GPU
-    if args.device is None:
-        args.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-    if args.device == "cpu":
-        gpu_str = "N/A"
+    device = torch.device(args.device or ("cuda:0" if torch.cuda.is_available() else "cpu"))
+    if device.type != "cpu":
+        device_model = model.to(device=device)
+        device_input = cpu_input.to(device=device)
+        results[f"pytorch_{device.type}"] = run_evaluation(
+            lambda: device_model(device_input),
+            device=device,
+            min_run_time=args.min_run_time,
+            warmup_it=args.warmup,
+            num_threads=args.num_threads,
+        )
+
+    report: dict[str, Any] = {
+        "architecture": args.arch,
+        "input_shape": list(input_shape),
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "onnxruntime": onnxruntime.__version__,
+        },
+        "results": results,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
     else:
-        device = torch.device(args.device)
-        model = model.to(device=device)
-
-        # Input
-        img_tensor = img_tensor.to(device=device)
-        timings = run_evaluation(model, img_tensor, args.it)
-        gpu_str = f"mean {1000 * timings.mean():.2f}ms, std {1000 * timings.std():.2f}ms"
-
-    print(f"{args.arch} ({args.it} runs on ({args.size}, {args.size}) inputs)")
-    print(f"CPU - {cpu_str}\nONNX - {onnx_str}\nGPU - {gpu_str}")
+        print(f"{args.arch} ({input_shape[0]}x3x{args.size}x{args.size})")
+        labels = {
+            "pytorch_cpu": "PyTorch CPU",
+            "onnxruntime_cpu": "ONNX Runtime CPU",
+            "pytorch_cuda": "PyTorch CUDA",
+            "pytorch_mps": "PyTorch MPS",
+        }
+        for name, result in results.items():
+            print(_format_measurement(labels.get(name, name), result))
+    return report
 
 
 if __name__ == "__main__":
@@ -108,13 +163,12 @@ if __name__ == "__main__":
         description="Holocron model latency benchmark", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument("arch", type=str, help="Architecture to use")
-    parser.add_argument("--size", type=int, default=224, help="The image input size")
-    parser.add_argument("--device", type=str, default=None, help="Default device to perform computation on")
-    parser.add_argument("--it", type=int, default=100, help="Number of iterations to run")
-    parser.add_argument("--warmup", type=int, default=10, help="Number of iterations for warmup")
-    parser.add_argument(
-        "--pretrained", dest="pretrained", help="Use pre-trained models from the modelzoo", action="store_true"
-    )
-    args = parser.parse_args()
-
-    main(args)
+    parser.add_argument("--size", type=int, default=224, help="The square image input size")
+    parser.add_argument("--batch-size", type=int, default=1, help="The batch size")
+    parser.add_argument("--device", type=str, help="Optional accelerator device, such as cuda:0 or mps")
+    parser.add_argument("--min-run-time", type=float, default=1.0, help="Minimum seconds per benchmark")
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations")
+    parser.add_argument("--num-threads", type=int, default=1, help="PyTorch CPU threads")
+    parser.add_argument("--pretrained", action="store_true", help="Use pretrained model-zoo weights")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    main(parser.parse_args())

--- a/scripts/export_to_onnx.py
+++ b/scripts/export_to_onnx.py
@@ -25,11 +25,11 @@ def load_model(arch: str, *, pretrained: bool = False, checkpoint: str | Path | 
     Raises:
         TypeError: If the architecture or checkpoint has an invalid type.
     """
-    factory = getattr(models, arch, None)
-    if not callable(factory):
-        raise TypeError(f"unknown architecture: {arch}")
+    try:
+        model = models.get_model(arch, pretrained=pretrained and checkpoint is None)
+    except ValueError as exc:
+        raise TypeError(f"unknown architecture: {arch}") from exc
 
-    model = factory(pretrained=pretrained and checkpoint is None)
     if checkpoint is not None:
         saved = torch.load(checkpoint, map_location="cpu", weights_only=True)
         state_dict = saved["model"] if isinstance(saved, Mapping) and isinstance(saved.get("model"), Mapping) else saved

--- a/scripts/export_to_onnx.py
+++ b/scripts/export_to_onnx.py
@@ -8,39 +8,94 @@ Holocron model ONNX export
 """
 
 import argparse
+from collections.abc import Mapping
+from pathlib import Path
 
 import torch
 
 from holocron import models
 
 
-@torch.inference_mode()
-def main(args):
-    is_pretrained = args.pretrained and not isinstance(args.checkpoint, str)
-    # Pretrained imagenet model
-    model = models.__dict__[args.arch](pretrained=is_pretrained).eval()
+def load_model(arch: str, *, pretrained: bool = False, checkpoint: str | Path | None = None) -> torch.nn.Module:
+    """Create an evaluation model and optionally restore its state.
 
-    # Load the checkpoint
-    if isinstance(args.checkpoint, str):
-        state_dict = torch.load(args.checkpoint, map_location="cpu")
+    Returns:
+        The restored model in evaluation mode.
+
+    Raises:
+        TypeError: If the architecture or checkpoint has an invalid type.
+    """
+    factory = getattr(models, arch, None)
+    if not callable(factory):
+        raise TypeError(f"unknown architecture: {arch}")
+
+    model = factory(pretrained=pretrained and checkpoint is None)
+    if checkpoint is not None:
+        saved = torch.load(checkpoint, map_location="cpu", weights_only=True)
+        state_dict = saved["model"] if isinstance(saved, Mapping) and isinstance(saved.get("model"), Mapping) else saved
+        if not isinstance(state_dict, Mapping):
+            raise TypeError("checkpoint must be a state dict or contain a 'model' state dict")
         model.load_state_dict(state_dict, strict=True)
 
-    # Reparametrizable models
     if hasattr(model, "reparametrize"):
         model.reparametrize()
+    return model.eval()
 
-    # Input
+
+def export_model(
+    model: torch.nn.Module,
+    img_tensor: torch.Tensor,
+    path: str | Path,
+    *,
+    verify: bool = False,
+    report: bool = False,
+    artifacts_dir: str | Path | None = None,
+) -> torch.onnx.ONNXProgram:
+    """Export a model with a dynamic batch dimension.
+
+    Returns:
+        The exported ONNX program.
+
+    Raises:
+        RuntimeError: If the dynamo exporter does not return a program.
+    """
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    report_dir = Path(artifacts_dir) if artifacts_dir is not None else output_path.parent
+    if report:
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+    program = torch.onnx.export(
+        model,
+        (img_tensor,),
+        output_path,
+        export_params=True,
+        opset_version=20,
+        dynamo=True,
+        input_names=("input",),
+        output_names=("output",),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=1)},),
+        verify=verify,
+        report=report,
+        artifacts_dir=report_dir,
+        verbose=False,
+    )
+    if program is None:  # pragma: no cover - dynamo=True always returns a program
+        raise RuntimeError("ONNX export did not return a program")
+    return program
+
+
+@torch.inference_mode()
+def main(args: argparse.Namespace) -> None:
+    model = load_model(args.arch, pretrained=args.pretrained, checkpoint=args.checkpoint)
     img_tensor = torch.rand((args.batch_size, args.in_channels, args.height, args.width))
-
-    # ONNX export
-    torch.onnx.export(
+    export_model(
         model,
         img_tensor,
         args.path,
-        export_params=True,
-        opset_version=20,
-        dynamo=False,
-        verbose=False,
+        verify=args.verify,
+        report=args.report,
+        artifacts_dir=args.artifacts_dir,
     )
 
 
@@ -53,11 +108,10 @@ if __name__ == "__main__":
     parser.add_argument("--width", type=int, default=224, help="The width of the input image")
     parser.add_argument("--in-channels", type=int, default=3, help="The number of channels of the input image")
     parser.add_argument("--batch-size", type=int, default=1, help="The batch size used for the model")
-    parser.add_argument("--path", type=str, default="./model.onnx", help="The path of the output file")
-    parser.add_argument("--checkpoint", type=str, default=None, help="The checkpoint to restore")
-    parser.add_argument(
-        "--pretrained", dest="pretrained", help="Use pre-trained models from the modelzoo", action="store_true"
-    )
-    args = parser.parse_args()
-
-    main(args)
+    parser.add_argument("--path", type=Path, default=Path("model.onnx"), help="The output ONNX file")
+    parser.add_argument("--checkpoint", type=Path, help="A raw state dict or trainer checkpoint to restore")
+    parser.add_argument("--pretrained", action="store_true", help="Use pretrained model-zoo weights")
+    parser.add_argument("--verify", action="store_true", help="Verify the export with ONNX Runtime")
+    parser.add_argument("--report", action="store_true", help="Write the torch.export conversion report")
+    parser.add_argument("--artifacts-dir", type=Path, help="Directory for the conversion report")
+    main(parser.parse_args())

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -52,13 +52,17 @@ def _assert_optimizer_equal(left: torch.optim.Optimizer, right: torch.optim.Opti
 
 @pytest.mark.parametrize("sched_type", ["cosine", "onecycle"])
 def test_interrupted_run_resumes_exactly(tmp_path: Path, sched_type: str) -> None:
+    def consume_rng(_metrics):
+        torch.rand(())
+
     torch.manual_seed(0)
-    baseline = _make_trainer(tmp_path / "baseline.pth")
+    baseline = _make_trainer(tmp_path / "baseline.pth", consume_rng)
     initial_state = deepcopy(baseline.model.state_dict())
     training_rng = torch.get_rng_state()
     baseline_result = baseline.fit_n_epochs(2, 0.05, sched_type=sched_type)
 
     def stop_after_first_epoch(_metrics):
+        torch.rand(())
         raise RuntimeError("stop")
 
     torch.manual_seed(999)
@@ -69,7 +73,7 @@ def test_interrupted_run_resumes_exactly(tmp_path: Path, sched_type: str) -> Non
         interrupted.fit_n_epochs(2, 0.05, sched_type=sched_type)
 
     resumed = _make_trainer(tmp_path / "resumed.pth")
-    resumed.load(torch.load(interrupted.output_file, map_location="cpu", weights_only=False))
+    resumed.load(torch.load(interrupted.output_file, map_location="cpu", weights_only=True))
     resumed.output_file = str(tmp_path / "resumed.pth")
     run_dir = tmp_path / "run"
     resumed_result = resumed.fit_n_epochs(1, 0.05, sched_type=sched_type, run_dir=str(run_dir))
@@ -86,7 +90,7 @@ def test_interrupted_run_resumes_exactly(tmp_path: Path, sched_type: str) -> Non
 def test_checkpoint_v2_is_atomic_and_legacy_loads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     learner = _make_trainer(tmp_path / "checkpoint.pth")
     learner.save(learner.output_file)
-    state = torch.load(learner.output_file, map_location="cpu", weights_only=False)
+    state = torch.load(learner.output_file, map_location="cpu", weights_only=True)
     assert state["schema_version"] == 2
     assert {"model", "optimizer", "scheduler", "scaler", "rng_state", "config"} <= state.keys()
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,149 @@
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from holocron import trainer
+from holocron.trainer import experiment
+
+
+class _TinyTrainer(trainer.Trainer):
+    @torch.inference_mode()
+    def evaluate(self) -> dict[str, float]:
+        self.model.eval()
+        losses = [self.criterion(self.model(x), target).item() for x, target in self.val_loader]
+        self.model.train()
+        return {"val_loss": sum(losses) / len(losses)}
+
+    @staticmethod
+    def _eval_metrics_str(eval_metrics: dict[str, float]) -> str:
+        return f"Validation loss: {eval_metrics['val_loss']:.4f}"
+
+
+def _make_trainer(output_file: Path, on_epoch_end=None) -> _TinyTrainer:
+    x = torch.arange(8, dtype=torch.float32).reshape(4, 2) / 8
+    target = x.sum(dim=1, keepdim=True)
+    loader = DataLoader(TensorDataset(x, target), batch_size=2, shuffle=True)
+    model = nn.Sequential(nn.Linear(2, 4), nn.ReLU(), nn.Dropout(0.2), nn.Linear(4, 1))
+    return _TinyTrainer(
+        model,
+        loader,
+        loader,
+        nn.MSELoss(),
+        torch.optim.SGD(model.parameters(), lr=0.05, momentum=0.9),
+        output_file=str(output_file),
+        on_epoch_end=on_epoch_end,
+    )
+
+
+def _assert_optimizer_equal(left: torch.optim.Optimizer, right: torch.optim.Optimizer) -> None:
+    left_state, right_state = left.state_dict(), right.state_dict()
+    assert left_state["param_groups"] == right_state["param_groups"]
+    assert left_state["state"].keys() == right_state["state"].keys()
+    for parameter, state in left_state["state"].items():
+        for key, value in state.items():
+            torch.testing.assert_close(value, right_state["state"][parameter][key], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("sched_type", ["cosine", "onecycle"])
+def test_interrupted_run_resumes_exactly(tmp_path: Path, sched_type: str) -> None:
+    torch.manual_seed(0)
+    baseline = _make_trainer(tmp_path / "baseline.pth")
+    initial_state = deepcopy(baseline.model.state_dict())
+    training_rng = torch.get_rng_state()
+    baseline_result = baseline.fit_n_epochs(2, 0.05, sched_type=sched_type)
+
+    def stop_after_first_epoch(_metrics):
+        raise RuntimeError("stop")
+
+    torch.manual_seed(999)
+    interrupted = _make_trainer(tmp_path / "interrupted.pth", stop_after_first_epoch)
+    interrupted.model.load_state_dict(initial_state)
+    torch.set_rng_state(training_rng)
+    with pytest.raises(RuntimeError, match="stop"):
+        interrupted.fit_n_epochs(2, 0.05, sched_type=sched_type)
+
+    resumed = _make_trainer(tmp_path / "resumed.pth")
+    resumed.load(torch.load(interrupted.output_file, map_location="cpu", weights_only=False))
+    resumed.output_file = str(tmp_path / "resumed.pth")
+    run_dir = tmp_path / "run"
+    resumed_result = resumed.fit_n_epochs(1, 0.05, sched_type=sched_type, run_dir=str(run_dir))
+
+    for key, parameter in baseline.model.state_dict().items():
+        torch.testing.assert_close(parameter, resumed.model.state_dict()[key], rtol=0, atol=0)
+    _assert_optimizer_equal(baseline.optimizer, resumed.optimizer)
+    assert baseline.scheduler.state_dict() == resumed.scheduler.state_dict()
+    assert (baseline_result.epoch, baseline_result.step) == (resumed_result.epoch, resumed_result.step)
+    assert baseline_result.metrics == resumed_result.metrics
+    assert (run_dir / "manifest.json").is_file()
+
+
+def test_checkpoint_v2_is_atomic_and_legacy_loads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    learner = _make_trainer(tmp_path / "checkpoint.pth")
+    learner.save(learner.output_file)
+    state = torch.load(learner.output_file, map_location="cpu", weights_only=False)
+    assert state["schema_version"] == 2
+    assert {"model", "optimizer", "scheduler", "scaler", "rng_state", "config"} <= state.keys()
+
+    legacy = {"epoch": 3, "step": 7, "min_loss": 0.4, "model": deepcopy(learner.model.state_dict())}
+    learner.load(legacy)
+    assert (learner.start_epoch, learner.epoch, learner.step, learner.min_loss) == (3, 3, 7, 0.4)
+
+    output = Path(learner.output_file)
+    previous = output.read_bytes()
+
+    def fail_save(_state, path):
+        Path(path).write_bytes(b"partial")
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr(torch, "save", fail_save)
+    with pytest.raises(RuntimeError, match="write failed"):
+        learner.save(learner.output_file)
+    assert output.read_bytes() == previous
+    assert not list(tmp_path.glob(".checkpoint.pth.*.tmp"))
+
+
+def test_run_bundle_writes_relative_hashes_and_manifest_last(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    checkpoint = tmp_path / "source.pth"
+    checkpoint.write_bytes(b"checkpoint")
+    artifact = tmp_path / "predictions.json"
+    artifact.write_text("{}", encoding="utf-8")
+    result = trainer.RunResult(
+        epoch=2,
+        step=4,
+        best_metric=0.25,
+        metrics=({"epoch": 1, "step": 2, "val_loss": 0.5}, {"epoch": 2, "step": 4, "val_loss": 0.25}),
+        config={"run": {"lr": 0.01}},
+        checkpoint=str(checkpoint),
+    )
+    bundle = tmp_path / "bundle"
+    writes: list[str] = []
+    original_write = experiment._atomic_write
+
+    def record_write(path: Path, content: str) -> None:
+        if path.name == "manifest.json":
+            assert (bundle / "metrics.jsonl").is_file()
+            assert (bundle / "checkpoints" / checkpoint.name).is_file()
+            assert (bundle / "artifacts" / artifact.name).is_file()
+        writes.append(path.name)
+        original_write(path, content)
+
+    monkeypatch.setattr(experiment, "_atomic_write", record_write)
+    manifest_path = trainer.write_run_bundle(bundle, result, [artifact])
+    assert writes[-1] == "manifest.json"
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    for bundled_artifact in manifest["artifacts"]:
+        path = bundle / bundled_artifact["path"]
+        assert not Path(bundled_artifact["path"]).is_absolute()
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == bundled_artifact["sha256"]
+
+    with pytest.raises(FileNotFoundError):
+        trainer.write_run_bundle(bundle, result, [tmp_path / "missing.json"])
+    assert not manifest_path.exists()

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -42,7 +42,7 @@ def test_generate_model_card_is_deterministic() -> None:
         "pipeline_tag: image-classification",
         "license: apache-2.0",
         "datasets:\n  - imagenette",
-        "| Maturity | validated |",
+        "| Maturity | preview |",
         f"`{checkpoint.meta.sha256}`",
         "## Intended use",
         "## Limitations",

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -1,0 +1,89 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from holocron.models import list_checkpoints
+from holocron.models.model_card import generate_model_card, main, write_model_cards
+
+
+def _write_manifest(root: Path, schema_version: int = 1) -> None:
+    artifact = root / "metrics.jsonl"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text('{"epoch": 2, "val_loss": 0.25}\n', encoding="utf-8")
+    manifest = {
+        "schema_version": schema_version,
+        "run": {
+            "epoch": 2,
+            "step": 4,
+            "best_metric": 0.25,
+            "config": {"optimizer": {"lr": 0.01}, "seed": 7},
+        },
+        "artifacts": [
+            {
+                "path": artifact.name,
+                "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+                "size": artifact.stat().st_size,
+            }
+        ],
+    }
+    (root / "manifest.json").write_text(f"{json.dumps(manifest)}\n", encoding="utf-8")
+
+
+def test_generate_model_card_is_deterministic() -> None:
+    checkpoint = list_checkpoints("convnext_atto")[0]
+
+    card = generate_model_card("convnext_atto", checkpoint)
+
+    assert card == generate_model_card("convnext_atto", checkpoint)
+    for fragment in (
+        "library_name: holocron",
+        "pipeline_tag: image-classification",
+        "license: apache-2.0",
+        "datasets:\n  - imagenette",
+        "| Maturity | validated |",
+        f"`{checkpoint.meta.sha256}`",
+        "## Intended use",
+        "## Limitations",
+        "Run bundle: **unknown / not reported**",
+    ):
+        assert fragment in card
+
+
+def test_generate_model_card_with_run_provenance(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write_manifest(run_dir)
+
+    card = generate_model_card("convnext_atto", list_checkpoints("convnext_atto")[0], run_dir)
+
+    assert card == generate_model_card("convnext_atto", list_checkpoints("convnext_atto")[0], run_dir)
+    assert '"seed": 7' in card
+    assert "| metrics.jsonl |" in card
+    assert hashlib.sha256((run_dir / "metrics.jsonl").read_bytes()).hexdigest() in card
+
+    (run_dir / "metrics.jsonl").write_text('{"epoch": 2, "val_loss": 0.26}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        generate_model_card("convnext_atto", list_checkpoints("convnext_atto")[0], run_dir)
+
+
+def test_generate_model_card_rejects_unfinished_or_invalid_run(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unfinished run bundle"):
+        generate_model_card("convnext_atto", run_dir=tmp_path)
+
+    _write_manifest(tmp_path, schema_version=2)
+    with pytest.raises(ValueError, match="unsupported run manifest schema_version"):
+        generate_model_card("convnext_atto", run_dir=tmp_path)
+
+
+def test_write_model_cards_and_cli(tmp_path: Path) -> None:
+    written = write_model_cards(tmp_path / "cards", ["convnext_atto"])
+    assert len(written) == 1
+    assert written[0].name.startswith("convnext_atto-imagenette-")
+
+    output = tmp_path / "README.md"
+    assert main(["convnext_atto", "--output", str(output)]) == 0
+    assert output.read_text(encoding="utf-8").startswith("---\n")
+
+    with pytest.raises(SystemExit):
+        main(["convnext_atto", "--checkpoint", "-1", "--output", str(output)])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,6 @@
+import hashlib
+from pathlib import Path
+
 import pytest
 import torch
 from torch import nn
@@ -83,6 +86,30 @@ def test_fuse_conv_bn():
         assert torch.allclose(bn(conv(x)), fused_conv(x), atol=1e-6)
 
 
+def test_pretrained_checkpoint_full_hash(monkeypatch, tmp_path):
+    model = nn.Linear(2, 1)
+    state_path = tmp_path / "source.pth"
+    torch.save(model.state_dict(), state_path)
+    digest = hashlib.sha256(state_path.read_bytes()).hexdigest()
+    downloads = []
+
+    def _download(url, destination, hash_prefix, progress):
+        downloads.append((url, hash_prefix, progress))
+        Path(destination).write_bytes(state_path.read_bytes())
+
+    monkeypatch.setattr(utils, "get_dir", lambda: str(tmp_path / "hub"))
+    monkeypatch.setattr(utils, "download_url_to_file", _download)
+    utils.load_pretrained_params(model, "https://example.org/weights.pth", progress=False, sha256=digest)
+    utils.load_pretrained_params(model, "https://example.org/weights.pth", progress=False, sha256=digest)
+
+    assert downloads == [("https://example.org/weights.pth", digest, False)]
+
+
+def test_pretrained_checkpoint_rejects_invalid_hash():
+    with pytest.raises(ValueError, match="64-character hexadecimal"):
+        utils.load_pretrained_params(nn.Linear(2, 1), "https://example.org/weights.pth", sha256="invalid")
+
+
 def test_model_from_hf_hub():
     model = utils.model_from_hf_hub("frgfm/repvgg_a0")
     # Check model type
@@ -100,7 +127,8 @@ def test_model_catalog():
         list_models(task="segmentation")
     )
     assert list_models(maturity=Maturity.EXPERIMENTAL) == ["yolov1", "yolov2", "yolov4"]
-    assert "convnext_atto" in list_models(maturity="validated", pretrained=True)
+    assert list_models(maturity="validated") == []
+    assert "convnext_atto" in list_models(maturity="preview", pretrained=True)
     assert "repvit_m0_9" in list_models(maturity="preview", pretrained=False)
     assert get_model_info("unet_rexnet13").pretrained
 
@@ -125,6 +153,7 @@ def test_get_model(name, kwargs):
 def test_model_checkpoints():
     checkpoint = list_checkpoints("convnext_atto")[0]
     assert checkpoint.meta.arch == "convnext_atto"
+    assert checkpoint.maturity is Maturity.PREVIEW
     assert list_checkpoints("repvit_m0_9") == ()
 
     with pytest.raises(ValueError, match="does not match"):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -111,12 +111,17 @@ def test_pretrained_checkpoint_rejects_invalid_hash():
 
 
 def test_model_from_hf_hub():
-    model = utils.model_from_hf_hub("frgfm/repvgg_a0")
+    model = utils.model_from_hf_hub("frgfm/repvgg_a0", revision="ab1c8cc7cd9dcc49c60352791c799fbda90cf2e8")
     # Check model type
     assert isinstance(model, RepVGG)
 
     # Check num of params
     assert sum(p.data.numel() for p in model.parameters()) == 24741642
+
+
+def test_model_from_hf_hub_requires_commit_revision():
+    with pytest.raises(ValueError, match="40-character commit SHA"):
+        utils.model_from_hf_hub("frgfm/repvgg_a0", revision="main")
 
 
 def test_model_catalog():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from torch import nn
 
-from holocron.models import utils
+from holocron.models import Maturity, get_model, get_model_info, list_checkpoints, list_models, utils
 from holocron.models.classification.repvgg import RepVGG
 from holocron.nn import SAM, BlurPool2d, DropBlock2d
 
@@ -90,3 +90,44 @@ def test_model_from_hf_hub():
 
     # Check num of params
     assert sum(p.data.numel() for p in model.parameters()) == 24741642
+
+
+def test_model_catalog():
+    names = list_models()
+    assert names == sorted(names)
+    assert len(names) == len(set(names)) == 59
+    assert set(names) == set(list_models(task="classification")) | set(list_models(task="detection")) | set(
+        list_models(task="segmentation")
+    )
+    assert list_models(maturity=Maturity.EXPERIMENTAL) == ["yolov1", "yolov2", "yolov4"]
+    assert "convnext_atto" in list_models(maturity="validated", pretrained=True)
+    assert "repvit_m0_9" in list_models(maturity="preview", pretrained=False)
+    assert get_model_info("unet_rexnet13").pretrained
+
+    with pytest.raises(ValueError, match="unknown task"):
+        list_models(task="generation")
+    with pytest.raises(ValueError, match="unknown model"):
+        get_model_info("missing")
+
+
+@pytest.mark.parametrize(
+    ("name", "kwargs"),
+    [
+        ("repvit_m0_9", {"num_classes": 7}),
+        ("yolov1", {"num_classes": 7, "pretrained_backbone": False}),
+        ("unet", {"num_classes": 7}),
+    ],
+)
+def test_get_model(name, kwargs):
+    assert isinstance(get_model(name, **kwargs), nn.Module)
+
+
+def test_model_checkpoints():
+    checkpoint = list_checkpoints("convnext_atto")[0]
+    assert checkpoint.meta.arch == "convnext_atto"
+    assert list_checkpoints("repvit_m0_9") == ()
+
+    with pytest.raises(ValueError, match="does not match"):
+        get_model("resnet18", checkpoint=checkpoint)
+    with pytest.raises(TypeError, match="must be a Checkpoint"):
+        get_model("resnet18", checkpoint="imagenette")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -122,7 +122,7 @@ def test_model_from_hf_hub():
 def test_model_catalog():
     names = list_models()
     assert names == sorted(names)
-    assert len(names) == len(set(names)) == 59
+    assert len(names) == len(set(names)) == 62
     assert set(names) == set(list_models(task="classification")) | set(list_models(task="detection")) | set(
         list_models(task="segmentation")
     )
@@ -130,6 +130,7 @@ def test_model_catalog():
     assert list_models(maturity="validated") == []
     assert "convnext_atto" in list_models(maturity="preview", pretrained=True)
     assert "repvit_m0_9" in list_models(maturity="preview", pretrained=False)
+    assert "iformer_t" in list_models(task="classification", maturity="preview", pretrained=False)
     assert get_model_info("unet_rexnet13").pretrained
 
     with pytest.raises(ValueError, match="unknown task"):
@@ -142,6 +143,7 @@ def test_model_catalog():
     ("name", "kwargs"),
     [
         ("repvit_m0_9", {"num_classes": 7}),
+        ("iformer_t", {"num_classes": 7}),
         ("yolov1", {"num_classes": 7, "pretrained_backbone": False}),
         ("unet", {"num_classes": 7}),
     ],
@@ -155,6 +157,7 @@ def test_model_checkpoints():
     assert checkpoint.meta.arch == "convnext_atto"
     assert checkpoint.maturity is Maturity.PREVIEW
     assert list_checkpoints("repvit_m0_9") == ()
+    assert list_checkpoints("iformer_t") == ()
 
     with pytest.raises(ValueError, match="does not match"):
         get_model("resnet18", checkpoint=checkpoint)

--- a/tests/test_models_classification.py
+++ b/tests/test_models_classification.py
@@ -162,6 +162,54 @@ def test_classification_model(arch, pretrained):
         "repvit_m0_9",
     ],
 )
+def test_classification_feature_interface(arch):
+    model = classification.__dict__[arch](pretrained=False, num_classes=7).eval()
+    x = torch.rand((1, 3, 64, 64))
+
+    with torch.no_grad():
+        features = model.forward_features(x)
+        logits = model.forward_head(features)
+        embedding = model.forward_head(features, pre_logits=True)
+        torch.testing.assert_close(logits, model(x))
+
+    classifier = model.get_classifier()
+    embedding_size = classifier.in_features if isinstance(classifier, nn.Linear) else classifier.in_channels
+    assert embedding.shape == (x.shape[0], embedding_size)
+
+    device, dtype = classifier.weight.device, classifier.weight.dtype
+    model.reset_classifier(3)
+    replacement = model.get_classifier()
+    assert replacement is not classifier
+    assert replacement.weight.device == device
+    assert replacement.weight.dtype == dtype
+
+    x.requires_grad_()
+    output = model(x)
+    assert output.shape == (x.shape[0], 3)
+    output.sum().backward()
+    assert x.grad is not None
+    assert replacement.weight.grad is not None
+
+
+@pytest.mark.parametrize(
+    "arch",
+    [
+        "darknet24",
+        "darknet19",
+        "darknet53",
+        "cspdarknet53",
+        "resnet18",
+        "res2net50_26w_4s",
+        "tridentnet50",
+        "pyconv_resnet50",
+        "rexnet1_0x",
+        "sknet50",
+        "repvgg_a0",
+        "convnext_atto",
+        "mobileone_s0",
+        "repvit_m0_9",
+    ],
+)
 def test_classification_onnx_export(arch, tmpdir_factory):
     model = classification.__dict__[arch](pretrained=False, num_classes=10).eval()
     if hasattr(model, "reparametrize"):

--- a/tests/test_models_classification.py
+++ b/tests/test_models_classification.py
@@ -27,10 +27,18 @@ def _test_classification_model(name, num_classes, pretrained):
 
 
 def test_repvgg_reparametrize():
+    torch.manual_seed(0)
     num_classes = 10
     batch_size = 2
     x = torch.rand((batch_size, 3, 224, 224))
-    model = classification.repvgg_a0(pretrained=False, num_classes=num_classes).eval()
+    model = classification.repvgg_a0(pretrained=False, num_classes=num_classes)
+    # Use representative running statistics before fusing BatchNorm layers. With
+    # their untouched defaults, numerical error is amplified through the random,
+    # untrained network and makes this equivalence check seed-dependent.
+    with torch.no_grad():
+        for _ in range(4):
+            model(x)
+    model.eval()
     with torch.no_grad():
         out = model(x)
 
@@ -43,7 +51,7 @@ def test_repvgg_reparametrize():
             assert mod.weight.data.shape[2:] == (3, 3)
     # Check that values are still matching
     with torch.no_grad():
-        assert torch.allclose(out, model(x), rtol=1e-4)  # logit score, not prob
+        assert torch.allclose(out, model(x), rtol=1e-4, atol=1e-3)  # logit score, not prob
 
 
 def test_mobileone_reparametrize():

--- a/tests/test_models_classification.py
+++ b/tests/test_models_classification.py
@@ -6,6 +6,7 @@ from torch import nn
 
 from holocron.models import classification
 from holocron.models.classification.repvit import _RepVGGDW  # noqa: PLC2701
+from scripts.export_to_onnx import export_model
 
 
 def _test_classification_model(name, num_classes, pretrained):
@@ -99,6 +100,31 @@ def test_repvit_reparametrize(arch, training_params, deployment_params):
 
 
 @pytest.mark.parametrize(
+    ("arch", "num_params"),
+    [
+        ("iformer_t", 2_886_456),
+        ("iformer_s", 6_563_368),
+        ("iformer_m", 8_907_424),
+    ],
+)
+def test_iformer(arch, num_params):
+    model = classification.__dict__[arch](pretrained=False, num_classes=1000)
+    assert sum(param.numel() for param in model.parameters()) == num_params
+
+    x = torch.rand((2, 3, 64, 64), requires_grad=True)
+    output = model(x)
+    assert output.shape == (x.shape[0], 1000)
+    output.sum().backward()
+    assert x.grad is not None
+
+
+def test_iformer_dynamo_onnx_export(tmp_path):
+    model = classification.iformer_t(pretrained=False, num_classes=10).eval()
+    export_model(model, torch.rand((1, 3, 64, 64)), tmp_path / "iformer_t.onnx")
+    assert (tmp_path / "iformer_t.onnx").is_file()
+
+
+@pytest.mark.parametrize(
     ("arch", "pretrained"),
     [
         ("darknet24", True),
@@ -168,6 +194,7 @@ def test_classification_model(arch, pretrained):
         "convnext_atto",
         "mobileone_s0",
         "repvit_m0_9",
+        "iformer_t",
     ],
 )
 def test_classification_feature_interface(arch):

--- a/tests/test_models_detection.py
+++ b/tests/test_models_detection.py
@@ -1,9 +1,12 @@
+import math
 from pathlib import Path
 
 import pytest
 import torch
 
 from holocron.models import detection
+from holocron.models.detection.yolo import _post_process  # noqa: PLC2701
+from holocron.models.detection.yolov4 import YoloLayer, Yolov4Head
 
 
 def _test_detection_model(name, input_size):
@@ -233,3 +236,146 @@ def test_yolov2():
     assert torch.all(dets[0]["labels"] == 0)
     assert torch.all(dets[0]["scores"] == 0.25)
     assert torch.equal(dets[0]["boxes"][0], torch.tensor([0, 0, 1, 1], dtype=torch.float32))
+
+
+def _yolov4_layers(num_classes=4):
+    anchors = (
+        torch.tensor(
+            [
+                [[12, 16], [19, 36], [40, 28]],
+                [[36, 75], [76, 55], [72, 146]],
+                [[142, 110], [192, 243], [459, 401]],
+            ],
+            dtype=torch.float32,
+        )
+        / 608
+    )
+    all_anchors = anchors.reshape(-1, 2)
+    return [
+        YoloLayer(
+            anchors[idx],
+            num_classes=num_classes,
+            all_anchors=all_anchors,
+            anchor_mask=torch.arange(3 * idx, 3 * (idx + 1)),
+        )
+        for idx in range(3)
+    ]
+
+
+def test_yolov4_global_anchor_assignment():
+    layers = _yolov4_layers()
+    pred_boxes = torch.zeros((1, 4, 4, 3, 4))
+    b_o = torch.zeros((1, 4, 4, 3))
+    b_scores = torch.zeros((1, 4, 4, 3, 4))
+    boxes = torch.tensor([[0.0975, 0.0975, 0.1025, 0.1025], [0.45, 0.45, 0.55, 0.55]], dtype=torch.float32)
+    target = [{"boxes": boxes, "labels": torch.tensor([1, 3])}]
+    expected = [
+        {(0, 0, 0, 0), (0, 2, 2, 2)},
+        {(0, 2, 2, 0), (0, 2, 2, 1), (0, 2, 2, 2)},
+        {(0, 2, 2, 0)},
+    ]
+
+    for layer, expected_positions in zip(layers, expected, strict=True):
+        target_boxes, target_scores, obj_mask, noobj_mask = layer._build_targets(pred_boxes, b_o, b_scores, target)
+        positions = {tuple(pos) for pos in obj_mask.nonzero().tolist()}
+        assert positions == expected_positions
+        assert torch.all(~noobj_mask[obj_mask])
+        for position in positions:
+            expected_idx = 0 if position[1:3] == (0, 0) else 1
+            assert torch.equal(target_boxes[position], boxes[expected_idx])
+            assert target_scores[position].argmax().item() == target[0]["labels"][expected_idx]
+            assert target_scores[position].sum().item() == 1
+
+    assert set(layers[0].state_dict()) == {"anchors"}
+
+
+def test_yolov4_ignore_mask():
+    layer = _yolov4_layers()[0]
+    pred_boxes = torch.zeros((1, 2, 2, 3, 4))
+    box = torch.tensor([[0.45, 0.45, 0.55, 0.55]])
+    pred_boxes[0, 0, 0, 0] = box[0]
+    b_o = torch.zeros((1, 2, 2, 3))
+    b_scores = torch.zeros((1, 2, 2, 3, 4))
+
+    _, _, obj_mask, noobj_mask = layer._build_targets(
+        pred_boxes, b_o, b_scores, [{"boxes": box, "labels": torch.tensor([2])}]
+    )
+
+    assert not noobj_mask[0, 0, 0, 0]
+    assert noobj_mask[0, 0, 0, 1]
+    assert obj_mask[0, 1, 1, 2]
+    assert not noobj_mask[0, 1, 1, 2]
+
+
+def test_yolov4_empty_targets_and_objectness_gradients():
+    layer = YoloLayer(torch.tensor([[0.2, 0.2]]), num_classes=2).train()
+    empty_output = torch.zeros((1, 7, 2, 2), requires_grad=True)
+    losses = layer(empty_output, [{"boxes": torch.zeros((0, 4)), "labels": torch.zeros(0, dtype=torch.long)}])
+    total_loss = sum(losses.values())
+    assert torch.isfinite(total_loss)
+    total_loss.backward()
+    assert torch.isfinite(empty_output.grad).all()
+
+    output = torch.zeros((1, 7, 1, 1), requires_grad=True)
+    target = [{"boxes": torch.tensor([[0.4, 0.4, 0.6, 0.6]]), "labels": torch.tensor([1])}]
+    layer(output, target)["obj_loss"].backward()
+    assert torch.count_nonzero(output.grad[:, 4]) > 0
+    assert torch.count_nonzero(output.grad[:, :4]) == 0
+    assert torch.count_nonzero(output.grad[:, 5:]) == 0
+
+
+@pytest.mark.parametrize("wh_logit", [-1000.0, 1000.0])
+def test_yolov4_extreme_box_logits_are_finite(wh_logit):
+    layer = YoloLayer(torch.tensor([[0.1, 0.1]]), num_classes=2).train()
+    output = torch.zeros((1, 7, 1, 1))
+    output[:, 2:4] = wh_logit
+    output.requires_grad_()
+    target = [{"boxes": torch.tensor([[0.4, 0.4, 0.6, 0.6]]), "labels": torch.tensor([1])}]
+
+    total_loss = sum(layer(output, target).values())
+    assert torch.isfinite(total_loss)
+    total_loss.backward()
+    assert torch.isfinite(output.grad).all()
+
+
+@torch.inference_mode()
+def test_yolo_post_process_combined_confidence_and_class_aware_nms():
+    low_objectness = _post_process(
+        torch.tensor([[[0.0, 0.0, 1.0, 1.0]]]),
+        torch.tensor([[0.4]]),
+        torch.tensor([[[0.9, 0.1]]]),
+        box_score_thresh=0.3,
+    )
+    assert low_objectness[0]["scores"].item() == pytest.approx(0.36)
+
+    boxes = torch.tensor([[[0.0, 0.0, 1.0, 1.0]] * 3])
+    detections = _post_process(
+        boxes,
+        torch.tensor([[0.9, 0.8, 0.9]]),
+        torch.tensor([[[0.9, 0.1], [0.8, 0.2], [0.1, 0.9]]]),
+    )
+    assert detections[0]["boxes"].shape[0] == 2
+    assert set(detections[0]["labels"].tolist()) == {0, 1}
+
+
+@torch.inference_mode()
+def test_yolov4_cross_scale_nms():
+    head = Yolov4Head(num_classes=2).eval()
+    output_layers = [head.head1[-1], head.head2_2[-1], head.head3[-1]]
+    for output_layer in output_layers:
+        output_layer.weight.zero_()
+        output_layer.bias.fill_(-20)
+
+    for yolo_layer, output_layer in zip((head.yolo1, head.yolo2), output_layers[:2], strict=True):
+        output_layer.bias.reshape(3, 7)[0] = torch.tensor([
+            0,
+            0,
+            math.log(0.1 / yolo_layer.anchors[0, 0].item()),
+            math.log(0.1 / yolo_layer.anchors[0, 1].item()),
+            10,
+            10,
+            -10,
+        ])
+
+    detections = head([torch.zeros((1, 128, 1, 1)), torch.zeros((1, 256, 1, 1)), torch.zeros((1, 512, 1, 1))])
+    assert detections[0]["boxes"].shape[0] == 1

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -57,7 +57,7 @@ def test_box_giou(boxes):
 
 def test_aspect_ratio(boxes):
     # All boxes are squares so arctan should yield Pi / 4
-    assert torch.equal(ops.boxes.aspect_ratio(boxes), math.pi / 4 * torch.ones(boxes.shape[0]))
+    assert torch.allclose(ops.boxes.aspect_ratio(boxes), math.pi / 4 * torch.ones(boxes.shape[0]))
 
 
 def test_aspect_ratio_consistency(boxes):
@@ -74,3 +74,18 @@ def test_ciou_loss(boxes):
     for idx in range(boxes.shape[0]):
         assert ciou[idx, idx].item() == 0.0
     assert ciou[0, 2].item() == ciou[2, 3].item()
+
+
+def test_ciou_loss_aspect_ratio_term():
+    boxes1 = torch.tensor([[-1, -0.5, 1, 0.5]], dtype=torch.float32, requires_grad=True)
+    boxes2 = torch.tensor([[-0.5, -1, 0.5, 1]], dtype=torch.float32)
+
+    iou = 1 / 3
+    v = 4 / math.pi**2 * (math.atan(2) - math.atan(0.5)) ** 2
+    expected = 1 - iou + v**2 / (1 - iou + v)
+    loss = ops.boxes.ciou_loss(boxes1, boxes2)
+
+    assert loss.item() == pytest.approx(expected)
+    assert loss.item() > ops.boxes.diou_loss(boxes1, boxes2).item()
+    loss.backward()
+    assert torch.isfinite(boxes1.grad).all()

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -45,16 +45,26 @@ def test_reference_parser_defaults(task: str, expected_arch: str, expected_size:
 
     assert args.arch == expected_arch
     assert args.seed == 0
+    assert args.run_dir is None
     if expected_size is not None:
         assert args.img_size == expected_size
 
 
 @pytest.mark.parametrize("task", ["detection", "segmentation"])
 def test_reference_parser_reproducibility_options(task: str):
-    args = _get_parser(task).parse_args([DATA_PATHS[task], "--seed", "7", "--img-size", "128"])
+    args = _get_parser(task).parse_args([
+        DATA_PATHS[task],
+        "--seed",
+        "7",
+        "--img-size",
+        "128",
+        "--run-dir",
+        "runs/test",
+    ])
 
     assert args.seed == 7
     assert args.img_size == 128
+    assert args.run_dir == "runs/test"
 
 
 @pytest.mark.parametrize("task", DATA_PATHS)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,69 @@
+import importlib.util
+import re
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+REFERENCE_ROOT = Path(__file__).parents[1] / "references"
+DATA_PATHS = {
+    "classification": "imagenette2-320/",
+    "detection": "VOC2012",
+    "segmentation": "VOC2012",
+}
+
+
+def _get_parser(task: str):
+    script = REFERENCE_ROOT / task / "train.py"
+    spec = importlib.util.spec_from_file_location(f"holocron_reference_{task}", script)
+    assert spec is not None
+    assert spec.loader is not None
+
+    sys.path.insert(0, str(script.parent))
+    try:
+        sys.modules.pop("transforms", None)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+        sys.modules.pop("transforms", None)
+
+    return module.get_parser()
+
+
+@pytest.mark.parametrize(
+    ("task", "expected_arch", "expected_size"),
+    [
+        ("classification", "darknet19", None),
+        ("detection", "yolov2", 416),
+        ("segmentation", "unet3p", 256),
+    ],
+)
+def test_reference_parser_defaults(task: str, expected_arch: str, expected_size: int | None):
+    args = _get_parser(task).parse_args([DATA_PATHS[task]])
+
+    assert args.arch == expected_arch
+    assert args.seed == 0
+    if expected_size is not None:
+        assert args.img_size == expected_size
+
+
+@pytest.mark.parametrize("task", ["detection", "segmentation"])
+def test_reference_parser_reproducibility_options(task: str):
+    args = _get_parser(task).parse_args([DATA_PATHS[task], "--seed", "7", "--img-size", "128"])
+
+    assert args.seed == 7
+    assert args.img_size == 128
+
+
+@pytest.mark.parametrize("task", DATA_PATHS)
+def test_documented_reference_commands_parse(task: str):
+    readme = (REFERENCE_ROOT / task / "README.md").read_text()
+    data_path = DATA_PATHS[task]
+    commands = re.findall(rf"(?:python train\.py )?({re.escape(data_path)} --arch [^|`\n]+)", readme)
+
+    assert commands
+    parser = _get_parser(task)
+    for command in commands:
+        parser.parse_args(shlex.split(command))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,90 @@
+from collections import OrderedDict
+
+import pytest
+import torch
+
+from scripts import eval_latency, export_to_onnx
+
+
+@pytest.mark.parametrize("bundle", [False, True])
+def test_load_model_checkpoint(monkeypatch, tmp_path, bundle):
+    reference = torch.nn.Linear(2, 1)
+    state_dict = OrderedDict((name, value.clone()) for name, value in reference.state_dict().items())
+    checkpoint = {"model": state_dict, "epoch": 3} if bundle else state_dict
+    checkpoint_path = tmp_path / "checkpoint.pt"
+    torch.save(checkpoint, checkpoint_path)
+
+    def tiny_factory(*, pretrained):
+        assert pretrained is False
+        return torch.nn.Linear(2, 1)
+
+    monkeypatch.setattr(export_to_onnx.models, "tiny", tiny_factory, raising=False)
+    restored = export_to_onnx.load_model("tiny", checkpoint=checkpoint_path)
+
+    for name, value in restored.state_dict().items():
+        torch.testing.assert_close(value, state_dict[name])
+
+
+def test_export_model_uses_dynamo_and_dynamic_batch(monkeypatch, tmp_path):
+    exported = object()
+    call = {}
+
+    def fake_export(*args, **kwargs):
+        call["args"] = args
+        call["kwargs"] = kwargs
+        return exported
+
+    monkeypatch.setattr(torch.onnx, "export", fake_export)
+    output = export_to_onnx.export_model(
+        torch.nn.Identity(),
+        torch.rand(1, 3, 4, 4),
+        tmp_path / "model.onnx",
+        verify=True,
+        report=True,
+    )
+
+    assert output is exported
+    assert call["kwargs"]["dynamo"] is True
+    assert call["kwargs"]["verify"] is True
+    assert call["kwargs"]["report"] is True
+    assert call["kwargs"]["dynamic_shapes"][0][0].__name__ == "batch"
+
+
+def test_run_evaluation_synchronizes_cuda(monkeypatch):
+    class Measurement:
+        mean = 0.002
+        median = 0.0015
+        iqr = 0.0005
+        raw_times = (0.01, 0.02)
+        number_per_run = 10
+
+    class Timer:
+        def __init__(self, **kwargs):
+            self.num_threads = kwargs["num_threads"]
+
+        def blocked_autorange(self, *, min_run_time):
+            assert self.num_threads == 2
+            assert min_run_time == 0.1
+            return Measurement()
+
+    calls = []
+    monkeypatch.setattr(eval_latency.benchmark, "Timer", Timer)
+    monkeypatch.setattr(torch.cuda, "synchronize", calls.append)
+
+    result = eval_latency.run_evaluation(
+        lambda: None,
+        device=torch.device("cuda:0"),
+        min_run_time=0.1,
+        warmup_it=2,
+        num_threads=2,
+    )
+
+    assert calls == [torch.device("cuda:0")]
+    assert result == {
+        "mean_ms": 2.0,
+        "median_ms": 1.5,
+        "iqr_ms": 0.5,
+        "measurements": 2,
+        "runs_per_measurement": 10,
+        "threads": 2,
+    }

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -14,11 +14,12 @@ def test_load_model_checkpoint(monkeypatch, tmp_path, bundle):
     checkpoint_path = tmp_path / "checkpoint.pt"
     torch.save(checkpoint, checkpoint_path)
 
-    def tiny_factory(*, pretrained):
+    def fake_get_model(arch, *, pretrained):
+        assert arch == "tiny"
         assert pretrained is False
         return torch.nn.Linear(2, 1)
 
-    monkeypatch.setattr(export_to_onnx.models, "tiny", tiny_factory, raising=False)
+    monkeypatch.setattr(export_to_onnx.models, "get_model", fake_get_model)
     restored = export_to_onnx.load_model("tiny", checkpoint=checkpoint_path)
 
     for name, value in restored.state_dict().items():

--- a/tests/test_train_characters.py
+++ b/tests/test_train_characters.py
@@ -90,6 +90,20 @@ def test_family_is_sampled_before_style():
         assert 0.25 < counts["Sans", style] / sans_count < 0.42
 
 
+def test_validation_holds_out_whole_font_families():
+    records = [
+        characters.FontRecord(SANS, "ignored"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSans-Bold.ttf", "ignored"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSerif.ttf", "ignored"),
+    ]
+    train, validation = characters.split_font_families("AB", records, 32, 0.2, 3)
+
+    assert {record.family for record in train}.isdisjoint({record.family for record in validation})
+    assert (train, validation) == characters.split_font_families("AB", records, 32, 0.2, 3)
+    with pytest.raises(ValueError, match="at least 2 font families"):
+        characters.split_font_families("AB", records[:2], 32, 0.2, 3)
+
+
 @pytest.mark.parametrize(
     ("alphabet", "message"),
     [
@@ -154,19 +168,20 @@ def test_dataloader_smoke(workers):
     gc.collect()
 
 
-def _write_manifest(path, filename, checksum):
+def _write_manifest(path, *fonts):
     path.write_text(
         json.dumps({
             "version": 1,
             "sources": {"test": {"revision": "abc123"}},
             "fonts": [
                 {
-                    "family": "DejaVu Sans",
+                    "family": family,
                     "style": "Regular",
                     "source": "test",
                     "filename": filename,
                     "sha256": checksum,
                 }
+                for family, filename, checksum in fonts
             ],
         }),
         encoding="utf-8",
@@ -177,9 +192,15 @@ def test_cli_grid_training_resume_and_provenance(monkeypatch, tmp_path):
     font_dir = tmp_path / "fonts"
     font_dir.mkdir()
     font_path = font_dir / "Test.ttf"
+    validation_font_path = font_dir / "Validation.ttf"
     shutil.copy2(SANS, font_path)
+    shutil.copy2(FONT_ROOT / "DejaVuSerif.ttf", validation_font_path)
     manifest = tmp_path / "fonts.json"
-    _write_manifest(manifest, font_path.name, characters._sha256(font_path))
+    _write_manifest(
+        manifest,
+        ("DejaVu Sans", font_path.name, characters._sha256(font_path)),
+        ("DejaVu Serif", validation_font_path.name, characters._sha256(validation_font_path)),
+    )
 
     common = [
         "--font-dir",
@@ -211,31 +232,48 @@ def test_cli_grid_training_resume_and_provenance(monkeypatch, tmp_path):
     characters.main(characters.get_parser().parse_args([*common, "--show-samples", str(grid_path)]))
     assert grid_path.is_file()
 
-    def tiny_classifier(pretrained=False, *, num_classes=1, **_kwargs):
-        assert not pretrained
+    model_calls = []
+
+    def tiny_classifier(name, *, num_classes=1, **_kwargs):
+        model_calls.append(name)
         return nn.Sequential(nn.Flatten(), nn.Linear(3 * 16 * 16, num_classes))
 
-    monkeypatch.setattr(characters.classification, "convnext_atto", tiny_classifier)
+    monkeypatch.setattr(characters, "get_model", tiny_classifier)
     output_dir = tmp_path / "output"
     training_args = [*common, "--output-dir", str(output_dir)]
     characters.main(characters.get_parser().parse_args(training_args))
 
     checkpoint = output_dir / "checkpoint.pth"
-    metadata_path = output_dir / "checkpoint.json"
     assert checkpoint.is_file()
-    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    manifest_path = output_dir / "manifest.json"
+    assert manifest_path.is_file()
+    bundle = json.loads(manifest_path.read_text(encoding="utf-8"))
+    metadata = bundle["run"]["config"]["recipe"]
+    assert bundle["schema_version"] == 1
+    assert {artifact["path"] for artifact in bundle["artifacts"]} == {
+        "metrics.jsonl",
+        "checkpoints/checkpoint.pth",
+        "artifacts/fonts.json",
+    }
     assert metadata["class_to_index"] == {"A": 0, "B": 1}
     assert metadata["architecture"] == "convnext_atto"
-    assert metadata["fonts"][0]["path"] == "Test.ttf"
+    assert metadata["maturity"] == "experimental"
+    assert {font["path"] for font in metadata["fonts"]} == {"Test.ttf", "Validation.ttf"}
     assert metadata["manifest"]["source_revisions"] == {"test": "abc123"}
-    metadata_before_resume = metadata_path.read_text(encoding="utf-8")
-    monkeypatch.setattr(
-        characters.ClassificationTrainer,
-        "evaluate",
-        lambda _self: {"val_loss": float("inf"), "acc1": 0.0, "acc5": 0.0},
-    )
-    characters.main(characters.get_parser().parse_args([*training_args, "--resume", str(checkpoint)]))
-    assert metadata_path.read_text(encoding="utf-8") == metadata_before_resume
+    assert set(metadata["font_split"]["training_families"]).isdisjoint(metadata["font_split"]["validation_families"])
+    assert model_calls == ["convnext_atto"]
+
+    loaded_versions = []
+    original_load = characters.ClassificationTrainer.load
+
+    def track_load(self, state):
+        loaded_versions.append(state["schema_version"])
+        return original_load(self, state)
+
+    monkeypatch.setattr(characters.ClassificationTrainer, "load", track_load)
+    monkeypatch.setattr(characters.ClassificationTrainer, "check_setup", lambda *_args, **_kwargs: None)
+    characters.main(characters.get_parser().parse_args([*training_args, "--resume", str(checkpoint), "--check-setup"]))
+    assert loaded_versions == [2]
 
 
 def test_manifest_checksum_is_verified(tmp_path):
@@ -244,7 +282,7 @@ def test_manifest_checksum_is_verified(tmp_path):
     font_path = font_dir / "Test.ttf"
     shutil.copy2(SANS, font_path)
     manifest = tmp_path / "fonts.json"
-    _write_manifest(manifest, font_path.name, "0" * 64)
+    _write_manifest(manifest, ("DejaVu Sans", font_path.name, "0" * 64))
     with pytest.raises(ValueError, match="checksum mismatch"):
         characters.resolve_font_records("A", font_dir, manifest)
 
@@ -260,11 +298,10 @@ def test_unmanifested_font_hashes_are_deferred(monkeypatch, tmp_path):
     assert hashes == []
     dataset = characters.SyntheticCharacterDataset("A", records, 32, 1, T.PILToTensor())
     args = characters.get_parser().parse_args(["--font-dir", str(font_dir)])
-    metadata = tmp_path / "checkpoint.json"
-    characters.write_provenance(metadata, args, dataset, dataset.fonts, None)
+    metadata = characters.recipe_metadata(args, dataset, dataset, dataset.fonts, None)
 
     assert hashes == [font_dir / "Test.ttf"]
-    assert json.loads(metadata.read_text(encoding="utf-8"))["fonts"][0]["sha256"] == "hash"
+    assert metadata["fonts"][0]["sha256"] == "hash"
 
 
 def test_fixed_batch_can_lower_loss(monkeypatch, tmp_path):

--- a/tests/test_train_characters.py
+++ b/tests/test_train_characters.py
@@ -77,6 +77,7 @@ def test_family_is_sampled_before_style():
     assert len(expected) == len(records)
 
     dataset = characters.SyntheticCharacterDataset("A", records, 32, 1, to_tensor)
+    assert {record.family for record in dataset.fonts} == {"DejaVu Sans", "DejaVu Serif"}
     torch.manual_seed(0)
     counts = Counter()
     for _ in range(1_000):
@@ -227,8 +228,6 @@ def test_cli_grid_training_resume_and_provenance(monkeypatch, tmp_path):
     assert metadata["architecture"] == "convnext_atto"
     assert metadata["fonts"][0]["path"] == "Test.ttf"
     assert metadata["manifest"]["source_revisions"] == {"test": "abc123"}
-    assert metadata["base_mask_cache"] is False
-
     metadata_before_resume = metadata_path.read_text(encoding="utf-8")
     monkeypatch.setattr(
         characters.ClassificationTrainer,
@@ -248,6 +247,24 @@ def test_manifest_checksum_is_verified(tmp_path):
     _write_manifest(manifest, font_path.name, "0" * 64)
     with pytest.raises(ValueError, match="checksum mismatch"):
         characters.resolve_font_records("A", font_dir, manifest)
+
+
+def test_unmanifested_font_hashes_are_deferred(monkeypatch, tmp_path):
+    font_dir = tmp_path / "fonts"
+    font_dir.mkdir()
+    shutil.copy2(SANS, font_dir / "Test.ttf")
+    hashes = []
+    monkeypatch.setattr(characters, "_sha256", lambda path: hashes.append(path) or "hash")
+
+    records, _ = characters.resolve_font_records("A", font_dir, None)
+    assert hashes == []
+    dataset = characters.SyntheticCharacterDataset("A", records, 32, 1, T.PILToTensor())
+    args = characters.get_parser().parse_args(["--font-dir", str(font_dir)])
+    metadata = tmp_path / "checkpoint.json"
+    characters.write_provenance(metadata, args, dataset, dataset.fonts, None)
+
+    assert hashes == [font_dir / "Test.ttf"]
+    assert json.loads(metadata.read_text(encoding="utf-8"))["fonts"][0]["sha256"] == "hash"
 
 
 def test_fixed_batch_can_lower_loss(monkeypatch, tmp_path):

--- a/tests/test_train_characters.py
+++ b/tests/test_train_characters.py
@@ -1,0 +1,285 @@
+import gc
+import json
+import shutil
+from collections import Counter
+from pathlib import Path
+
+import matplotlib as mpl
+import pytest
+import torch
+from PIL import ImageFont
+from torch import nn
+from torch.utils.data import SequentialSampler
+from torchvision.transforms import v2 as T
+
+from references.classification import train_characters as characters
+
+FONT_ROOT = Path(mpl.get_data_path()) / "fonts" / "ttf"
+SANS = FONT_ROOT / "DejaVuSans.ttf"
+
+
+def _transform_args(*args):
+    return characters.get_parser().parse_args([
+        "--image-size",
+        "24",
+        "--render-size",
+        "32",
+        "--margin",
+        "2",
+        *args,
+    ])
+
+
+def test_dataset_balance_outputs_and_reproducibility():
+    train_transform, val_transform = characters.build_transforms(
+        _transform_args("--rotation", "20", "--translate", "0.2", "--scale-jitter", "0.2")
+    )
+    record = characters.FontRecord(SANS, "DejaVu Sans")
+    dataset = characters.SyntheticCharacterDataset("ABC", [record], 32, 7, train_transform)
+
+    assert dataset.classes == ("A", "B", "C")
+    assert dataset.class_to_idx == {"A": 0, "B": 1, "C": 2}
+    assert Counter(dataset[index][1] for index in range(len(dataset))) == {0: 3, 1: 2, 2: 2}
+    image, target = dataset[1]
+    assert image.shape == (3, 24, 24)
+    assert image.dtype == torch.float32
+    assert target == 1
+
+    torch.manual_seed(3)
+    first = dataset[0][0]
+    torch.manual_seed(3)
+    repeated = dataset[0][0]
+    torch.manual_seed(4)
+    different = dataset[0][0]
+    assert torch.equal(first, repeated)
+    assert not torch.equal(first, different)
+
+    validation = characters.SyntheticCharacterDataset("ABC", [record], 32, 6, val_transform, deterministic=True)
+    first_pass = [validation[index] for index in range(len(validation))]
+    second_pass = [validation[index] for index in range(len(validation))]
+    assert [target for _, target in first_pass] == [0, 1, 2, 0, 1, 2]
+    assert all(torch.equal(first[0], second[0]) for first, second in zip(first_pass, second_pass, strict=True))
+
+
+def test_family_is_sampled_before_style():
+    records = [
+        characters.FontRecord(FONT_ROOT / "DejaVuSans.ttf", "Sans", "Regular"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSans-Bold.ttf", "Sans", "Bold"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSans-Oblique.ttf", "Sans", "Oblique"),
+        characters.FontRecord(FONT_ROOT / "DejaVuSerif.ttf", "Serif", "Regular"),
+    ]
+    to_tensor = T.PILToTensor()
+    expected = {}
+    for record in records:
+        font = ImageFont.truetype(str(record.path), 32)
+        image = to_tensor(characters.render_text("A", font))
+        expected[tuple(image.shape), image.numpy().tobytes()] = (record.family, record.style)
+    assert len(expected) == len(records)
+
+    dataset = characters.SyntheticCharacterDataset("A", records, 32, 1, to_tensor)
+    torch.manual_seed(0)
+    counts = Counter()
+    for _ in range(1_000):
+        image, _ = dataset[0]
+        counts[expected[tuple(image.shape), image.numpy().tobytes()]] += 1
+
+    sans_count = sum(count for (family, _), count in counts.items() if family == "Sans")
+    assert 430 < sans_count < 570
+    for style in ("Regular", "Bold", "Oblique"):
+        assert 0.25 < counts["Sans", style] / sans_count < 0.42
+
+
+@pytest.mark.parametrize(
+    ("alphabet", "message"),
+    [
+        ("", "must not be empty"),
+        ("AA", "duplicate"),
+        (" ", "visible"),
+        ("你", "no visible font supports"),
+    ],
+)
+def test_dataset_rejects_invalid_alphabets(alphabet, message):
+    with pytest.raises(ValueError, match=message):
+        characters.SyntheticCharacterDataset(alphabet, [SANS], 32, 1, T.PILToTensor())
+
+
+def test_dataset_rejects_invalid_fonts(tmp_path):
+    missing = tmp_path / "missing.ttf"
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        characters.SyntheticCharacterDataset("A", [missing], 32, 1, T.PILToTensor())
+
+    corrupt = tmp_path / "corrupt.ttf"
+    corrupt.write_text("not a font", encoding="utf-8")
+    with pytest.raises(ValueError, match="unable to load"):
+        characters.SyntheticCharacterDataset("A", [corrupt], 32, 1, T.PILToTensor())
+
+
+def test_font_objects_are_reused(monkeypatch):
+    dataset = characters.SyntheticCharacterDataset("A", [SANS], 32, 2, T.PILToTensor())
+    original = characters.ImageFont.truetype
+    calls = 0
+
+    def counted_truetype(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(characters.ImageFont, "truetype", counted_truetype)
+    dataset[0]
+    dataset[1]
+    assert calls == 1
+    state = dataset.__getstate__()
+    assert state["_font_cache"] == {}
+    assert state["_font_cache_pid"] is None
+
+
+@pytest.mark.parametrize("workers", [0, 1])
+def test_dataloader_smoke(workers):
+    _, val_transform = characters.build_transforms(_transform_args())
+    dataset = characters.SyntheticCharacterDataset("AB", [SANS], 32, 4, val_transform, deterministic=True)
+    dataset[0]
+    loader = characters.build_loader(
+        dataset,
+        2,
+        workers,
+        SequentialSampler(dataset),
+        0,
+        pin_memory=False,
+    )
+    images, targets = next(iter(loader))
+    assert images.shape == (2, 3, 24, 24)
+    assert targets.tolist() == [0, 1]
+    del loader
+    gc.collect()
+
+
+def _write_manifest(path, filename, checksum):
+    path.write_text(
+        json.dumps({
+            "version": 1,
+            "sources": {"test": {"revision": "abc123"}},
+            "fonts": [
+                {
+                    "family": "DejaVu Sans",
+                    "style": "Regular",
+                    "source": "test",
+                    "filename": filename,
+                    "sha256": checksum,
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_cli_grid_training_resume_and_provenance(monkeypatch, tmp_path):
+    font_dir = tmp_path / "fonts"
+    font_dir.mkdir()
+    font_path = font_dir / "Test.ttf"
+    shutil.copy2(SANS, font_path)
+    manifest = tmp_path / "fonts.json"
+    _write_manifest(manifest, font_path.name, characters._sha256(font_path))
+
+    common = [
+        "--font-dir",
+        str(font_dir),
+        "--manifest",
+        str(manifest),
+        "--alphabet",
+        "AB",
+        "--arch",
+        "convnext_atto",
+        "--image-size",
+        "16",
+        "--render-size",
+        "32",
+        "--samples-per-epoch",
+        "4",
+        "--validation-fonts-per-class",
+        "1",
+        "--batch-size",
+        "2",
+        "--workers",
+        "0",
+        "--epochs",
+        "1",
+        "--device",
+        "cpu",
+    ]
+    grid_path = tmp_path / "grid.png"
+    characters.main(characters.get_parser().parse_args([*common, "--show-samples", str(grid_path)]))
+    assert grid_path.is_file()
+
+    def tiny_classifier(pretrained=False, *, num_classes=1, **_kwargs):
+        assert not pretrained
+        return nn.Sequential(nn.Flatten(), nn.Linear(3 * 16 * 16, num_classes))
+
+    monkeypatch.setattr(characters.classification, "convnext_atto", tiny_classifier)
+    output_dir = tmp_path / "output"
+    training_args = [*common, "--output-dir", str(output_dir)]
+    characters.main(characters.get_parser().parse_args(training_args))
+
+    checkpoint = output_dir / "checkpoint.pth"
+    metadata_path = output_dir / "checkpoint.json"
+    assert checkpoint.is_file()
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["class_to_index"] == {"A": 0, "B": 1}
+    assert metadata["architecture"] == "convnext_atto"
+    assert metadata["fonts"][0]["path"] == "Test.ttf"
+    assert metadata["manifest"]["source_revisions"] == {"test": "abc123"}
+    assert metadata["base_mask_cache"] is False
+
+    metadata_before_resume = metadata_path.read_text(encoding="utf-8")
+    monkeypatch.setattr(
+        characters.ClassificationTrainer,
+        "evaluate",
+        lambda _self: {"val_loss": float("inf"), "acc1": 0.0, "acc5": 0.0},
+    )
+    characters.main(characters.get_parser().parse_args([*training_args, "--resume", str(checkpoint)]))
+    assert metadata_path.read_text(encoding="utf-8") == metadata_before_resume
+
+
+def test_manifest_checksum_is_verified(tmp_path):
+    font_dir = tmp_path / "fonts"
+    font_dir.mkdir()
+    font_path = font_dir / "Test.ttf"
+    shutil.copy2(SANS, font_path)
+    manifest = tmp_path / "fonts.json"
+    _write_manifest(manifest, font_path.name, "0" * 64)
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        characters.resolve_font_records("A", font_dir, manifest)
+
+
+def test_fixed_batch_can_lower_loss(monkeypatch, tmp_path):
+    torch.manual_seed(0)
+    transform = T.Compose([
+        T.Resize((8, 8), antialias=True),
+        T.Grayscale(num_output_channels=3),
+        T.ToImage(),
+        T.ToDtype(torch.float32, scale=True),
+    ])
+    dataset = characters.SyntheticCharacterDataset("AB", [SANS], 32, 2, transform, deterministic=True)
+    loader = characters.build_loader(
+        dataset,
+        2,
+        0,
+        SequentialSampler(dataset),
+        0,
+        pin_memory=False,
+    )
+    model = nn.Sequential(nn.Flatten(), nn.Linear(3 * 8 * 8, 2))
+    criterion = nn.CrossEntropyLoss()
+    trainer = characters.ClassificationTrainer(
+        model,
+        loader,
+        loader,
+        criterion,
+        torch.optim.SGD(model.parameters(), lr=0.2),
+        output_file=str(tmp_path / "checkpoint.pth"),
+    )
+    images, targets = next(iter(loader))
+    initial_loss = criterion(model(images), targets).item()
+    monkeypatch.setattr(characters.plt, "show", lambda **_kwargs: None)
+    trainer.check_setup(lr=0.2, num_it=30)
+    final_loss = criterion(model(images), targets).item()
+    assert final_loss < initial_loss

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -9,6 +9,7 @@ from torchvision.models import get_model, get_model_weights
 
 from holocron import trainer
 from holocron.nn import GlobalAvgPool2d
+from holocron.trainer.detection import assign_iou
 
 
 class MockClassificationDataset(Dataset):
@@ -73,6 +74,32 @@ class MockDetDataset(Dataset):
 
     def __len__(self):
         return self.n
+
+
+@pytest.mark.parametrize(
+    "device",
+    ["cpu", pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable"))],
+)
+def test_assign_iou_device(device):
+    gt_boxes = torch.tensor([[0, 0, 1, 1], [2, 2, 3, 3]], dtype=torch.float32, device=device)
+    pred_boxes = gt_boxes.clone()
+
+    gt_indices, pred_indices = assign_iou(gt_boxes, pred_boxes)
+
+    assert gt_indices.device == gt_boxes.device
+    assert pred_indices.device == gt_boxes.device
+    torch.testing.assert_close(gt_indices, torch.tensor([0, 1], device=device))
+    torch.testing.assert_close(pred_indices, torch.tensor([0, 1], device=device))
+
+
+def test_assign_iou_duplicate_predictions():
+    gt_boxes = torch.tensor([[0, 0, 0.8, 0.8], [2, 2, 3, 3], [0, 0, 1, 1]], dtype=torch.float32)
+    pred_boxes = torch.tensor([[0, 0, 1, 1], [2, 2, 3, 3]], dtype=torch.float32)
+
+    gt_indices, pred_indices = assign_iou(gt_boxes, pred_boxes)
+
+    torch.testing.assert_close(gt_indices, torch.tensor([2, 1]))
+    torch.testing.assert_close(pred_indices, torch.tensor([0, 1]))
 
 
 def collate_fn(batch):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,3 +1,4 @@
+import builtins
 import math
 import warnings
 
@@ -9,7 +10,7 @@ from torchvision.models import get_model, get_model_weights
 
 from holocron import trainer
 from holocron.nn import GlobalAvgPool2d
-from holocron.trainer.detection import assign_iou
+from holocron.trainer.detection import assign_iou, detection_average_precision
 
 
 class MockClassificationDataset(Dataset):
@@ -100,6 +101,101 @@ def test_assign_iou_duplicate_predictions():
 
     torch.testing.assert_close(gt_indices, torch.tensor([2, 1]))
     torch.testing.assert_close(pred_indices, torch.tensor([0, 1]))
+
+
+def test_detection_average_precision_perfect_multi_image(capsys):
+    pytest.importorskip("pycocotools")
+    targets = [
+        {"boxes": torch.tensor([[0.1, 0.1, 0.4, 0.4], [0.5, 0.5, 0.9, 0.9]]), "labels": torch.tensor([0, 2])},
+        {"boxes": torch.tensor([[0.2, 0.3, 0.7, 0.8]]), "labels": torch.tensor([2])},
+    ]
+    predictions = [{**target, "scores": torch.ones(target["boxes"].shape[0])} for target in targets]
+
+    metrics = detection_average_precision(predictions, targets)
+
+    assert metrics["ap50"] == pytest.approx(1)
+    assert metrics["ap50_95"] == pytest.approx(1)
+    assert not capsys.readouterr().out
+
+
+def test_detection_average_precision_miss():
+    pytest.importorskip("pycocotools")
+    targets = [{"boxes": torch.tensor([[0.0, 0.0, 0.2, 0.2]]), "labels": torch.tensor([1])}]
+    predictions = [
+        {"boxes": torch.tensor([[0.8, 0.8, 1.0, 1.0]]), "labels": torch.tensor([1]), "scores": torch.ones(1)}
+    ]
+
+    metrics = detection_average_precision(predictions, targets)
+
+    assert metrics == {"ap50": 0.0, "ap50_95": 0.0}
+
+
+@pytest.mark.parametrize(
+    ("predictions", "targets", "expected"),
+    [
+        (
+            [{"boxes": torch.zeros((0, 4)), "labels": torch.zeros(0, dtype=torch.long), "scores": torch.zeros(0)}],
+            [{"boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]]), "labels": torch.tensor([0])}],
+            {"ap50": 0.0, "ap50_95": 0.0},
+        ),
+        (
+            [{"boxes": torch.zeros((0, 4)), "labels": torch.zeros(0, dtype=torch.long), "scores": torch.zeros(0)}],
+            [{"boxes": torch.zeros((0, 4)), "labels": torch.zeros(0, dtype=torch.long)}],
+            {"ap50": None, "ap50_95": None},
+        ),
+        (
+            [{"boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]]), "labels": torch.tensor([0]), "scores": torch.ones(1)}],
+            [{"boxes": torch.zeros((0, 4)), "labels": torch.zeros(0, dtype=torch.long)}],
+            {"ap50": None, "ap50_95": None},
+        ),
+    ],
+)
+def test_detection_average_precision_empty(predictions, targets, expected):
+    assert detection_average_precision(predictions, targets) == expected
+
+
+def test_detection_average_precision_requires_extra(monkeypatch):
+    import_ = builtins.__import__
+
+    def import_without_pycocotools(name, *args, **kwargs):
+        if name.startswith("pycocotools"):
+            raise ImportError
+        return import_(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_pycocotools)
+    targets = [{"boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]]), "labels": torch.tensor([0])}]
+    predictions = [{**targets[0], "scores": torch.ones(1)}]
+
+    with pytest.raises(ImportError, match=r"pylocron\[evaluation\]"):
+        detection_average_precision(predictions, targets)
+
+
+def test_detection_trainer_average_precision():
+    pytest.importorskip("pycocotools")
+
+    class PerfectDetector(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(1))
+
+        def forward(self, x):
+            score = torch.sigmoid(self.weight)
+            return [
+                {"boxes": torch.tensor([[0.1, 0.2, 0.8, 0.9]]), "labels": torch.tensor([1]), "scores": score} for _ in x
+            ]
+
+    dataset = [(torch.zeros((3, 4, 4)), {"boxes": torch.tensor([[0.1, 0.2, 0.8, 0.9]]), "labels": torch.tensor([1])})]
+    loader = DataLoader(dataset, collate_fn=collate_fn)
+    model = PerfectDetector()
+    learner = trainer.DetectionTrainer(model, loader, loader, None, torch.optim.SGD(model.parameters(), lr=0.1))
+
+    metrics = learner.evaluate()
+
+    assert metrics["ap50"] == pytest.approx(1)
+    assert metrics["ap50_95"] == pytest.approx(1)
+    assert metrics["loc_err"] == 0
+    assert metrics["clf_err"] == 0
+    assert metrics["det_err"] == 0
 
 
 def collate_fn(batch):
@@ -444,7 +540,11 @@ def test_segmentation_trainer(tmpdir_factory):
     _test_trainer(learner, num_it, "2.weight", None)
 
 
-def test_detection_trainer(tmpdir_factory):
+def test_detection_trainer(tmpdir_factory, monkeypatch):
+    monkeypatch.setattr(
+        "holocron.trainer.detection.detection_average_precision",
+        lambda *_: {"ap50": 1.0, "ap50_95": 1.0},
+    )
     folder = tmpdir_factory.mktemp("checkpoints")
     file_path = str(folder.join("tmp.pt"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -308,23 +308,12 @@ wheels = [
 ]
 
 [[package]]
-name = "coloredlogs"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "humanfriendly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
-]
-
-[[package]]
 name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -560,6 +549,83 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/86/fd7f58fc498b3166f3a7e8e0cddb6e620fe1da35b02248b1bd59e95dbaaa/cssselect2-0.8.0.tar.gz", hash = "sha256:7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a", size = 35716, upload-time = "2025-03-05T14:46:07.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/e7/aa315e6a749d9b96c2504a1ba0ba031ba2d0517e972ce22682e3fccecb09/cssselect2-0.8.0-py3-none-any.whl", hash = "sha256:46fc70ebc41ced7a32cd42d58b1884d72ade23d21e5a4eaaf022401c13f0e76e", size = 15454, upload-time = "2025-03-05T14:46:06.463Z" },
+]
+
+[[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl", hash = "sha256:1503af579d8379c24bdd65528379bc57039b0455be9f5f9686cf8e473a1fce51", size = 54591, upload-time = "2026-07-21T15:03:56.224Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -833,18 +899,6 @@ wheels = [
 ]
 
 [[package]]
-name = "humanfriendly"
-version = "10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1094,7 +1148,8 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -1334,68 +1389,44 @@ wheels = [
 
 [[package]]
 name = "ml-dtypes"
-version = "0.4.1"
+version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/15/76f86faa0902836cc133939732f7611ace68cf54148487a99c539c272dc8/ml_dtypes-0.4.1.tar.gz", hash = "sha256:fad5f2de464fd09127e49b7fd1252b9006fb43d2edc1ff112d390c324af5ca7a", size = 692594, upload-time = "2024-09-13T19:07:11.624Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/76/9835c8609c29f2214359e88f29255fc4aad4ea0f613fb48aa8815ceda1b6/ml_dtypes-0.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2d55b588116a7085d6e074cf0cdb1d6fa3875c059dddc4d2c94a4cc81c23e975", size = 397973, upload-time = "2024-09-13T19:06:51.748Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/99/e68c56fac5de973007a10254b6e17a0362393724f40f66d5e4033f4962c2/ml_dtypes-0.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e138a9b7a48079c900ea969341a5754019a1ad17ae27ee330f7ebf43f23877f9", size = 2185134, upload-time = "2024-09-13T19:06:53.197Z" },
-    { url = "https://files.pythonhosted.org/packages/28/bc/6a2344338ea7b61cd7b46fb24ec459360a5a0903b57c55b156c1e46c644a/ml_dtypes-0.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74c6cfb5cf78535b103fde9ea3ded8e9f16f75bc07789054edc7776abfb3d752", size = 2163661, upload-time = "2024-09-13T19:06:54.519Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/d3/ddfd9878b223b3aa9a930c6100a99afca5cfab7ea703662e00323acb7568/ml_dtypes-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:274cc7193dd73b35fb26bef6c5d40ae3eb258359ee71cd82f6e96a8c948bdaa6", size = 126727, upload-time = "2024-09-13T19:06:55.897Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/1a/99e924f12e4b62139fbac87419698c65f956d58de0dbfa7c028fa5b096aa/ml_dtypes-0.4.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:827d3ca2097085cf0355f8fdf092b888890bb1b1455f52801a2d7756f056f54b", size = 405077, upload-time = "2024-09-13T19:06:57.538Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/8c/7b610bd500617854c8cc6ed7c8cfb9d48d6a5c21a1437a36a4b9bc8a3598/ml_dtypes-0.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:772426b08a6172a891274d581ce58ea2789cc8abc1c002a27223f314aaf894e7", size = 2181554, upload-time = "2024-09-13T19:06:59.196Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/c6/f89620cecc0581dc1839e218c4315171312e46c62a62da6ace204bda91c0/ml_dtypes-0.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:126e7d679b8676d1a958f2651949fbfa182832c3cd08020d8facd94e4114f3e9", size = 2160488, upload-time = "2024-09-13T19:07:03.131Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/11/a742d3c31b2cc8557a48efdde53427fd5f9caa2fa3c9c27d826e78a66f51/ml_dtypes-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:df0fb650d5c582a9e72bb5bd96cfebb2cdb889d89daff621c8fbc60295eba66c", size = 127462, upload-time = "2024-09-13T19:07:04.916Z" },
-]
-
-[[package]]
-name = "ml-dtypes"
-version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform != 'linux'",
-]
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/a7/aad060393123cfb383956dca68402aff3db1e1caffd5764887ed5153f41b/ml_dtypes-0.5.3.tar.gz", hash = "sha256:95ce33057ba4d05df50b1f3cfefab22e351868a843b3b15a46c65836283670c9", size = 692316, upload-time = "2025-07-29T18:39:19.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/f1/720cb1409b5d0c05cff9040c0e9fba73fa4c67897d33babf905d5d46a070/ml_dtypes-0.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4a177b882667c69422402df6ed5c3428ce07ac2c1f844d8a1314944651439458", size = 667412, upload-time = "2025-07-29T18:38:25.275Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d5/05861ede5d299f6599f86e6bc1291714e2116d96df003cfe23cc54bcc568/ml_dtypes-0.5.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9849ce7267444c0a717c80c6900997de4f36e2815ce34ac560a3edb2d9a64cd2", size = 4964606, upload-time = "2025-07-29T18:38:27.045Z" },
-    { url = "https://files.pythonhosted.org/packages/db/dc/72992b68de367741bfab8df3b3fe7c29f982b7279d341aa5bf3e7ef737ea/ml_dtypes-0.5.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3f5ae0309d9f888fd825c2e9d0241102fadaca81d888f26f845bc8c13c1e4ee", size = 4938435, upload-time = "2025-07-29T18:38:29.193Z" },
-    { url = "https://files.pythonhosted.org/packages/81/1c/d27a930bca31fb07d975a2d7eaf3404f9388114463b9f15032813c98f893/ml_dtypes-0.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:58e39349d820b5702bb6f94ea0cb2dc8ec62ee81c0267d9622067d8333596a46", size = 206334, upload-time = "2025-07-29T18:38:30.687Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d8/6922499effa616012cb8dc445280f66d100a7ff39b35c864cfca019b3f89/ml_dtypes-0.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:66c2756ae6cfd7f5224e355c893cfd617fa2f747b8bbd8996152cbdebad9a184", size = 157584, upload-time = "2025-07-29T18:38:32.187Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/eb/bc07c88a6ab002b4635e44585d80fa0b350603f11a2097c9d1bfacc03357/ml_dtypes-0.5.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:156418abeeda48ea4797db6776db3c5bdab9ac7be197c1233771e0880c304057", size = 663864, upload-time = "2025-07-29T18:38:33.777Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/89/11af9b0f21b99e6386b6581ab40fb38d03225f9de5f55cf52097047e2826/ml_dtypes-0.5.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1db60c154989af253f6c4a34e8a540c2c9dce4d770784d426945e09908fbb177", size = 4951313, upload-time = "2025-07-29T18:38:36.45Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/a9/b98b86426c24900b0c754aad006dce2863df7ce0bb2bcc2c02f9cc7e8489/ml_dtypes-0.5.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b255acada256d1fa8c35ed07b5f6d18bc21d1556f842fbc2d5718aea2cd9e55", size = 4928805, upload-time = "2025-07-29T18:38:38.29Z" },
-    { url = "https://files.pythonhosted.org/packages/50/c1/85e6be4fc09c6175f36fb05a45917837f30af9a5146a5151cb3a3f0f9e09/ml_dtypes-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:da65e5fd3eea434ccb8984c3624bc234ddcc0d9f4c81864af611aaebcc08a50e", size = 208182, upload-time = "2025-07-29T18:38:39.72Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/17/cf5326d6867be057f232d0610de1458f70a8ce7b6290e4b4a277ea62b4cd/ml_dtypes-0.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:8bb9cd1ce63096567f5f42851f5843b5a0ea11511e50039a7649619abfb4ba6d", size = 161560, upload-time = "2025-07-29T18:38:41.072Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/87/1bcc98a66de7b2455dfb292f271452cac9edc4e870796e0d87033524d790/ml_dtypes-0.5.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5103856a225465371fe119f2fef737402b705b810bd95ad5f348e6e1a6ae21af", size = 663781, upload-time = "2025-07-29T18:38:42.984Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/2c/bd2a79ba7c759ee192b5601b675b180a3fd6ccf48ffa27fe1782d280f1a7/ml_dtypes-0.5.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cae435a68861660af81fa3c5af16b70ca11a17275c5b662d9c6f58294e0f113", size = 4956217, upload-time = "2025-07-29T18:38:44.65Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f3/091ba84e5395d7fe5b30c081a44dec881cd84b408db1763ee50768b2ab63/ml_dtypes-0.5.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6936283b56d74fbec431ca57ce58a90a908fdbd14d4e2d22eea6d72bb208a7b7", size = 4933109, upload-time = "2025-07-29T18:38:46.405Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/24/054036dbe32c43295382c90a1363241684c4d6aaa1ecc3df26bd0c8d5053/ml_dtypes-0.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:d0f730a17cf4f343b2c7ad50cee3bd19e969e793d2be6ed911f43086460096e4", size = 208187, upload-time = "2025-07-29T18:38:48.24Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/3d/7dc3ec6794a4a9004c765e0c341e32355840b698f73fd2daff46f128afc1/ml_dtypes-0.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:2db74788fc01914a3c7f7da0763427280adfc9cd377e9604b6b64eb8097284bd", size = 161559, upload-time = "2025-07-29T18:38:50.493Z" },
-    { url = "https://files.pythonhosted.org/packages/12/91/e6c7a0d67a152b9330445f9f0cf8ae6eee9b83f990b8c57fe74631e42a90/ml_dtypes-0.5.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:93c36a08a6d158db44f2eb9ce3258e53f24a9a4a695325a689494f0fdbc71770", size = 689321, upload-time = "2025-07-29T18:38:52.03Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/6c/b7b94b84a104a5be1883305b87d4c6bd6ae781504474b4cca067cb2340ec/ml_dtypes-0.5.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0e44a3761f64bc009d71ddb6d6c71008ba21b53ab6ee588dadab65e2fa79eafc", size = 5274495, upload-time = "2025-07-29T18:38:53.797Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/38/6266604dffb43378055394ea110570cf261a49876fc48f548dfe876f34cc/ml_dtypes-0.5.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdf40d2aaabd3913dec11840f0d0ebb1b93134f99af6a0a4fd88ffe924928ab4", size = 5285422, upload-time = "2025-07-29T18:38:56.603Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/88/8612ff177d043a474b9408f0382605d881eeb4125ba89d4d4b3286573a83/ml_dtypes-0.5.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:aec640bd94c4c85c0d11e2733bd13cbb10438fb004852996ec0efbc6cacdaf70", size = 661182, upload-time = "2025-07-29T18:38:58.414Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/2b/0569a5e88b29240d373e835107c94ae9256fb2191d3156b43b2601859eff/ml_dtypes-0.5.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bda32ce212baa724e03c68771e5c69f39e584ea426bfe1a701cb01508ffc7035", size = 4956187, upload-time = "2025-07-29T18:39:00.611Z" },
-    { url = "https://files.pythonhosted.org/packages/51/66/273c2a06ae44562b104b61e6b14444da00061fd87652506579d7eb2c40b1/ml_dtypes-0.5.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c205cac07d24a29840c163d6469f61069ce4b065518519216297fc2f261f8db9", size = 4930911, upload-time = "2025-07-29T18:39:02.405Z" },
-    { url = "https://files.pythonhosted.org/packages/93/ab/606be3e87dc0821bd360c8c1ee46108025c31a4f96942b63907bb441b87d/ml_dtypes-0.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:cd7c0bb22d4ff86d65ad61b5dd246812e8993fbc95b558553624c33e8b6903ea", size = 216664, upload-time = "2025-07-29T18:39:03.927Z" },
-    { url = "https://files.pythonhosted.org/packages/30/a2/e900690ca47d01dffffd66375c5de8c4f8ced0f1ef809ccd3b25b3e6b8fa/ml_dtypes-0.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:9d55ea7f7baf2aed61bf1872116cefc9d0c3693b45cae3916897ee27ef4b835e", size = 160203, upload-time = "2025-07-29T18:39:05.671Z" },
-    { url = "https://files.pythonhosted.org/packages/53/21/783dfb51f40d2660afeb9bccf3612b99f6a803d980d2a09132b0f9d216ab/ml_dtypes-0.5.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:e12e29764a0e66a7a31e9b8bf1de5cc0423ea72979f45909acd4292de834ccd3", size = 689324, upload-time = "2025-07-29T18:39:07.567Z" },
-    { url = "https://files.pythonhosted.org/packages/09/f7/a82d249c711abf411ac027b7163f285487f5e615c3e0716c61033ce996ab/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19f6c3a4f635c2fc9e2aa7d91416bd7a3d649b48350c51f7f715a09370a90d93", size = 5275917, upload-time = "2025-07-29T18:39:09.339Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/3c/541c4b30815ab90ebfbb51df15d0b4254f2f9f1e2b4907ab229300d5e6f2/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ab039ffb40f3dc0aeeeba84fd6c3452781b5e15bef72e2d10bcb33e4bbffc39", size = 5285284, upload-time = "2025-07-29T18:39:11.532Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
 ]
 
 [[package]]
@@ -1418,128 +1449,280 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "1.26.4"
+version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554, upload-time = "2024-02-05T23:51:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127, upload-time = "2024-02-05T23:52:15.314Z" },
-    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994, upload-time = "2024-02-05T23:52:47.569Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005, upload-time = "2024-02-05T23:53:15.637Z" },
-    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297, upload-time = "2024-02-05T23:53:42.16Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567, upload-time = "2024-02-05T23:54:11.696Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812, upload-time = "2024-02-05T23:54:26.453Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913, upload-time = "2024-02-05T23:54:53.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
-    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
-    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
-    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
-    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
-    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
+name = "numpy"
+version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/69/72/dccb0aaf40972777283303919f613964227266d0c13adebb79ac124f1c3e/numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c", size = 16891693, upload-time = "2026-08-09T13:44:51.702Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03", size = 11903109, upload-time = "2026-08-09T13:44:55.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f4/29e78102a80601cf034d4e9767022cffeca2c3b4c926e1754572ca95593d/numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb", size = 5350202, upload-time = "2026-08-09T13:44:58.401Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4b/dcd3b7eadaf4035d2c7a4289d232523a6964f602598ef7674e4bd7291f93/numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414", size = 6687736, upload-time = "2026-08-09T13:45:00.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/21/4947e0e9d6c9fc2e2ff15b8949049ee44f63adb9cacc729ab8793f97e712/numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9", size = 15612696, upload-time = "2026-08-09T13:45:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8", size = 16722264, upload-time = "2026-08-09T13:45:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/3f0be4c1b9fdf5dd5e708a6806978564d7c46a055c000496309ff2a2f8af/numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab", size = 16974396, upload-time = "2026-08-09T13:45:11.316Z" },
+    { url = "https://files.pythonhosted.org/packages/22/72/6262cbdeeb45da9d971e40715f579d791603ba8ec0b5e2db1ac55454421d/numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7", size = 18476044, upload-time = "2026-08-09T13:45:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/29208b8b075bde62d26a81d14b358c42b0f69b6cabd98d4ff97f37f22b05/numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a", size = 6072817, upload-time = "2026-08-09T13:45:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4", size = 12464674, upload-time = "2026-08-09T13:45:20.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/032b97e00461ab0809bbe4c588b035620e5a14b8cdee47ecddefc7b17d33/numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1", size = 10397131, upload-time = "2026-08-09T13:45:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c6/28de0191c5f82b7d42a0a51390ba98587048aa93a39fafb05bdbe6e8d00c/numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f", size = 16885274, upload-time = "2026-08-09T13:47:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/973ca116000d244897e468ea1aff30b589e5022e3c8744b71706fe33bd57/numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842", size = 11907846, upload-time = "2026-08-09T13:47:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d9/8c4b3937ef204cb2fd88d389ccd0f265a2ffb11f35a01d2064cf46714bd6/numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6", size = 5354892, upload-time = "2026-08-09T13:47:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/b6ee65ea2999fdb7023935e108e6fb776ee4082aa15f159acfa857e578c8/numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8", size = 6679309, upload-time = "2026-08-09T13:47:20.456Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f3/acb18d8b137a393c8e7803a8c994c9e64bde3930692a69d826993113a159/numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69", size = 15625850, upload-time = "2026-08-09T13:47:24.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bf/a8e9bb0db815a0e265b5744ebedd3af0bd5faad8604e5b50a1cd012f3c91/numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab", size = 16713664, upload-time = "2026-08-09T13:47:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/6e913736b3dd6582344af32418b5fb9dab34282e8a8174ae1d54ceb0fc13/numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514", size = 16986749, upload-time = "2026-08-09T13:47:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/7d3b23eff5c7428ef6c01e6f7052bb60d504c4d33e317b36b8959c24ad97/numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710", size = 18470495, upload-time = "2026-08-09T13:47:35.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a4/68a321d825374f6eb677ffe8ef8c6b9a328304e6fd2e39d9530822776607/numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617", size = 6120696, upload-time = "2026-08-09T13:47:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/deafbb1700f79fae9cd1e91220f133d124cc267de1b584da3fbf6db2f6cd/numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7", size = 12597324, upload-time = "2026-08-09T13:47:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cd/3272ba105e3bbbdaeb11357eda31e7a6825ffe159e8171665660299a948f/numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788", size = 10680466, upload-time = "2026-08-09T13:47:44.873Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/58370637b1bb70a5c9ce2b43f4b521ccb224e36ccb76a6596b17ae4b447c/numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b", size = 16993947, upload-time = "2026-08-09T13:47:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/93/2abcb807712b289d6d60fe4cf30532f98974a8396d885650f3ba5a13026e/numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e", size = 12025331, upload-time = "2026-08-09T13:47:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3a/2898e003a5fbaf87e76c039b4ee1f5eb390471b4ffe74887c1f34c4e791e/numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a", size = 5472336, upload-time = "2026-08-09T13:47:55.403Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/23f69d07c544597b29758b31b55c27dc9d541012a2c1496189fef702aec2/numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8", size = 6788387, upload-time = "2026-08-09T13:47:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ea/c0dbdbcf22f43782510a3e492dd3da73c6112b69cac8929d16d127536fc4/numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc", size = 15667096, upload-time = "2026-08-09T13:48:01.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/29c73c31748cdb0f7566642125ba17fd5b56780cddf891b085dab27e4466/numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec", size = 16751730, upload-time = "2026-08-09T13:48:05.706Z" },
+    { url = "https://files.pythonhosted.org/packages/47/95/02501e8454796bb58dadf7a99d3181e0b464bf264e1003039572f9779fac/numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0", size = 17038686, upload-time = "2026-08-09T13:48:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/53a681d91b5c82687067d8ea5035e02d917b5509d6f334cb06484a954714/numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2", size = 18507727, upload-time = "2026-08-09T13:48:13.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
 ]
 
 [[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
+name = "nvidia-cublas"
+version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
 ]
 
 [[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
 ]
 
 [[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
+name = "nvidia-cufft"
+version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
 ]
 
 [[package]]
@@ -1552,187 +1735,145 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
 ]
 
 [[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
+name = "nvidia-nvjitlink"
+version = "13.3.33"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
 ]
 
 [[package]]
-name = "nvidia-nvshmem-cu12"
-version = "3.3.20"
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
 ]
 
 [[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
+name = "nvidia-nvtx"
+version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
-]
-
-[[package]]
-name = "onnx"
-version = "1.19.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-]
-dependencies = [
-    { name = "ml-dtypes", version = "0.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", hash = "sha256:aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473", size = 11949859, upload-time = "2025-08-27T02:34:27.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/5c/b959b17608cfb6ccf6359b39fe56a5b0b7d965b3d6e6a3c0add90812c36e/onnx-1.19.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:206f00c47b85b5c7af79671e3307147407991a17994c26974565aadc9e96e4e4", size = 18312580, upload-time = "2025-08-27T02:33:03.081Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ee/ac052bbbc832abe0debb784c2c57f9582444fb5f51d63c2967fd04432444/onnx-1.19.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4d7bee94abaac28988b50da675ae99ef8dd3ce16210d591fbd0b214a5930beb3", size = 18029165, upload-time = "2025-08-27T02:33:05.771Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c9/8687ba0948d46fd61b04e3952af9237883bbf8f16d716e7ed27e688d73b8/onnx-1.19.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7730b96b68c0c354bbc7857961bb4909b9aaa171360a8e3708d0a4c749aaadeb", size = 18202125, upload-time = "2025-08-27T02:33:09.325Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/16/6249c013e81bd689f46f96c7236d7677f1af5dd9ef22746716b48f10e506/onnx-1.19.0-cp311-cp311-win32.whl", hash = "sha256:7cb7a3ad8059d1a0dfdc5e0a98f71837d82002e441f112825403b137227c2c97", size = 16332738, upload-time = "2025-08-27T02:33:12.448Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/28/34a1e2166e418c6a78e5c82e66f409d9da9317832f11c647f7d4e23846a6/onnx-1.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:d75452a9be868bd30c3ef6aa5991df89bbfe53d0d90b2325c5e730fbd91fff85", size = 16452303, upload-time = "2025-08-27T02:33:15.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b7/639664626e5ba8027860c4d2a639ee02b37e9c322215c921e9222513c3aa/onnx-1.19.0-cp311-cp311-win_arm64.whl", hash = "sha256:23c7959370d7b3236f821e609b0af7763cff7672a758e6c1fc877bac099e786b", size = 16425340, upload-time = "2025-08-27T02:33:17.78Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/94/f56f6ca5e2f921b28c0f0476705eab56486b279f04e1d568ed64c14e7764/onnx-1.19.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:61d94e6498ca636756f8f4ee2135708434601b2892b7c09536befb19bc8ca007", size = 18322331, upload-time = "2025-08-27T02:33:20.373Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/00/8cc3f3c40b54b28f96923380f57c9176872e475face726f7d7a78bd74098/onnx-1.19.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:224473354462f005bae985c72028aaa5c85ab11de1b71d55b06fdadd64a667dd", size = 18027513, upload-time = "2025-08-27T02:33:23.44Z" },
-    { url = "https://files.pythonhosted.org/packages/61/90/17c4d2566fd0117a5e412688c9525f8950d467f477fbd574e6b32bc9cb8d/onnx-1.19.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae475c85c89bc4d1f16571006fd21a3e7c0e258dd2c091f6e8aafb083d1ed9b", size = 18202278, upload-time = "2025-08-27T02:33:26.103Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/6e/a9383d9cf6db4ac761a129b081e9fa5d0cd89aad43cf1e3fc6285b915c7d/onnx-1.19.0-cp312-cp312-win32.whl", hash = "sha256:323f6a96383a9cdb3960396cffea0a922593d221f3929b17312781e9f9b7fb9f", size = 16333080, upload-time = "2025-08-27T02:33:28.559Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/2e/3ff480a8c1fa7939662bdc973e41914add2d4a1f2b8572a3c39c2e4982e5/onnx-1.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:50220f3499a499b1a15e19451a678a58e22ad21b34edf2c844c6ef1d9febddc2", size = 16453927, upload-time = "2025-08-27T02:33:31.177Z" },
-    { url = "https://files.pythonhosted.org/packages/57/37/ad500945b1b5c154fe9d7b826b30816ebd629d10211ea82071b5bcc30aa4/onnx-1.19.0-cp312-cp312-win_arm64.whl", hash = "sha256:efb768299580b786e21abe504e1652ae6189f0beed02ab087cd841cb4bb37e43", size = 16426022, upload-time = "2025-08-27T02:33:33.515Z" },
-    { url = "https://files.pythonhosted.org/packages/be/29/d7b731f63d243f815d9256dce0dca3c151dcaa1ac59f73e6ee06c9afbe91/onnx-1.19.0-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:9aed51a4b01acc9ea4e0fe522f34b2220d59e9b2a47f105ac8787c2e13ec5111", size = 18322412, upload-time = "2025-08-27T02:33:36.723Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f5/d3106becb42cb374f0e17ff4c9933a97f1ee1d6a798c9452067f7d3ff61b/onnx-1.19.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce2cdc3eb518bb832668c4ea9aeeda01fbaa59d3e8e5dfaf7aa00f3d37119404", size = 18026565, upload-time = "2025-08-27T02:33:39.493Z" },
-    { url = "https://files.pythonhosted.org/packages/83/fa/b086d17bab3900754c7ffbabfb244f8e5e5da54a34dda2a27022aa2b373b/onnx-1.19.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b546bd7958734b6abcd40cfede3d025e9c274fd96334053a288ab11106bd0aa", size = 18202077, upload-time = "2025-08-27T02:33:42.115Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f2/5e2dfb9d4cf873f091c3f3c6d151f071da4295f9893fbf880f107efe3447/onnx-1.19.0-cp313-cp313-win32.whl", hash = "sha256:03086bffa1cf5837430cf92f892ca0cd28c72758d8905578c2bf8ffaf86c6743", size = 16333198, upload-time = "2025-08-27T02:33:45.172Z" },
-    { url = "https://files.pythonhosted.org/packages/79/67/b3751a35c2522f62f313156959575619b8fa66aa883db3adda9d897d8eb2/onnx-1.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:1715b51eb0ab65272e34ef51cb34696160204b003566cd8aced2ad20a8f95cb8", size = 16453836, upload-time = "2025-08-27T02:33:47.779Z" },
-    { url = "https://files.pythonhosted.org/packages/14/b9/1df85effc960fbbb90bb7bc36eb3907c676b104bc2f88bce022bcfdaef63/onnx-1.19.0-cp313-cp313-win_arm64.whl", hash = "sha256:6bf5acdb97a3ddd6e70747d50b371846c313952016d0c41133cbd8f61b71a8d5", size = 16425877, upload-time = "2025-08-27T02:33:50.357Z" },
-    { url = "https://files.pythonhosted.org/packages/23/2b/089174a1427be9149f37450f8959a558ba20f79fca506ba461d59379d3a1/onnx-1.19.0-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:46cf29adea63e68be0403c68de45ba1b6acc9bb9592c5ddc8c13675a7c71f2cb", size = 18348546, upload-time = "2025-08-27T02:33:56.132Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d6/3458f0e3a9dc7677675d45d7d6528cb84ad321c8670cc10c69b32c3e03da/onnx-1.19.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:246f0de1345498d990a443d55a5b5af5101a3e25a05a2c3a5fe8b7bd7a7d0707", size = 18033067, upload-time = "2025-08-27T02:33:58.661Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/16/6e4130e1b4b29465ee1fb07d04e8d6f382227615c28df8f607ba50909e2a/onnx-1.19.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae0d163ffbc250007d984b8dd692a4e2e4506151236b50ca6e3560b612ccf9ff", size = 18205741, upload-time = "2025-08-27T02:34:01.538Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/d8/f64d010fd024b2a2b11ce0c4ee179e4f8f6d4ccc95f8184961c894c22af1/onnx-1.19.0-cp313-cp313t-win_amd64.whl", hash = "sha256:7c151604c7cca6ae26161c55923a7b9b559df3344938f93ea0074d2d49e7fe78", size = 16453839, upload-time = "2025-08-27T02:34:06.515Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ec/8761048eabef4dad55af4c002c672d139b9bd47c3616abaed642a1710063/onnx-1.19.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:236bc0e60d7c0f4159300da639953dd2564df1c195bce01caba172a712e75af4", size = 18027605, upload-time = "2025-08-27T02:34:08.962Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
 name = "onnx"
-version = "1.19.1"
+version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform != 'linux'",
-]
 dependencies = [
-    { name = "ml-dtypes", version = "0.5.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/2f/c619eb65769357e9b6de9212c9a821ab39cd484448e5d6b3fb5fb0a64c6d/onnx-1.19.1.tar.gz", hash = "sha256:737524d6eb3907d3499ea459c6f01c5a96278bb3a0f2ff8ae04786fb5d7f1ed5", size = 12033525, upload-time = "2025-10-10T04:01:34.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/19/8ea73a64b368b75fe339771a20a02bc61ea1f551484c9e3d9d0bfbd0450f/onnx-1.22.0.tar.gz", hash = "sha256:ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0", size = 12024721, upload-time = "2026-06-15T12:50:05.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/07/0019c72924909e4f64b9199770630ab7b8d7914b912b03230e68f5eda7ae/onnx-1.19.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:17aaf5832126de0a5197a5864e4f09a764dd7681d3035135547959b4b6b77a09", size = 18320936, upload-time = "2025-10-10T04:00:04.235Z" },
-    { url = "https://files.pythonhosted.org/packages/af/2f/5c47acf740dc35f0decc640844260fbbdc0efa0565657c93fd7ff30f13f3/onnx-1.19.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01b292a4d0b197c45d8184545bbc8ae1df83466341b604187c1b05902cb9c920", size = 18044269, upload-time = "2025-10-10T04:00:07.449Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/61/6c457ee8c3a62a3cad0a4bfa4c5436bb3ac4df90c3551d40bee1224b5b51/onnx-1.19.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1839af08ab4a909e4af936b8149c27f8c64b96138981024e251906e0539d8bf9", size = 18218092, upload-time = "2025-10-10T04:00:11.135Z" },
-    { url = "https://files.pythonhosted.org/packages/54/d5/ab832e1369505e67926a70e9a102061f89ad01f91aa296c4b1277cb81b25/onnx-1.19.1-cp311-cp311-win32.whl", hash = "sha256:0bdbb676e3722bd32f9227c465d552689f49086f986a696419d865cb4e70b989", size = 16344809, upload-time = "2025-10-10T04:00:14.634Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/b5/6eb4611d24b85002f878ba8476b4cecbe6f9784c0236a3c5eff85236cc0a/onnx-1.19.1-cp311-cp311-win_amd64.whl", hash = "sha256:1346853df5c1e3ebedb2e794cf2a51e0f33759affd655524864ccbcddad7035b", size = 16464319, upload-time = "2025-10-10T04:00:18.235Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ff/f0e1f06420c70e20d497fec7c94a864d069943b6312bedd4224c0ab946f8/onnx-1.19.1-cp311-cp311-win_arm64.whl", hash = "sha256:2d69c280c0e665b7f923f499243b9bb84fe97970b7a4668afa0032045de602c8", size = 16437503, upload-time = "2025-10-10T04:00:21.247Z" },
-    { url = "https://files.pythonhosted.org/packages/50/07/f6c5b2cffef8c29e739616d1415aea22f7b7ef1f19c17f02b7cff71f5498/onnx-1.19.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:3612193a89ddbce5c4e86150869b9258780a82fb8c4ca197723a4460178a6ce9", size = 18327840, upload-time = "2025-10-10T04:00:24.259Z" },
-    { url = "https://files.pythonhosted.org/packages/93/20/0568ebd52730287ae80cac8ac893a7301c793ea1630984e2519ee92b02a9/onnx-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c2fd2f744e7a3880ad0c262efa2edf6d965d0bd02b8f327ec516ad4cb0f2f15", size = 18042539, upload-time = "2025-10-10T04:00:27.693Z" },
-    { url = "https://files.pythonhosted.org/packages/14/fd/cd7a0fd10a04f8cc5ae436b63e0022e236fe51b9dbb8ee6317fd48568c72/onnx-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:485d3674d50d789e0ee72fa6f6e174ab81cb14c772d594f992141bd744729d8a", size = 18218271, upload-time = "2025-10-10T04:00:30.495Z" },
-    { url = "https://files.pythonhosted.org/packages/65/68/cc8b8c05469fe08384b446304ad7e6256131ca0463bf6962366eebec98c0/onnx-1.19.1-cp312-cp312-win32.whl", hash = "sha256:638bc56ff1a5718f7441e887aeb4e450f37a81c6eac482040381b140bd9ba601", size = 16345111, upload-time = "2025-10-10T04:00:34.982Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5e/d1cb16693598a512c2cf9ffe0841d8d8fd2c83ae8e889efd554f5aa427cf/onnx-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:bc7e2e4e163e679721e547958b5a7db875bf822cad371b7c1304aa4401a7c7a4", size = 16465621, upload-time = "2025-10-10T04:00:39.107Z" },
-    { url = "https://files.pythonhosted.org/packages/90/32/da116cc61fdef334782aa7f87a1738431dd1af1a5d1a44bd95d6d51ad260/onnx-1.19.1-cp312-cp312-win_arm64.whl", hash = "sha256:17c215b1c0f20fe93b4cbe62668247c1d2294b9bc7f6be0ca9ced28e980c07b7", size = 16437505, upload-time = "2025-10-10T04:00:42.255Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/b8/ab1fdfe2e8502f4dc4289fc893db35816bd20d080d8370f86e74dda5f598/onnx-1.19.1-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:4e5f938c68c4dffd3e19e4fd76eb98d298174eb5ebc09319cdd0ec5fe50050dc", size = 18327815, upload-time = "2025-10-10T04:00:45.682Z" },
-    { url = "https://files.pythonhosted.org/packages/04/40/eb875745a4b92aea10e5e32aa2830f409c4d7b6f7b48ca1c4eaad96636c5/onnx-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:86e20a5984b017feeef2dbf4ceff1c7c161ab9423254968dd77d3696c38691d0", size = 18041464, upload-time = "2025-10-10T04:00:48.557Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/8e/8586135f40dbe4989cec4d413164bc8fc5c73d37c566f33f5ea3a7f2b6f6/onnx-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d9c467f0f29993c12f330736af87972f30adb8329b515f39d63a0db929cb2c", size = 18218244, upload-time = "2025-10-10T04:00:51.891Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b5/4201254b8683129db5da3fb55aa1f7e56d0a8d45c66ce875dec21ca1ff25/onnx-1.19.1-cp313-cp313-win32.whl", hash = "sha256:65eee353a51b4e4ca3e797784661e5376e2b209f17557e04921eac9166a8752e", size = 16345330, upload-time = "2025-10-10T04:00:54.858Z" },
-    { url = "https://files.pythonhosted.org/packages/69/67/c6d239afbcdbeb6805432969b908b5c9f700c96d332b34e3f99518d76caf/onnx-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:c3bc87e38b53554b1fc9ef7b275c81c6f5c93c90a91935bb0aa8d4d498a6d48e", size = 16465567, upload-time = "2025-10-10T04:00:57.893Z" },
-    { url = "https://files.pythonhosted.org/packages/99/fe/89f1e40f5bc54595ff0dcf5391ce19e578b528973ccc74dd99800196d30d/onnx-1.19.1-cp313-cp313-win_arm64.whl", hash = "sha256:e41496f400afb980ec643d80d5164753a88a85234fa5c06afdeebc8b7d1ec252", size = 16437562, upload-time = "2025-10-10T04:01:00.703Z" },
-    { url = "https://files.pythonhosted.org/packages/86/43/b186ccbc8fe7e93643a6a6d40bbf2bb6ce4fb9469bbd3453c77e270c50ad/onnx-1.19.1-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:5f6274abf0fd74e80e78ecbb44bd44509409634525c89a9b38276c8af47dc0a2", size = 18355703, upload-time = "2025-10-10T04:01:03.735Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f1/22ee4d8b8f9fa4cb1d1b9579da3b4b5187ddab33846ec5ac744af02c0e2b/onnx-1.19.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07dcd4d83584eb4bf8f21ac04c82643712e5e93ac2a0ed10121ec123cb127e1e", size = 18047830, upload-time = "2025-10-10T04:01:06.552Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a4/8f3d51e3a095d42cdf2039a590cff06d024f2a10efbd0b1a2a6b3825f019/onnx-1.19.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1975860c3e720db25d37f1619976582828264bdcc64fa7511c321ac4fc01add3", size = 18221126, upload-time = "2025-10-10T04:01:09.77Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/0d/f9d6c2237083f1aac14b37f0b03b0d81f1147a8e2af0c3828165e0a6a67b/onnx-1.19.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9807d0e181f6070ee3a6276166acdc571575d1bd522fc7e89dba16fd6e7ffed9", size = 16465560, upload-time = "2025-10-10T04:01:13.212Z" },
-    { url = "https://files.pythonhosted.org/packages/36/70/8418a58faa7d606d6a92cab69ae8d361b3b3969bf7e7e9a65a86d5d1b674/onnx-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6ee83e6929d75005482d9f304c502ac7c9b8d6db153aa6b484dae74d0f28570", size = 18042812, upload-time = "2025-10-10T04:01:15.919Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/55/30825c02c92a0380ce84c3feeeec95d329fa77548ba58cb10ad4bbfd83c6/onnx-1.22.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:2d8f229a553fa440fe623ed7b36fca5e7762da3af871c3f8f8ce451df73e2914", size = 20167891, upload-time = "2026-06-15T12:49:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/24/cd4ab52ecaf41c3fbed674772ccbfe39041cb257b8471a47a37e48bff3f8/onnx-1.22.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a89a7cb9ba13d78f009bdec448ec82a98972589734f157022a2bff7a5973a6", size = 18892720, upload-time = "2026-06-15T12:49:16.904Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/c9d9d56ceadb1c0a90a7cbec5a0510520ab6538938944fa84548e4b5b054/onnx-1.22.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d0a2bdb15eb2b3cb65c438f3423d9620d14fdce32f92380e6bb1b2e09568ef5", size = 19110720, upload-time = "2026-06-15T12:49:19.812Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/e43e5a68d9cadde55df75310027f87127333a77e5ddcea14c73e96a10cac/onnx-1.22.0-cp311-cp311-win32.whl", hash = "sha256:239958534464612fbcb6ed23d5228aaa925b39b8773f58726809ffdccb4edd1c", size = 17083746, upload-time = "2026-06-15T12:49:22.935Z" },
+    { url = "https://files.pythonhosted.org/packages/54/57/cc0a9f2cf4522e42829d089927b4b75924d32f50dca237482e7b741df003/onnx-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:8561a2c00041c07e08db0c228593b5b4694100398685f348532af7dbb84189da", size = 17215684, upload-time = "2026-06-15T12:49:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/99/0f049f9eaa06c8383060c5f0a338e3a6caac8822e6e326c9162f05abf95a/onnx-1.22.0-cp311-cp311-win_arm64.whl", hash = "sha256:8907b9b9389893bc0dc6314cc00ee1e3a69844e48d689eacc6a0340411a7da58", size = 17210398, upload-time = "2026-06-15T12:49:29.091Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/6a/481561f1093834376ed493e4ca42a73e5be0d50031f2969c86593bdc7c96/onnx-1.22.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:596fbf0490947533c1c1045ba860851dc9fb77471023dac9a71ba5b42ceab103", size = 20167081, upload-time = "2026-06-15T12:49:32.078Z" },
+    { url = "https://files.pythonhosted.org/packages/84/55/b34fc2aa30aa54b4a775402d24c4082242c720283a274fe976ac8eb94480/onnx-1.22.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae5a563f281cd9d2845622cecf6c092a57e4ee1b138f66fdbbdd4200567a5e16", size = 18889249, upload-time = "2026-06-15T12:49:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a6/bd32357e6cc1ecb473afd78193d7231724f284435d2db25696ecfaaa1503/onnx-1.22.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:955e02e1f6d385b53d52f9cd7b9cdf5caf417c300bcfe3c64c6d542be763845b", size = 19106514, upload-time = "2026-06-15T12:49:37.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9d/3af461ac6c714b8b369cb71499659932f4f12cfb066250b62f7567c3d530/onnx-1.22.0-cp312-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:82e9f27fc1223cb06d68a56bed6f9d3caf3d0dad1b61bce45006d529b15bd94c", size = 16966387, upload-time = "2026-06-15T12:49:40.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f0/68195b5e5a53e333faf2660f5352ee43738d0e42fc5216cc6b1871a9fbfb/onnx-1.22.0-cp312-abi3-win32.whl", hash = "sha256:cc8b66b312f8f03a53e268afb67180a2d97dd12cc79e2b61361c6c0073448016", size = 17081568, upload-time = "2026-06-15T12:49:43.398Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a8/734725bb703c5fabb687f79c79e51249475212b3eb37771ac4a4ac9b487f/onnx-1.22.0-cp312-abi3-win_amd64.whl", hash = "sha256:72ccebab3bac07215c204ce8848d42e78eaaa666badbf72d25cd359b9f269e3a", size = 17213290, upload-time = "2026-06-15T12:49:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/8ce48d8ae26a8761ad4e5dc771961b155c5c3c7c8540ec7f2f2d71b69af0/onnx-1.22.0-cp312-abi3-win_arm64.whl", hash = "sha256:f3c120dcdb70ad738f3c061b32798f408ea299eb69f84dd69ab4a6bf3c2ec01f", size = 17207030, upload-time = "2026-06-15T12:49:48.635Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/13/47323b97846387848efb1044ded11bb94b83526f3d1fbdb37c6480d4520f/onnx-1.22.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:19e45e4af88e3fe3261458d4b8cc461957ae2782a358a3560503569bf3b23b72", size = 20176465, upload-time = "2026-06-15T12:49:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0c/d3b8a7e7eee123938586c608bb9894b5723f2342b9450c0eec59fbec7099/onnx-1.22.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c21a0e59fd967a95b358e4a6e756d1f1eec2d304a83480f329f66e30d2bf0223", size = 18894028, upload-time = "2026-06-15T12:49:54.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8a/da2a97ab46fe6e0cd9beb3ac14603a22f5be492f9ca347faf8233a07bb33/onnx-1.22.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2632406b8f523ef2e2873c363f90b20a3d88c0fbcfac757d3addffccf8f452c2", size = 19110420, upload-time = "2026-06-15T12:49:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/ce984063017518307ebfaa545782fc400e593dc2d7fdf4f23ce4be1ed197/onnx-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a3a39fc4643867aecb33417fdddb11e308ee79d2d4a584b9d50cc7aec2091b13", size = 17237547, upload-time = "2026-06-15T12:50:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/257a880384a1dd502d543b0067945074d63cd17d0840e958355bc8197da8/onnx-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:8e268cdc0547e3949799ffd4a44451dc2b9080b57d0824a2db680b6ec65506f0", size = 17231391, upload-time = "2026-06-15T12:50:03.047Z" },
 ]
 
 [[package]]
 name = "onnx-ir"
-version = "0.1.8"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "ml-dtypes", version = "0.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy" },
-    { name = "onnx", version = "1.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "onnx", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "onnx" },
+    { name = "sympy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/4a/7ea3952e556e7281b8bfe7f7fce016a13fdac85544d6d6af8ebca5cae160/onnx_ir-0.1.8.tar.gz", hash = "sha256:85ea59eaf165b2b107788193480a260e2723cfc7a1dac1bde7085fd0b7e380d7", size = 108961, upload-time = "2025-09-05T15:45:33.887Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/c2/61194cec0dbc5622273c0ebd592d37cc1dca0d7f1a744f02edd45ac905a3/onnx_ir-1.0.0.tar.gz", hash = "sha256:9e261f25fde8da9612ae5cb43b3b374d5ff469c04af0363cad588b2bb000b812", size = 163121, upload-time = "2026-08-11T14:49:46.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1c/3bb51fa9e278cbc655a1943c8016163d76a6e24137e73e5198ebc20fc965/onnx_ir-0.1.8-py3-none-any.whl", hash = "sha256:61a42021b6249e566ff3b89a03342bc88dce4dc2d984b97cfb060f33ef179f8a", size = 125316, upload-time = "2025-09-05T15:45:31.211Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cd/6d1637172eb59c7b18ac90ed089d1f599a11fe0e63b4db2d017f3bb38a32/onnx_ir-1.0.0-py3-none-any.whl", hash = "sha256:e578f0d608d3062866b48223616eb2d10a6d6d01f8b8faac596129034f483cc7", size = 185849, upload-time = "2026-08-11T14:49:45.524Z" },
 ]
 
 [[package]]
 name = "onnxruntime"
-version = "1.23.2"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coloredlogs" },
     { name = "flatbuffers" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "packaging" },
     { name = "protobuf" },
-    { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/be/467b00f09061572f022ffd17e49e49e5a7a789056bad95b54dfd3bee73ff/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6f91d2c9b0965e86827a5ba01531d5b669770b01775b23199565d6c1f136616c", size = 17196113, upload-time = "2025-10-22T03:47:33.526Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a8/3c23a8f75f93122d2b3410bfb74d06d0f8da4ac663185f91866b03f7da1b/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612", size = 19153857, upload-time = "2025-10-22T03:46:37.578Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/d8/506eed9af03d86f8db4880a4c47cd0dffee973ef7e4f4cff9f1d4bcf7d22/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbfd2fca76c855317568c1b36a885ddea2272c13cb0e395002c402f2360429a6", size = 15220095, upload-time = "2025-10-22T03:46:24.769Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/80/113381ba832d5e777accedc6cb41d10f9eca82321ae31ebb6bcede530cea/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da44b99206e77734c5819aa2142c69e64f3b46edc3bd314f6a45a932defc0b3e", size = 17372080, upload-time = "2025-10-22T03:47:00.265Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/db/1b4a62e23183a0c3fe441782462c0ede9a2a65c6bbffb9582fab7c7a0d38/onnxruntime-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:902c756d8b633ce0dedd889b7c08459433fbcf35e9c38d1c03ddc020f0648c6e", size = 13468349, upload-time = "2025-10-22T03:47:25.783Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
-    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/41/fba0cabccecefe4a1b5fc8020c44febb334637f133acefc7ec492029dd2c/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2ff531ad8496281b4297f32b83b01cdd719617e2351ffe0dba5684fb283afa1f", size = 17196337, upload-time = "2025-10-22T03:46:35.168Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a1/428ee29c6eaf09a6f6be56f836213f104618fb35ac6cc586ff0f477263eb/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d127d6e1e9b99d1ebeae9bcd8f98617a812f53f46699eafeb976275744826b", size = 15226898, upload-time = "2025-10-22T03:46:30.039Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/2b/b57c8a2466a3126dbe0a792f56ad7290949b02f47b86216cd47d857e4b77/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bace4e0d46480fbeeb7bbe1ffe1f080e6663a42d1086ff95c1551f2d39e7872", size = 17382518, upload-time = "2025-10-22T03:47:05.407Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
+    { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/97/b7ce1bc8bb6048b5fe9129f55d6506dc19499068ef2e0a0af1ae3c8aa4e7/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8d66f9ceb29909c70839e4e4fb3435c7b490050d8f162bd5f3aba4ca01ee517f", size = 17039880, upload-time = "2026-07-25T01:21:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/17/4e5ecd8764f87573c495d834ce79e61ecca47f7a01d1e444a606e570edcb/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a166b78ee04f3a37fa1ef82034b6a3ce96d9684e582d4d30b296de83e9998bb5", size = 19193162, upload-time = "2026-07-25T01:21:59.151Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/10/3d946d5d5f2cdcc3c8da36cae63190c516d16349edaffd944bda60ca4c3e/onnxruntime-1.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d650aeee29368414367b65529e90afe4bf1bab76254789063b8b2f7ea3013c8", size = 13752539, upload-time = "2026-07-25T01:22:24.524Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/74/1c440be7af1e026280b139caa1be5d11bd4dc368011ddbe8f5362b58e12f/onnxruntime-1.28.0-cp311-cp311-win_arm64.whl", hash = "sha256:0faf85fb447a663c9cdadc39bd6b19bdf7bedded6699e45731b9b36c46fd993d", size = 13449940, upload-time = "2026-07-25T01:22:14.97Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/3807e2b17d9eb71d3cb78ed2ba76869b05c637c9b9d6112e636098b0c97a/onnxruntime-1.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:31410f544674f534c2f27348af52ef81682ca9c8719154bf4d48f0ef23823b1e", size = 19141759, upload-time = "2026-07-25T01:21:53.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/23/b46045c3bf67a9cf54c12f5df0f018a422c65fbb9d6072b10071bebfaae2/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f649dd6f6452d12a8059888aa489fe519e062e18793dac72b9efa0f9fdb64135", size = 17049339, upload-time = "2026-07-25T01:21:43.005Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/8c5396e7894e77c5a7d1e026f3acb9dd39c4b5644e412e37a0055eaa3bc5/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fa221d669282bd8f582708ce4c96010a7e9fb0661f9006b37fe2fedafb73fe", size = 19214329, upload-time = "2026-07-25T01:22:04.133Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f1/51225c202edba4dfc94e1ea03f3d78f1aaf307da75fd792c0ce1946b2514/onnxruntime-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:1a1a19175464665c9b8d50bc916f216cc0b569110045b7bbca8f9f290b186f58", size = 13755033, upload-time = "2026-07-25T01:22:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/db/f59f715edfdd96a051f32b5ef0e680a20a8755d4ecd75f63090e960e347a/onnxruntime-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:cfab507abe09d6ffeb817eee07944d452fdc0b00fdcef34cab4db10a45e378c7", size = 13454175, upload-time = "2026-07-25T01:22:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/47/28/810314fa88647af9f4cdaf438a30ad1cfebebb53ded55499232d7a0094e6/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac301f53b1930402fc46c368e268acfed02f3207272aaff05070d7e09f96f031", size = 17057307, upload-time = "2026-07-25T01:21:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cc/9e9f193cc0f29f263a8f09ec08487aed6c96ee856d5fd77da32a425c1949/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7f022a1103cae591c75fc4565589a515f2ddd14a6ac8e8a05812dfeda142e28", size = 19222954, upload-time = "2026-07-25T01:22:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/952314c451d9463e5c9aed9978eec76cf32930d407d9ab8700dd0f4ea1ea/onnxruntime-1.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:8adff67a3f28257b37cfe945a7e952e4122666aa8c91a0380862e9fd4c2ed19f", size = 19143748, upload-time = "2026-07-25T01:21:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/139180b4dd810329aaa42c238b4e6383c906202d98609ae29d66eb7c32b1/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc2565e487b4896fb988d6383577d875d958e071fc5f6c3550bd5d02ae98264b", size = 17051950, upload-time = "2026-07-25T01:21:48.606Z" },
+    { url = "https://files.pythonhosted.org/packages/03/88/9432428273356ad3c8aa01f52c1b3e7f53c4c0192748f41ad983872b436b/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6afdc83f1317c136e92fc29f5ee9f058de59d87c0b22cee3fdbfbaa0ccc2098a", size = 19214924, upload-time = "2026-07-25T01:22:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/e2/6feb3a43517aaf2b1bf7e46897ba5eb81a29717f7d7901420614d5ee4653/onnxruntime-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:f2a3b9e30ce880d4ca54999cb313569e36da4f62eefe25f87be18f43e9a3a4d5", size = 14093738, upload-time = "2026-07-25T01:22:31.629Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8f/83974a1e201dc2e58e5e7111bcaeb1ca2413e9c41f505d26419ee9e3dddf/onnxruntime-1.28.0-cp314-cp314-win_arm64.whl", hash = "sha256:07fb3cbe990d6bf0ab3c22bfbbfb0e314151266046ea6edb4a07f556b4258c5f", size = 13821117, upload-time = "2026-07-25T01:22:22.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/83/00e606bc25c756d76a267370c39b7516ad52f9cf134d7ff2bff8b6108bc4/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e562d6e36a749f6764481c0ddb0f2af3d0b5a3c164291361d08803c557f369af", size = 17055518, upload-time = "2026-07-25T01:21:51.08Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a9/68707e1ce345cbdbcd4df65932ebc82a673e917d63eda0007ebcff948691/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f6e92367ddce1e4d33cf295024f40192be6c6171a09208f515ba169ced06c8e", size = 19222976, upload-time = "2026-07-25T01:22:12.474Z" },
 ]
 
 [[package]]
 name = "onnxscript"
-version = "0.5.0"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "ml-dtypes", version = "0.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy" },
-    { name = "onnx", version = "1.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "onnx", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "onnx" },
     { name = "onnx-ir" },
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/2f/0bb2b6ca727e4d5173f640527f402ab4225def4bc8d667269b83047be8c4/onnxscript-0.5.0.tar.gz", hash = "sha256:4aba215e1f80fbcd07ba0d97d6bca96797fc3e9639eacb5434d35317ce1406aa", size = 588762, upload-time = "2025-09-12T16:57:46.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/3a/4d79bce3f460e0df7fed54a92ce80827f25da66511da368bb00783ad8d20/onnxscript-0.7.1.tar.gz", hash = "sha256:309fb86484b11fa4ded90dba580e0d63f1a0827588e521cecaf2eeddb46d6e86", size = 618160, upload-time = "2026-06-29T23:33:21.526Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/f7/f0eb0b10771637a8c176a3b0594c65c5ba3cea440847741297901cef2c5e/onnxscript-0.5.0-py3-none-any.whl", hash = "sha256:da33715ac8ec80e0263a5200f1ad1b3532225804c05a13a0d6ea83712b5b4a8f", size = 684685, upload-time = "2025-09-12T16:57:48.869Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/bd/a0c8e737b6afda10e42a597787d53d5b66e00268df6f59184701eeae37d9/onnxscript-0.7.1-py3-none-any.whl", hash = "sha256:544763b7fdef49940cdd9412ff5135cbae96d59ac6bc1921457f21280f40f4b7", size = 721970, upload-time = "2026-06-29T23:33:23.298Z" },
 ]
 
 [[package]]
@@ -1758,7 +1899,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -2148,7 +2290,8 @@ dependencies = [
     { name = "fastprogress" },
     { name = "huggingface-hub" },
     { name = "matplotlib" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pillow" },
     { name = "torch" },
     { name = "torchvision" },
@@ -2175,8 +2318,7 @@ scripts = [
     { name = "onnxscript" },
 ]
 test = [
-    { name = "onnx", version = "1.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "onnx", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "onnx" },
     { name = "onnxscript" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -2209,7 +2351,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = "==6.2.1" },
     { name = "pytest-pretty", marker = "extra == 'test'", specifier = "==1.3.0" },
     { name = "ruff", marker = "extra == 'quality'", specifier = "==0.16.0" },
-    { name = "torch", specifier = ">=2.0.0,<3.0.0" },
+    { name = "torch", specifier = ">=2.9.0,<3.0.0" },
     { name = "torchvision", specifier = ">=0.24.0,<1.0.0" },
     { name = "tqdm", specifier = ">=4.1.0" },
     { name = "ty", marker = "extra == 'quality'", specifier = "==0.0.65" },
@@ -2251,15 +2393,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
-]
-
-[[package]]
-name = "pyreadline3"
-version = "3.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
 ]
 
 [[package]]
@@ -2690,94 +2823,78 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.9.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/fe/334225e6330e672b36aef23d77451fa906ea12881570c08638a91331a212/torch-2.9.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c596708b5105d0b199215acf0c9be7c1db5f1680d88eddadf4b75a299259a677", size = 104230578, upload-time = "2025-10-15T15:46:08.182Z" },
-    { url = "https://files.pythonhosted.org/packages/05/cc/49566caaa218872ec9a2912456f470ff92649894a4bc2e5274aa9ef87c4a/torch-2.9.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:51de31219c97c51cf4bf2be94d622e3deb5dcc526c6dc00e97c17eaec0fc1d67", size = 899815990, upload-time = "2025-10-15T15:48:03.336Z" },
-    { url = "https://files.pythonhosted.org/packages/74/25/e9ab21d5925b642d008f139d4a3c9664fc9ee1faafca22913c080cc4c0a5/torch-2.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd515c70059afd95f48b8192733764c08ca37a1d19803af6401b5ecad7c8676e", size = 109313698, upload-time = "2025-10-15T15:46:12.425Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/b7/205ef3e94de636feffd64b28bb59a0dfac0771221201b9871acf9236f5ca/torch-2.9.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:614a185e4986326d526a91210c8fc1397e76e8cfafa78baf6296a790e53a9eec", size = 74463678, upload-time = "2025-10-15T15:46:29.779Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/d3/3985739f3b8e88675127bf70f82b3a48ae083e39cda56305dbd90398fec0/torch-2.9.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e5f7af1dc4c0a7c4a260c2534f41ddaf209714f7c89145e644c44712fbd6b642", size = 104107898, upload-time = "2025-10-15T15:46:20.883Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/4b/f4bb2e6c25d0272f798cd6d7a04ed315da76cec68c602d87040c7847287f/torch-2.9.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:01cff95ecd9a212ea2f141db28acccdceb6a4c54f64e6c51091146f5e2a772c6", size = 899738273, upload-time = "2025-10-15T15:50:04.188Z" },
-    { url = "https://files.pythonhosted.org/packages/66/11/c1c5ba6691cda6279087c35bd626536e4fd29521fe740abf5008377a9a02/torch-2.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4582b162f541651f0cb184d3e291c05c2f556c7117c64a9873e2ee158d40062b", size = 109280887, upload-time = "2025-10-15T15:46:26.228Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/5f/b85bd8c05312d71de9402bf5868d217c38827cfd09d8f8514e5be128a52b/torch-2.9.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:33f58e9a102a91259af289d50525c30323b5c9ae1d31322b6447c0814da68695", size = 74478983, upload-time = "2025-10-15T15:46:39.406Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/1c/90eb13833cdf4969ea9707586d7b57095c3b6e2b223a7256bf111689bcb8/torch-2.9.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c30a17fc83eeab346913e237c64b15b5ba6407fff812f6c541e322e19bc9ea0e", size = 104111330, upload-time = "2025-10-15T15:46:35.238Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/21/2254c54b8d523592c25ef4434769aa23e29b1e6bf5f4c0ad9e27bf442927/torch-2.9.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8f25033b8667b57857dfd01458fbf2a9e6a6df1f8def23aef0dc46292f6aa642", size = 899750243, upload-time = "2025-10-15T15:48:57.459Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a5/5cb94fa4fd1e78223455c23c200f30f6dc10c6d4a2bcc8f6e7f2a2588370/torch-2.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:d037f1b4ffd25013be4a7bf3651a0a910c68554956c7b2c92ebe87c76475dece", size = 109284513, upload-time = "2025-10-15T15:46:45.061Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e8/fc414d8656250ee46120b44836ffbb3266343db424b3e18ca79ebbf69d4f/torch-2.9.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e4e5b5cba837a2a8d1a497ba9a58dae46fa392593eaa13b871c42f71847503a5", size = 74830362, upload-time = "2025-10-15T15:46:48.983Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/5f/9474c98fc5ae0cd04b9466035428cd360e6611a86b8352a0fc2fa504acdc/torch-2.9.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:64693568f5dc4dbd5f880a478b1cea0201cc6b510d91d1bc54fea86ac5d1a637", size = 104144940, upload-time = "2025-10-15T15:47:29.076Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5a/8e0c1cf57830172c109d4bd6be2708cabeaf550983eee7029291322447a0/torch-2.9.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:f8ed31ddd7d10bfb3fbe0b9fe01b1243577f13d75e6f4a0839a283915ce3791e", size = 899744054, upload-time = "2025-10-15T15:48:29.864Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/28/82c28b30fcb4b7c9cdd995763d18bbb830d6521356712faebbad92ffa61d/torch-2.9.0-cp313-cp313t-win_amd64.whl", hash = "sha256:eff527d4e4846e6f70d2afd8058b73825761203d66576a7e04ea2ecfebcb4ab8", size = 109517546, upload-time = "2025-10-15T15:47:33.395Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/c3/a91f96ec74347fa5fd24453fa514bc61c61ecc79196fa760b012a1873d96/torch-2.9.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:f8877779cf56d1ce431a7636703bdb13307f5960bb1af49716d8b179225e0e6a", size = 74480732, upload-time = "2025-10-15T15:47:38.002Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/73/9f70af34b334a7e0ef496ceec96b7ec767bd778ea35385ce6f77557534d1/torch-2.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e614fae699838038d888729f82b687c03413c5989ce2a9481f9a7e7a396e0bb", size = 74433037, upload-time = "2025-10-15T15:47:41.894Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/84/37cf88625901934c97109e583ecc21777d21c6f54cda97a7e5bbad1ee2f2/torch-2.9.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:dfb5b8cd310ba3436c7e14e8b7833ef658cf3045e50d2bdaed23c8fc517065eb", size = 104116482, upload-time = "2025-10-15T15:47:46.266Z" },
-    { url = "https://files.pythonhosted.org/packages/56/8e/ca8b17866943a8d4f4664d402ea84210aa274588b4c5d89918f5caa24eec/torch-2.9.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b3d29524993a478e46f5d598b249cd824b7ed98d7fba538bd9c4cde6c803948f", size = 899746916, upload-time = "2025-10-15T15:50:40.294Z" },
-    { url = "https://files.pythonhosted.org/packages/43/65/3b17c0fbbdab6501c5b320a52a648628d0d44e7379f64e27d9eef701b6bf/torch-2.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:71c7578984f5ec0eb645eb4816ac8435fcf3e3e2ae1901bcd2f519a9cafb5125", size = 109275151, upload-time = "2025-10-15T15:49:20.715Z" },
-    { url = "https://files.pythonhosted.org/packages/83/36/74f8c051f785500396e42f93542422422dfd874a174f21f8d955d36e5d64/torch-2.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:71d9309aee457bbe0b164bce2111cd911c4ed4e847e65d5077dbbcd3aba6befc", size = 74823353, upload-time = "2025-10-15T15:49:16.59Z" },
-    { url = "https://files.pythonhosted.org/packages/62/51/dc3b4e2f9ba98ae27238f0153ca098bf9340b2dafcc67fde645d496dfc2a/torch-2.9.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c08fb654d783899e204a32cca758a7ce8a45b2d78eeb89517cc937088316f78e", size = 104140340, upload-time = "2025-10-15T15:50:19.67Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/8d/b00657f8141ac16af7bb6cda2e67de18499a3263b78d516b9a93fcbc98e3/torch-2.9.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ec8feb0099b2daa5728fbc7abb0b05730fd97e0f359ff8bda09865aaa7bd7d4b", size = 899731750, upload-time = "2025-10-15T15:49:36.673Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/29/bd361e0cbb2c79ce6450f42643aaf6919956f89923a50571b0ebfe92d142/torch-2.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:695ba920f234ad4170c9c50e28d56c848432f8f530e6bc7f88fcb15ddf338e75", size = 109503850, upload-time = "2025-10-15T15:50:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.24.0"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pillow" },
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/17/54ed2ec6944ea972b461a86424c8c7f98835982c90cbc45bf59bd962863a/torchvision-0.24.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f771cf918351ad509a28488be475f3e9cc71a750d6b1467842bfb64863a5e986", size = 1891719, upload-time = "2025-10-15T15:51:10.384Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/07/0cd6776eee784742ad3cb2bfd3295383d84cb2f9e87386119333d1587f0f/torchvision-0.24.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbd63bf4ebff84c48c50123eba90526cc9f794fe45bc9f5dd07cec19e8c62bce", size = 2420513, upload-time = "2025-10-15T15:51:18.087Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/f4/6026c08011ddcefcbc14161c5aa9dce55c35c6b045e04ef0952e88bf4594/torchvision-0.24.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:78fe414b3bb6dbf7e6f6da6f733ba96881f6b29a9b997228de7c5f603e5ed940", size = 8048018, upload-time = "2025-10-15T15:51:13.579Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/b4/362b4e67ed87cee0fb4f8f0363a852eaeef527968bf62c07ed56f764d729/torchvision-0.24.0-cp311-cp311-win_amd64.whl", hash = "sha256:629584b94e52f32a6278f2a35d85eeaae95fcc38730fcb765064f26c3c96df5d", size = 4027686, upload-time = "2025-10-15T15:51:19.189Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ef/81e4e69e02e2c4650b30e8c11c8974f946682a30e0ab7e9803a831beff76/torchvision-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c61d40bcd2e2451e932902a702ad495ba1ec6f279e90b1e15cef2bb55dc911e2", size = 1891726, upload-time = "2025-10-15T15:51:16.977Z" },
-    { url = "https://files.pythonhosted.org/packages/00/7b/e3809b3302caea9a12c13f3adebe4fef127188438e719fd6c8dc93db1da6/torchvision-0.24.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b0531d1483fc322d7da0d83be52f0df860a75114ab87dbeeb9de765feaeda843", size = 2419495, upload-time = "2025-10-15T15:51:11.885Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/e6/7324ead6793075a8c75c56abeed1236d1750de16a5613cfe2ddad164a92a/torchvision-0.24.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:26b9dd9c083f8e5f7ac827de6d5b88c615d9c582dc87666770fbdf16887e4c25", size = 8050480, upload-time = "2025-10-15T15:51:24.012Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/ad/3c56fcd2a0d6e8afa80e115b5ade4302232ec99655220a51d05709819523/torchvision-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:060b7c50ed4b3fb0316b08e2e31bfd874ec2f63ef5ae02f81e54341ca4e88703", size = 4292225, upload-time = "2025-10-15T15:51:27.699Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b5/b2008e4b77a8d6aada828dd0f6a438d8f94befa23fdd2d62fa0ac6e60113/torchvision-0.24.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:84d79cfc6457310107ce4d712de7a3d388b24484bc9aeded4a76d8f8e3a2813d", size = 1891722, upload-time = "2025-10-15T15:51:28.854Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/02/e2f6b0ff93ca4db5751ac9c5be43f13d5e53d9e9412324f464dca1775027/torchvision-0.24.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fec12a269cf80f6b0b71471c8d498cd3bdd9d8e892c425bf39fecb604852c3b0", size = 2371478, upload-time = "2025-10-15T15:51:37.842Z" },
-    { url = "https://files.pythonhosted.org/packages/77/85/42e5fc4f716ec7b73cf1f32eeb5c77961be4d4054b26cd6a5ff97f20c966/torchvision-0.24.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7323a9be5e3da695605753f501cdc87824888c5655d27735cdeaa9986b45884c", size = 8050200, upload-time = "2025-10-15T15:51:46.276Z" },
-    { url = "https://files.pythonhosted.org/packages/93/c2/48cb0b6b26276d2120b1e0dbc877579a748eae02b4091a7522ce54f6d5e1/torchvision-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:08cad8b204196e945f0b2d73adee952d433db1c03645851d52b22a45f1015b13", size = 4309939, upload-time = "2025-10-15T15:51:39.002Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/d7/3dd10830b047eeb46ae6b465474258d7b4fbb7d8872dca69bd42449f5c82/torchvision-0.24.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6ab956a6e588623353e0f20d4b03eb1656cb4a3c75ca4dd8b4e32e01bc43271a", size = 2028355, upload-time = "2025-10-15T15:51:22.384Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/cf/2d7e43409089ce7070f5336161f9216d58653ee1cb26bcb5d6c84cc2de36/torchvision-0.24.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:b1b3db80609c32a088554e8e94b4fc31f1033fe5bb4ac0673ec49c3eb03fb4da", size = 2374466, upload-time = "2025-10-15T15:51:35.382Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/30/8f7c328fd7e0a9665da4b6b56b1c627665c18470bfe62f3729ad3eda9aec/torchvision-0.24.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:e6635f100d455c80b43f297df4b8585a76c6a2e114802f6567ddd28d7b5479b0", size = 8217068, upload-time = "2025-10-15T15:51:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/55/a2/b6f9e40e2904574c80b3bb872c66af20bbd642053e7c8e1b9e99ab396535/torchvision-0.24.0-cp313-cp313t-win_amd64.whl", hash = "sha256:4ce158bbdc3a9086034bced0b5212888bd5b251fee6d08a9eff151d30b4b228a", size = 4273912, upload-time = "2025-10-15T15:51:33.866Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/24/790a39645cc8c71bf442d54a76da9bda5caeb2a44c5f7e02498649cd99d4/torchvision-0.24.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4bdfc85a5ed706421555f32cdc5e3ddb6d40bf65ef03a274ce3c176393e2904b", size = 2028335, upload-time = "2025-10-15T15:51:26.252Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d7/69479a066ea773653e88eda99031e38681e9094046f87cb957af5036db0e/torchvision-0.24.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:73576a9c4a593223fbae85a64e8bbd77049abd1101893ecf3c5e981284fd58b4", size = 2371609, upload-time = "2025-10-15T15:51:29.859Z" },
-    { url = "https://files.pythonhosted.org/packages/46/64/3c7fdb3771ec992b9445a1f7a969466b23ce2cdb14e09303b3db351a0655/torchvision-0.24.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:dd565b1b06666ff399d0801d4d1824fa570c0167a179ca700a5be232527b3c62", size = 8214918, upload-time = "2025-10-15T15:51:41.465Z" },
-    { url = "https://files.pythonhosted.org/packages/58/51/abc416bc34d574ad479af738e413d9ebf93027ee92d0f4ae38f966b818f7/torchvision-0.24.0-cp314-cp314-win_amd64.whl", hash = "sha256:eb45d12ac48d757738788fd3fb8e88e647d6b2ab2424134ca87556efc72d81b5", size = 4257776, upload-time = "2025-10-15T15:51:42.642Z" },
-    { url = "https://files.pythonhosted.org/packages/08/f7/261d1353c611820541ecd43046b89da3f1ae998dc786e4288b890a009883/torchvision-0.24.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:68120e7e03c31900e499a10bb7fdd63cfd67f0054c9fa108e7e27f9cd372f315", size = 2028359, upload-time = "2025-10-15T15:51:32.119Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/fd/615d8a86db1578345de7fa1edaf476fbcf4f057bf7e4fd898306b620c487/torchvision-0.24.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:64e54494043eecf9f57a9881c6fdea49c62282782e737c002ae8b1639e6ea80e", size = 2374469, upload-time = "2025-10-15T15:51:40.19Z" },
-    { url = "https://files.pythonhosted.org/packages/04/98/bac11e8fdbf00d6c398246ff2781370aa72c99f2ac685c01ce79354c9a32/torchvision-0.24.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:75ef9546323b321a451239d886f0cb528f7e98bb294da47a3200effd4e572064", size = 8217060, upload-time = "2025-10-15T15:51:45.033Z" },
-    { url = "https://files.pythonhosted.org/packages/47/6f/9fba8abc468c904570699eceeb51588f9622172b8fffa4ab11bcf15598c2/torchvision-0.24.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2efb617667950814fc8bb9437e5893861b3616e214285be33cbc364a3f42c599", size = 4358490, upload-time = "2025-10-15T15:51:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b2/1e010052079e4c577007b789db336ea7075f1a426e84d17121fbc3745516/torchvision-0.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83fe6c020866a85acd7d97deccc45ff11d66daf42916d04396a4309c66c0ccb8", size = 1856017, upload-time = "2026-07-08T16:07:55.533Z" },
+    { url = "https://files.pythonhosted.org/packages/27/be/1b9c5de9c655ca2df4a74100fa671a7b848532ff787e077ccde14a7dea2a/torchvision-0.28.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5a38bc6da3d72621be003400b66f66a2b4c6d644fde05f680c2cb7ca8cf8dd6c", size = 7841822, upload-time = "2026-07-08T16:07:49.207Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/9b/f1e68e861d4462e3e195a642c2b448e7b7d3fad5f209487162b9a2133d9b/torchvision-0.28.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7e80f543b22503d9415e126db5f0ff3917036925e38560ee6b9ae38c571a4002", size = 7670718, upload-time = "2026-07-08T16:07:46.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/1494610ff54cbb154beb55033cc2cd50f3de04dac132fa2dd00e4f2b2556/torchvision-0.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:9a45ea67235d965ef52187130d20002a4de20c54ea3d927a24286961d268dc37", size = 3814319, upload-time = "2026-07-08T16:07:37.153Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4c/95233776e2def960e5abb7a07931230a545f43717a56a1e1140162033598/torchvision-0.28.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5cf78ebc401ce64ae19b8c55de866bb836797d559a4de9c25ccbe74cfa642d3a", size = 7842127, upload-time = "2026-07-08T16:07:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e4/e9b2495d0d57b9f60d63c57d0a910410a81b4b073bf70917bef815291119/torchvision-0.28.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:028a3d481b37d785605620d7cdad897064c5a55bae2aa1f2658766333e291940", size = 7675040, upload-time = "2026-07-08T16:07:58.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9c/55ed9cb6dfe3ee9c837df5cd0e758372e5829aa38b8dd71343aa632cc4e2/torchvision-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:87dc16b2df427c1318ad335f1e2be2b3b15b2cf20f7934c83b0505a48425ee5d", size = 4085785, upload-time = "2026-07-08T16:07:50.928Z" },
+    { url = "https://files.pythonhosted.org/packages/20/55/08a726c14c67b37c8aca04b077766909f1c7ed23f76116884fe63b9bd033/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d483b4aa3f5237569053f749cd1a2b5bb548ca456e40461a5dd087f21149d123", size = 1856021, upload-time = "2026-07-08T16:07:45.386Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/40beacd53809194f5259e590d1afaeaa8ad57da15f77c646e6560bcc4616/torchvision-0.28.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bb6dd6918460ed89cc7644adcc2402991474d6933cf1ce92b390641cb233fddf", size = 7797014, upload-time = "2026-07-08T16:07:43.04Z" },
+    { url = "https://files.pythonhosted.org/packages/32/db/062cdb5a84380a60439775311fff34d89229760d2a50680393dc18699956/torchvision-0.28.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad7b3a439265cc3739a4ab5b4c998c0e38ea99c0ee7ca4dea35c5d0b099ec237", size = 7674669, upload-time = "2026-07-08T16:07:38.91Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a6/b4081e2d04e1541abf82785ac9e5178a494c19330391f551356c8c18b7b3/torchvision-0.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:7e9dd6f60d6e15f8dc27d4f877fdb6002fc70d70272412135f1c2ff9cfa08d3b", size = 4157380, upload-time = "2026-07-08T16:07:40.22Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b9/da40eca5bbe9596c12ae9899ab7abaf887f5e20f29d08b924b4633714821/torchvision-0.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3bd9dba55224a9db4a2d77f6feaa5651770d8c8e86d3d0ddb0fa6bec54c8712b", size = 1856014, upload-time = "2026-07-08T16:07:44.282Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d6/313aafd3df4eaf5f330211bd4e75b7598bddbfee4f55580d3b58536e1b20/torchvision-0.28.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:89f90e29b0966352811b12589f3a3c61943bf2bb9487b9d7bbec10efb1096bb5", size = 7796873, upload-time = "2026-07-08T16:07:30.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/41/31f8e959ab8f942600b6357f8999c21d779d5fd3304b0fd204ff4b518239/torchvision-0.28.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:36beb0782976906069ca03d4c9aacaf4b6b838b06ed6c20960ea9c51cce7acdd", size = 7674634, upload-time = "2026-07-08T16:07:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/15/15/4c5115253fd470672cdac0a1cf139e06b4f3e29d041238a2b255937f63be/torchvision-0.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:3557cc7b539f46dabcda2b6f2b14017ccbeef024de466d4fc5835fc3f287f769", size = 4184005, upload-time = "2026-07-08T16:07:35.805Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/80/822a6163da716f8a78141cf6678d74e26a572285d4ea866ef8aa657bb307/torchvision-0.28.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:09ce8f56e81f19b9c378ae7bb109f83f6659fd8bc3cd14241a48e4af46e9ed49", size = 1856011, upload-time = "2026-07-08T16:07:33.404Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d1/cd3f9463b39a790ec8c0c2f6e6c8061edb1562114d04fcdfa786ed889345/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:62c7d110f86a039245b587e4fae60278c649f3bd42ff79cfbc1178eca4e72542", size = 7796742, upload-time = "2026-07-08T16:07:28.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/3e0a7ad18e99831e2d7f4713d3be717b7159ff5a920862dd5c23c454aa71/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:904cf89af220f8c6b2ed0296bb5065b474ce43b77558e48b2bf9de8b0ba17204", size = 7675526, upload-time = "2026-07-08T16:07:34.572Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/23aea03b28297bc66a4461f55ae4296368a9d85fa9a454bafcb2a5348bd7/torchvision-0.28.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46f581979c010ad6da6bd85ee602aa707e1ff44312670223b7a0ee517ad06d47", size = 4291452, upload-time = "2026-07-08T16:07:32.236Z" },
 ]
 
 [[package]]
@@ -2794,15 +2911,19 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.5.0"
+version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/78/949a04391c21956c816523678f0e5fa308eb5b1e7622d88c4e4ef5fceca0/triton-3.5.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f34bfa21c5b3a203c0f0eab28dcc1e49bd1f67d22724e77fb6665a659200a4ec", size = 170433488, upload-time = "2025-10-13T16:37:57.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/3a/e991574f3102147b642e49637e0281e9bb7c4ba254edb2bab78247c85e01/triton-3.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9e71db82261c4ffa3921cd050cd5faa18322d2d405c30eb56084afaff3b0833", size = 170476535, upload-time = "2025-10-13T16:38:05.18Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/29/10728de8a6e932e517c10773486b8e99f85d1b1d9dd87d9a9616e1fef4a1/triton-3.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e6bb9aa5519c084a333acdba443789e50012a4b851cd486c54f0b8dc2a8d3a12", size = 170487289, upload-time = "2025-10-13T16:38:11.662Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/38/db80e48b9220c9bce872b0f616ad0446cdf554a40b85c7865cbca99ab3c2/triton-3.5.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c83f2343e1a220a716c7b3ab9fccfcbe3ad4020d189549200e2d2e8d5868bed9", size = 170577179, upload-time = "2025-10-13T16:38:17.865Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/60/1810655d1d856c9a4fcc90ee8966d85f552d98c53a6589f95ab2cbe27bb8/triton-3.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da0fa67ccd76c3dcfb0bffe1b1c57c685136a6bd33d141c24d9655d4185b1289", size = 170487949, upload-time = "2025-10-13T16:38:24.881Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/b7/1dec8433ac604c061173d0589d99217fe7bf90a70bdc375e745d044b8aad/triton-3.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:317fe477ea8fd4524a6a8c499fb0a36984a56d0b75bf9c9cb6133a1c56d5a6e7", size = 170580176, upload-time = "2025-10-13T16:38:31.14Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2157,6 +2157,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pycocotools"
+version = "2.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/df/32354b5dda963ffdfc8f75c9acf8828ef7890723a4ed57bb3ff2dc1d6f7e/pycocotools-2.0.11.tar.gz", hash = "sha256:34254d76da85576fcaf5c1f3aa9aae16b8cb15418334ba4283b800796bd1993d", size = 25381, upload-time = "2025-12-15T22:31:46.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/3f/41ce3fce61b7721158f21b61727eb054805babc0088cfa48506935b80a36/pycocotools-2.0.11-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:81bdceebb4c64e9265213e2d733808a12f9c18dfb14457323cc6b9af07fa0e61", size = 158947, upload-time = "2025-12-15T22:31:03.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9b/a739705b246445bd1376394bf9d1ec2dd292b16740e92f203461b2bb12ed/pycocotools-2.0.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c05f91ccc658dfe01325267209c4b435da1722c93eeb5749fabc1d087b6882", size = 485174, upload-time = "2025-12-15T22:31:04.395Z" },
+    { url = "https://files.pythonhosted.org/packages/34/70/7a12752784e57d8034a76c245c618a2f88a9d2463862b990f314aea7e5d6/pycocotools-2.0.11-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18ba75ff58cedb33a85ce2c18f1452f1fe20c9dd59925eec5300b2bf6205dbe1", size = 493172, upload-time = "2025-12-15T22:31:05.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fc/d703599ac728209dba08aea8d4bee884d5adabfcd9041abed1658d863747/pycocotools-2.0.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:693417797f0377fd094eb815c0a1e7d1c3c0251b71e3b3779fce3b3cf24793c5", size = 480506, upload-time = "2025-12-15T22:31:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d9/e1cfc320bbb2cd58c3b4398c3821cbe75d93c16ed3135ac9e774a18a02d3/pycocotools-2.0.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b6a07071c441d0f5e480a8f287106191582e40289d4e242dfe684e0c8a751088", size = 497595, upload-time = "2025-12-15T22:31:08.277Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/d17f6111c2a6ae8631d4fa90202bea05844da715d61431fbc34d276462d5/pycocotools-2.0.11-cp311-cp311-win_amd64.whl", hash = "sha256:8e159232adae3aef6b4e2d37b008bff107b26e9ed3b48e70ea6482302834bd34", size = 80519, upload-time = "2025-12-15T22:31:09.613Z" },
+    { url = "https://files.pythonhosted.org/packages/00/4c/76b00b31a724c3f5ccdab0f85e578afb2ca38d33be0a0e98f1770cafd958/pycocotools-2.0.11-cp311-cp311-win_arm64.whl", hash = "sha256:4fc9889e819452b9c142036e1eabac8a13a8bd552d8beba299a57e0da6bfa1ec", size = 69304, upload-time = "2025-12-15T22:31:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/87/12/2f2292332456e4e4aba1dec0e3de8f1fc40fb2f4fdb0ca1cb17db9861682/pycocotools-2.0.11-cp312-abi3-macosx_10_13_universal2.whl", hash = "sha256:a2e9634bc7cadfb01c88e0b98589aaf0bd12983c7927bde93f19c0103e5441f4", size = 147795, upload-time = "2025-12-15T22:31:11.519Z" },
+    { url = "https://files.pythonhosted.org/packages/63/3c/68d7ea376aada9046e7ea2d7d0dad0d27e1ae8b4b3c26a28346689390ab2/pycocotools-2.0.11-cp312-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fd4121766cc057133534679c0ec3f9023dbd96e9b31cf95c86a069ebdac2b65", size = 398434, upload-time = "2025-12-15T22:31:12.558Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/dc81895beff4e1207a829d40d442ea87cefaac9f6499151965f05c479619/pycocotools-2.0.11-cp312-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a82d1c9ed83f75da0b3f244f2a3cf559351a283307bd9b79a4ee2b93ab3231dd", size = 411685, upload-time = "2025-12-15T22:31:13.995Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0b/5a8a7de300862a2eb5e2ecd3cb015126231379206cd3ebba8f025388d770/pycocotools-2.0.11-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:89e853425018e2c2920ee0f2112cf7c140a1dcf5f4f49abd9c2da112c3e0f4b3", size = 390500, upload-time = "2025-12-15T22:31:15.138Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b5/519bb68647f06feea03d5f355c33c05800aeae4e57b9482b2859eb00752e/pycocotools-2.0.11-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:87af87b8d06d5b852a885a319d9362dca3bed9f8bbcc3feb6513acb1f88ea242", size = 409790, upload-time = "2025-12-15T22:31:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/83/b4/f6708404ff494706b80e714b919f76dc4ec9845a4007affd6d6b0843f928/pycocotools-2.0.11-cp312-abi3-win_amd64.whl", hash = "sha256:ffe806ce535f5996445188f9a35643791dc54beabc61bd81e2b03367356d604f", size = 77570, upload-time = "2025-12-15T22:31:17.703Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/63/778cd0ddc9d4a78915ac0a72b56d7fb204f7c3fabdad067d67ea0089762e/pycocotools-2.0.11-cp312-abi3-win_arm64.whl", hash = "sha256:c230f5e7b14bd19085217b4f40bba81bf14a182b150b8e9fab1c15d504ade343", size = 64564, upload-time = "2025-12-15T22:31:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/31c81e99d596a20c137d8a2e7a25f39a88f88fada5e0b253fce7323ecf0d/pycocotools-2.0.11-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fd72b9734e6084b217c1fc3945bfd4ec05bdc75a44e4f0c461a91442bb804973", size = 168931, upload-time = "2025-12-15T22:31:19.845Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/63/fdd488e4cd0fdc6f93134f2cd68b1fce441d41566e86236bf6156961ef9b/pycocotools-2.0.11-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7eb43b79448476b094240450420b7425d06e297880144b8ea6f01e9b4340e43", size = 484856, upload-time = "2025-12-15T22:31:21.231Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fc/c83648a8fb7ea3b8e2ce2e761b469807e6cadb81577bf1af31c4f2ef0d87/pycocotools-2.0.11-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3546b93b39943347c4f5b0694b5824105cbe2174098a416bcad4acd9c21e957", size = 480994, upload-time = "2025-12-15T22:31:22.426Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2d/35e1122c0d007288aa9545be9549cbc7a4987b2c22f21d75045260a8b5b8/pycocotools-2.0.11-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:efd1694b2075f2f10c5828f10f6e6c4e44368841fd07dae385c3aa015c8e25f9", size = 467956, upload-time = "2025-12-15T22:31:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ff/30cfe8142470da3e45abe43a9842449ca0180d993320559890e2be19e4a5/pycocotools-2.0.11-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:368244f30eb8d6cae7003aa2c0831fbdf0153664a32859ec7fbceea52bfb6878", size = 474658, upload-time = "2025-12-15T22:31:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/62/254ca92604106c7a5af3258e589e465e681fe0166f9b10f97d8ca70934d6/pycocotools-2.0.11-cp313-cp313t-win_amd64.whl", hash = "sha256:ac8aa17263e6489aa521f9fa91e959dfe0ea3a5519fde2cbf547312cdce7559e", size = 89681, upload-time = "2025-12-15T22:31:26.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f0/c019314dc122ad5e6281de420adc105abe9b59d00008f72ef3ad32b1e328/pycocotools-2.0.11-cp313-cp313t-win_arm64.whl", hash = "sha256:04480330df5013f6edd94891a0ee8294274185f1b5093d1b0f23d51778f0c0e9", size = 70520, upload-time = "2025-12-15T22:31:26.999Z" },
+    { url = "https://files.pythonhosted.org/packages/66/2b/58b35c88f2086c043ff1c87bd8e7bf36f94e84f7b01a5e00b6f5fabb92a7/pycocotools-2.0.11-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a6b13baf6bfcf881b6d6ac6e23c776f87a68304cd86e53d1d6b9afa31e363c4e", size = 169883, upload-time = "2025-12-15T22:31:28.233Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c0/b970eefb78746c8b4f8b3fa1b49d9f3ec4c5429ef3c5d4bbcc55abebe478/pycocotools-2.0.11-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78bae4a9de9d34c4759754a848dfb3306f9ef1c2fcb12164ffbd3d013d008321", size = 486894, upload-time = "2025-12-15T22:31:29.283Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f7/db7436820a1948d96fa9764b6026103e808840979be01246049f2c1e7f94/pycocotools-2.0.11-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83d896f4310379849dfcfa7893afb0ff21f4f3cdb04ab3f61b05dd98953dd0ad", size = 483249, upload-time = "2025-12-15T22:31:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a6/a14a12c9f50c41998fdc0d31fd3755bcbce124bac9abb1d6b99d1853cafd/pycocotools-2.0.11-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:eebd723503a2eb2c8b285f56ea3be1d9f3875cd7c40d945358a428db94f14015", size = 469070, upload-time = "2025-12-15T22:31:32.821Z" },
+    { url = "https://files.pythonhosted.org/packages/46/de/aa4f65ece3da8e89310a1be00cad0700170fd13f41a3aaae2712291269d5/pycocotools-2.0.11-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bd7a1e19ef56a828a94bace673372071d334a9232cd32ae3cd48845a04d45c4f", size = 475589, upload-time = "2025-12-15T22:31:34.188Z" },
+    { url = "https://files.pythonhosted.org/packages/44/6f/04a30df03ae6236b369b361df0c50531d173d03678978806aa2182e02d1e/pycocotools-2.0.11-cp314-cp314t-win_amd64.whl", hash = "sha256:63026e11a56211058d0e84e8263f74cbccd5e786fac18d83fd221ecb9819fcc7", size = 93863, upload-time = "2025-12-15T22:31:35.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/05/8942b640d6307a21c3ede188e8c56f07bedf246fac0e501437dbda72a350/pycocotools-2.0.11-cp314-cp314t-win_arm64.whl", hash = "sha256:8cedb8ccb97ffe9ed2c8c259234fa69f4f1e8665afe3a02caf93f6ef2952c07f", size = 72038, upload-time = "2025-12-15T22:31:36.768Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -2284,7 +2324,7 @@ wheels = [
 
 [[package]]
 name = "pylocron"
-version = "0.2.2.dev0"
+version = "0.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fastprogress" },
@@ -2306,6 +2346,9 @@ docs = [
     { name = "mkdocs-material", extra = ["imaging"] },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+evaluation = [
+    { name = "pycocotools" },
+]
 quality = [
     { name = "prek" },
     { name = "ruff" },
@@ -2320,6 +2363,7 @@ scripts = [
 test = [
     { name = "onnx" },
     { name = "onnxscript" },
+    { name = "pycocotools" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-pretty" },
@@ -2347,6 +2391,8 @@ requires-dist = [
     { name = "onnxscript", marker = "extra == 'test'", specifier = ">=0.5.0,<1.0.0" },
     { name = "pillow", specifier = ">=12.3.0,<13.0.0" },
     { name = "prek", marker = "extra == 'quality'", specifier = "==0.4.11" },
+    { name = "pycocotools", marker = "extra == 'evaluation'", specifier = ">=2.0.11,<3.0.0" },
+    { name = "pycocotools", marker = "extra == 'test'", specifier = ">=2.0.11,<3.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.3" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = "==6.2.1" },
     { name = "pytest-pretty", marker = "extra == 'test'", specifier = "==1.3.0" },
@@ -2359,7 +2405,7 @@ requires-dist = [
     { name = "types-tqdm", marker = "extra == 'quality'" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.10.31,<1.0.0" },
 ]
-provides-extras = ["test", "training", "quality", "scripts", "docs"]
+provides-extras = ["test", "training", "evaluation", "quality", "scripts", "docs"]
 
 [[package]]
 name = "pymdown-extensions"


### PR DESCRIPTION
## Summary

Make Holocron v0.3 a trustworthy computer-vision research workbench:

- discover models and checkpoint maturity through a public catalog
- train with atomic full-state checkpoints, exact resume, `RunResult`, and schema-v1 run bundles
- repair YOLOv4 training correctness and report COCO AP through optional `pycocotools`
- expose a consistent classifier feature-extraction interface
- export with dynamo ONNX verification and benchmark with synchronized, machine-readable timings
- generate provenance-backed model cards and harden package/release artifact verification
- add reproducible reference commands, migration docs, agent guidance, and preview iFormer T/S/M models

## Trust boundaries

- `manifest.json` remains the run-bundle completion marker and is written last.
- Published typed checkpoints enforce their recorded SHA-256.
- Legacy model-only checkpoints remain supported as warm restarts, not exact resume.
- Detection stays experimental and unbenchmarked architectures stay preview.
- No CUDA benchmark, competitive detection benchmark, SegNeXt, or YOLOv10 claim is made here.

## Validation

- `244 passed, 1 skipped` across the aggregate CPU suite; skip is CUDA-only
- `11 passed` for the catalog after the final Ponytail simplification
- `make quality` passes: Ruff, formatting, ty, and dependency-sync verification
- documentation build passes with existing MkDocs/Griffe warnings
- wheel and sdist build once, install independently, expose `py.typed`, and discover 62 models
- representative ONNX export parity and latency JSON smokes pass on CPU

## Migration

See `docs/docs/v0.3-migration.md` for catalog, checkpoint, experiment, and export changes.
