### PR TITLE
ci: reduce workflow setup overhead

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,6 +18,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: package-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   UV_VERSION: "0.12.5"
   PYTHON_VERSION: "3.11"
@@ -44,6 +48,8 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true
+      - name: Build the package
+        run: make build
       - name: Install the engine
         env:
           UV_TORCH_BACKEND: cpu
@@ -65,62 +71,18 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true
-      - uses: actions/cache@v6
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}-test
       - name: Run tests
         env:
           UV_TORCH_BACKEND: cpu
         run: |
           UV_TORCH_BACKEND='cpu' make install-test
           UV_TORCH_BACKEND='cpu' make test
-      - uses: actions/upload-artifact@v7
-        with:
-          path: ./coverage.xml
-          name: coverage-reports
-
-  codecov-upload:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: actions/download-artifact@v8
-        with:
-          name: coverage-reports
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           files: ./coverage.xml
           fail_ci_if_error: true
-
-  build:
-    if: github.event_name == 'pull_request'
-    needs: install
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ['3.11', '3.12', '3.13']
-        exclude:
-          - os: windows-latest
-            python: '3.13'
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: ${{ matrix.python }}
-          architecture: x64
-      - uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-      - name: Build the package
-        env:
-          UV_TORCH_BACKEND: cpu
-        run: make build
 
   publish:
     if: github.event_name == 'release'

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ precommit: ${PYPROJECT_FILE} .pre-commit-config.yaml ## Run pre-commit hooks
 	prek run --all-files
 
 typing-check: ${PYPROJECT_FILE} ## Check type annotations
-	uv run ty check .
+	uv run --no-sync ty check .
 
 deps-check: .github/verify_deps_sync.py ## Check dependency synchronization
 	uv run --script .github/verify_deps_sync.py
@@ -91,7 +91,7 @@ install-test: ${PY_DIR} ${PYPROJECT_FILE} ## Install with test dependencies
 	uv pip install -e '${PY_DIR}[test]'
 
 test: ${PYPROJECT_FILE} ## Run the tests
-	uv run pytest --cov-report xml
+	uv run --no-sync pytest --cov-report xml
 
 ########################################################
 # Scripts
@@ -101,7 +101,7 @@ install-scripts: ${PY_DIR} ${PYPROJECT_FILE} ## Install with test dependencies
 	uv pip install -e '${PY_DIR}[scripts]'
 
 bench-latency: ${PYPROJECT_FILE} ${LATENCY_SCRIPT} ## Run the tests
-	uv run python ${LATENCY_SCRIPT} rexnet1_0x
+	uv run --no-sync python ${LATENCY_SCRIPT} rexnet1_0x
 
 
 ########################################################
@@ -117,7 +117,7 @@ serve-docs: ${DOCS_DIR}
 
 # Check that docs can build
 build-docs: ${DOCS_DIR}
-	DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib uv run mkdocs build -f ${DOCS_DIR}/mkdocs.yml
+	DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib uv run --no-sync mkdocs build -f ${DOCS_DIR}/mkdocs.yml
 
 push-docs: ${DOCS_DIR}
 	DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib uv run mkdocs gh-deploy -f ${DOCS_DIR}/mkdocs.yml --force


### PR DESCRIPTION
## Summary
- preserve all eight package matrix combinations while running build, install, and import in one job
- prevent uv run from replacing the prepared CPU environment in test, typing, docs, and latency targets
- upload coverage directly and cancel superseded package runs

## Validation
- check-yaml, trailing-whitespace, lint, typing, and dependency-sync checks passed
- package build, documentation build, and latency benchmark passed
- CPU validation retained torch 2.13.0 with cuda=None
- GitHub package run 32501922748 passed: 4.53 minutes wall, 11.40 runner-minutes, zero NVIDIA download lines
- all 20 executed PR checks passed; publish and verify-publish were correctly skipped
- full local macOS suite: 180 passed; unchanged tests/test_ops.py::test_aspect_ratio exact-float assertion fails with Torch 2.13

## Adversarial review
- completed Mimo and Sol reviews found no actionable or blocking defects
- release flow rechecked: install remains PR-only and publish still builds its own artifact
